### PR TITLE
Fix 'Invalid number value (NaN) in JSON write' crash

### DIFF
--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -96,9 +96,12 @@ static NSString *const statusKeyPath = @"status";
         *stop = YES;
       }
     }];
-    return [NSNumber numberWithFloat:CMTimeGetSeconds(CMTimeRangeGetEnd(effectiveTimeRange))];
+    Float64 playableDuration = CMTimeGetSeconds(CMTimeRangeGetEnd(effectiveTimeRange));
+    if (playableDuration > 0) {
+      return [NSNumber numberWithFloat:playableDuration];
+    }
   }
-  return [NSNumber numberWithFloat:CMTimeGetSeconds(kCMTimeInvalid)];
+  return [NSNumber numberWithInteger:0];
 }
 
 - (void)stopProgressTimer


### PR DESCRIPTION
I found that switching video sources causes a crash due to a NaN value being passed as playableDuration. Other different cases might lead to a crash because of the same issue as well.
