### PR TITLE
Provide a fallback if the duration cannot be get

### DIFF
--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -135,7 +135,7 @@ static NSString *const statusKeyPath = @"status";
   if (object == _playerItem) {
     if (_playerItem.status == AVPlayerItemStatusReadyToPlay) {
       [_eventDispatcher sendInputEventWithName:RNVideoEventLoaded body:@{
-        @"duration": [NSNumber numberWithFloat:CMTimeGetSeconds(_playerItem.duration)],
+        @"duration": [NSNumber numberWithFloat:(CMTimeGetSeconds(_playerItem.duration) || 0.0)],
         @"currentTime": [NSNumber numberWithFloat:CMTimeGetSeconds(_playerItem.currentTime)],
         @"canPlayReverse": [NSNumber numberWithBool:_playerItem.canPlayReverse],
         @"canPlayFastForward": [NSNumber numberWithBool:_playerItem.canPlayFastForward],


### PR DESCRIPTION
This to avoid to send an errors stack caused by the `NaN` given in the JSON of the RCTEventDispatcher.

fixes #26
