### PR TITLE
video breaks on react-native 0.9.0-rc

### DIFF
--- a/Video.ios.js
+++ b/Video.ios.js
@@ -80,7 +80,7 @@ var Video = React.createClass({
       resizeMode = NativeModules.VideoManager.ScaleNone;
     }
 
-    var nativeProps = merge(this.props, {
+    var nativeProps = merge({},this.props, {
       style,
       resizeMode: resizeMode,
       src: {


### PR DESCRIPTION
You can't modify this.props on 0.9.0-rc, so you just need to create a new object, not modify this.props to work correctly on new versions.  Also removes a bunch of warnings on 0.8.0.
