### PR TITLE
Disables default system animation when resizing AVPlayerLayer

### DIFF
--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -405,7 +405,10 @@ static NSString *const statusKeyPath = @"status";
 - (void)layoutSubviews
 {
   [super layoutSubviews];
+  [CATransaction begin];
+  [CATransaction setAnimationDuration:0];
   _playerLayer.frame = self.bounds;
+  [CATransaction commit];
 }
 
 #pragma mark - Lifecycle


### PR DESCRIPTION
Not sure if this something you will want – perhaps it could go behind a flag. When animating video size, the default system animation makes the rendered size of the video lag behind the bounds of the react view. This patch disables the default animation, ensuring the video renders at the correct size.
