### PR TITLE
Update for RN 0.7.0-rc.2

### DIFF
--- a/Video.ios.js
+++ b/Video.ios.js
@@ -1,13 +1,11 @@
 var React = require('react-native');
 var {
   requireNativeComponent,
-
-  ReactNativeViewAttributes,
   NativeModules,
   StyleSheet,
   PropTypes,
 
-  // Once these are exposed, use them instead.
+  // Once these are exposed, use them
   // ReactNativeViewAttributes,
   // StyleSheetPropType,
   // NativeMethodsMixin,

--- a/Video.ios.js
+++ b/Video.ios.js
@@ -1,16 +1,32 @@
 var React = require('react-native');
-var { requireNativeComponent, } = React;
+var {
+  requireNativeComponent,
+
+  ReactNativeViewAttributes,
+  NativeModules,
+  StyleSheet,
+  PropTypes,
+
+  // Once these are exposed, use them instead.
+  // ReactNativeViewAttributes,
+  // StyleSheetPropType,
+  // NativeMethodsMixin,
+  // flattenStyle,
+  // merge,
+  // deepDiffer,
+} = React;
+
+// These are not yet exposed by the react-native package, so we must continue
+// requiring them this way, which will cause warnings.
 var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
-var NativeModules = require('NativeModules');
-var StyleSheet = require('StyleSheet');
-var PropTypes = require('ReactPropTypes');
 var StyleSheetPropType = require('StyleSheetPropType');
-var VideoResizeMode = require('./VideoResizeMode');
-var VideoStylePropTypes = require('./VideoStylePropTypes');
 var NativeMethodsMixin = require('NativeMethodsMixin');
 var flattenStyle = require('flattenStyle');
 var merge = require('merge');
 var deepDiffer = require('deepDiffer');
+
+var VideoResizeMode = require('./VideoResizeMode');
+var VideoStylePropTypes = require('./VideoStylePropTypes');
 
 var Video = React.createClass({
   propTypes: {

--- a/VideoStylePropTypes.js
+++ b/VideoStylePropTypes.js
@@ -1,6 +1,9 @@
 'use strict';
 
 var VideoResizeMode = require('./VideoResizeMode');
+
+// As of 0.7.0-rc.2 these cause warnings, but are not yet exposed via the public
+// react-native interface yet.
 var ViewStylePropTypes = require('ViewStylePropTypes');
 var ReactPropTypes = require('ReactPropTypes');
 


### PR DESCRIPTION
Use the public react-native interface for requiring internal modules where possible (causes warnings in 0.7.0-rc.2).

**Note:** There are several modules that are not yet exposed via the `react-native` public interface, so there will still be warnings.  Here are the ones you can still expect a warning from:

```
ReactNativeViewAttributes
StyleSheetPropType
NativeMethodsMixin
flattenStyle
merge
deepDiffer
```
