### PR TITLE
Add end notification

### DIFF
--- a/RCTVideo.h
+++ b/RCTVideo.h
@@ -4,6 +4,7 @@ extern NSString *const RNVideoEventLoaded;
 extern NSString *const RNVideoEventLoading;
 extern NSString *const RNVideoEventProgress;
 extern NSString *const RNVideoEventLoadingError;
+extern NSString *const RNVideoEventEnd;
 
 @class RCTEventDispatcher;
 

--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -9,6 +9,7 @@ NSString *const RNVideoEventLoaded = @"videoLoaded";
 NSString *const RNVideoEventLoading = @"videoLoading";
 NSString *const RNVideoEventProgress = @"videoProgress";
 NSString *const RNVideoEventLoadingError = @"videoLoadError";
+NSString *const RNVideoEventEnd = @"videoEnd";
 
 static NSString *const statusKeyPath = @"status";
 
@@ -75,6 +76,12 @@ static NSString *const statusKeyPath = @"status";
   [_progressUpdateTimer addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
 }
 
+- (void)notifyEnd: (NSNotification *)notification {
+    [_eventDispatcher sendInputEventWithName:RNVideoEventEnd body:@{
+        @"target": self.reactTag
+    }];
+}
+
 #pragma mark - Player and source
 
 - (void)setSrc:(NSDictionary *)source {
@@ -139,6 +146,7 @@ static NSString *const statusKeyPath = @"status";
       }];
 
       [self startProgressTimer];
+      [self attachListeners];
       [_player play];
       [self applyModifiers];
     } else if(_playerItem.status == AVPlayerItemStatusFailed) {
@@ -153,6 +161,16 @@ static NSString *const statusKeyPath = @"status";
   } else {
     [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
   }
+}
+
+- (void)attachListeners {
+
+    // listen for end of file
+    [[NSNotificationCenter defaultCenter] addObserver:self
+        selector:@selector(notifyEnd:)
+        name:AVPlayerItemDidPlayToEndTimeNotification
+        object:[_player currentItem]];
+
 }
 
 - (void)playerItemDidReachEnd:(NSNotification *)notification {

--- a/RCTVideoManager.m
+++ b/RCTVideoManager.m
@@ -31,6 +31,9 @@ RCT_EXPORT_MODULE();
     RNVideoEventProgress: @{
       @"registrationName": @"onProgress"
     },
+    RNVideoEventEnd: @{
+      @"registrationName": @"onEnd"
+    },
   };
 }
 

--- a/README.md
+++ b/README.md
@@ -57,5 +57,5 @@ Example code [here](https://github.com/brentvatne/react-native-login/blob/master
 - [ ] Add support for captions
 - [ ] Support `require('video!...')`
 - [ ] Add support for playing multiple videos in a sequence (will interfere with current `repeat` implementation)
-- [ ] Add `onComplete` callback for when it finishes playing
+- [x] Add `onComplete` callback for when it finishes playing
 - [ ] Callback to get buffering progress for remote videos

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A <Video> component for react-native, as seen in
        paused={false}               // Pauses playback entirely.
        resizeMode="cover"           // Fill the whole screen at aspect ratio.
        repeat={true}                // Repeat forever.
+       onEnd={this._onEnd}          // handle end of playback
        style={styles.backgroundVideo} />
 
 // Later on in your styles..

--- a/Video.ios.js
+++ b/Video.ios.js
@@ -28,6 +28,7 @@ var Video = React.createClass({
     onLoad: PropTypes.func,
     onError: PropTypes.func,
     onProgress: PropTypes.func,
+    onEnd: PropTypes.func,
   },
 
   mixins: [NativeMethodsMixin],
@@ -51,6 +52,10 @@ var Video = React.createClass({
 
   _onProgress(event) {
     this.props.onProgress && this.props.onProgress(event.nativeEvent);
+  },
+
+  _onEnd(event) {
+    this.props.onEnd && this.props.onEnd(event.nativeEvent);
   },
 
   render() {
@@ -81,6 +86,7 @@ var Video = React.createClass({
       },
       onLoad: this._onLoad,
       onProgress: this._onProgress,
+      onEnd: this._onEnd,
 
     });
 


### PR DESCRIPTION
This PR allows for user to handle end of file playback. 

The currentTime == duration approach doesn't work so well as it depends on comparing time, and I found that there were multiple progress updates for a given second.

User is given option to have an onEnd prop which they can then use to call a function to do whatever they like once file has ended playback.
