### PR TITLE
Use the `ViewStylePropTypes` since they work &  inherit from `LayoutPropTypes`

### DIFF
--- a/VideoStylePropTypes.js
+++ b/VideoStylePropTypes.js
@@ -1,11 +1,11 @@
 'use strict';
 
 var VideoResizeMode = require('./VideoResizeMode');
-var LayoutPropTypes = require('LayoutPropTypes');
+var ViewStylePropTypes = require('ViewStylePropTypes');
 var ReactPropTypes = require('ReactPropTypes');
 
 var VideoStylePropTypes = {
-  ...LayoutPropTypes,
+  ...ViewStylePropTypes,
 };
 
 module.exports = VideoStylePropTypes;


### PR DESCRIPTION
Fixes the false-positive for invalid prop types mentioned here: https://github.com/brentvatne/react-native-video/issues/31
