### PR TITLE
Use lodash instead of merge, unbreaking the component (for us)

### DIFF
--- a/Video.ios.js
+++ b/Video.ios.js
@@ -2,7 +2,7 @@ var React = require('react-native');
 var { StyleSheet, requireNativeComponent, PropTypes, NativeModules, } = React;
 
 var VideoResizeMode = require('./VideoResizeMode');
-var merge = require('merge');
+var { extend } = require('lodash');
 
 var VIDEO_REF = 'video';
 
@@ -80,7 +80,7 @@ var Video = React.createClass({
       resizeMode = NativeModules.VideoManager.ScaleNone;
     }
 
-    var nativeProps = merge({},this.props, {
+    var nativeProps = extend({}, this.props, {
       style,
       resizeMode: resizeMode,
       src: {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   },
   "dependencies": {
     "keymirror": "^0.1.1",
-    "merge": "^1.2.0"
+    "lodash": "^3.10.1"
   }
 }


### PR DESCRIPTION
Not sure if others are experiencing this, but a few of us (@emibob, @ilanasufrin, @benmidi & I) could not get any videos to play at all (iOS, React 0.10).

We tracked it down to this line in `Video.ios.js` that was using the `merge` library. For whatever reason, the third param was being ignored. Using underscore/lodash's `extend` method fixes it for us.
