### PR TITLE
Add playableDuration property to onProgress event

### DIFF
--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -80,7 +80,7 @@ static NSString *const statusKeyPath = @"status";
 /*!
  * Calculates and returns the playable duration of the current player item using its loaded time ranges.
  *
- * \returns The playable duration of the current player item.
+ * \returns The playable duration of the current player item in seconds.
  */
 - (NSNumber *)calculatePlayableDuration {
   AVPlayerItem *video = _player.currentItem;

--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -69,11 +69,33 @@ static NSString *const statusKeyPath = @"status";
      (([_prevProgressUpdateTime timeIntervalSinceNow] * -1000.0) >= _progressUpdateInterval)) {
     [_eventDispatcher sendInputEventWithName:RNVideoEventProgress body:@{
       @"currentTime": [NSNumber numberWithFloat:CMTimeGetSeconds(video.currentTime)],
+      @"playableDuration": [self calculatePlayableDuration],
       @"target": self.reactTag
     }];
 
     _prevProgressUpdateTime = [NSDate date];
   }
+}
+
+/*!
+ * Calculates and returns the playable duration of the current player item using its loaded time ranges.
+ *
+ * \returns The playable duration of the current player item.
+ */
+- (NSNumber *)calculatePlayableDuration {
+  AVPlayerItem *video = _player.currentItem;
+  if (video.status == AVPlayerItemStatusReadyToPlay) {
+    __block CMTimeRange effectiveTimeRange;
+    [video.loadedTimeRanges enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+      CMTimeRange timeRange = [obj CMTimeRangeValue];
+      if (CMTimeRangeContainsTime(timeRange, video.currentTime)) {
+        effectiveTimeRange = timeRange;
+        *stop = YES;
+      }
+    }];
+    return [NSNumber numberWithFloat:CMTimeGetSeconds(CMTimeRangeGetEnd(effectiveTimeRange))];
+  }
+  return [NSNumber numberWithFloat:CMTimeGetSeconds(kCMTimeInvalid)];
 }
 
 - (void)stopProgressTimer


### PR DESCRIPTION
Closes #51

I am new to the React Native and JS world and didn't know how to test this by creating a private node package. Therefore approach with caution.

The method itself is O(n) in time complexity. However, this shouldn't be a problem as the count of loadedTimeRanges should always be negligibly small if I'm not mistaken.
