### PR TITLE
Call setRate instead of pause/play as they are equivalent

### DIFF
--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -297,12 +297,12 @@ static NSString *const statusKeyPath = @"status";
   if (paused) {
     [self stopProgressTimer];
     dispatch_async(dispatch_get_main_queue(), ^{
-      [_player pause];
+      [_player setRate:0.0];
     });
   } else {
     [self startProgressTimer];
     dispatch_async(dispatch_get_main_queue(), ^{
-      [_player play];
+      [_player setRate:_rate];
     });
   }
 
@@ -379,9 +379,6 @@ static NSString *const statusKeyPath = @"status";
   [self setResizeMode:_resizeMode];
   [self setRepeat:_repeat];
   [self setPaused:_paused];
-  dispatch_async(dispatch_get_main_queue(), ^{
-    [_player setRate:_rate];
-  });
 }
 
 - (void)setRepeat:(BOOL)repeat {


### PR DESCRIPTION
Video was resuming after seek when setRate was called after play/pause in applyModifiers. According
to [Apple's docs](https://developer.apple.com/library/prerelease/ios/documentation/AVFoundation/Reference/AVPlayer_Class/index.html#//apple_ref/occ/instm/AVPlayer/play) play/pause are equivalent to setRate:1.0 and setRate:0.0, meaning that if rate was
1.0 the video resumed after seeking completed.
