### PR TITLE
Example fix, test script, and some refactoring

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,4 @@
+{
+  "extends": "airbnb",
+  "parser": "babel-eslint"
+}

--- a/Examples/VideoPlayer/VideoPlayer.xcodeproj/project.pbxproj
+++ b/Examples/VideoPlayer/VideoPlayer.xcodeproj/project.pbxproj
@@ -302,7 +302,7 @@
 		83CBB9F71A601CBA00E9B192 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = Facebook;
 			};
 			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "VideoPlayer" */;
@@ -487,8 +487,10 @@
 					"$(SRCROOT)/node_modules/react-native/React/**",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/iOS/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = VideoPlayer;
 			};
 			name = Debug;
@@ -503,8 +505,10 @@
 					"$(SRCROOT)/node_modules/react-native/React/**",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/iOS/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = VideoPlayer;
 			};
 			name = Release;
@@ -529,6 +533,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;

--- a/Examples/VideoPlayer/VideoPlayer.xcodeproj/xcshareddata/xcschemes/VideoPlayer.xcscheme
+++ b/Examples/VideoPlayer/VideoPlayer.xcodeproj/xcshareddata/xcschemes/VideoPlayer.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+               BuildableName = "VideoPlayer.app"
+               BlueprintName = "VideoPlayer"
+               ReferencedContainer = "container:VideoPlayer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "VideoPlayer.app"
+            BlueprintName = "VideoPlayer"
+            ReferencedContainer = "container:VideoPlayer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "VideoPlayer.app"
+            BlueprintName = "VideoPlayer"
+            ReferencedContainer = "container:VideoPlayer.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "VideoPlayer.app"
+            BlueprintName = "VideoPlayer"
+            ReferencedContainer = "container:VideoPlayer.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/VideoPlayer/iOS/Info.plist
+++ b/Examples/VideoPlayer/iOS/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Examples/VideoPlayer/package.json
+++ b/Examples/VideoPlayer/package.json
@@ -1,15 +1,12 @@
 {
   "name": "VideoPlayer",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "start": "node_modules/react-native/packager/packager.sh"
   },
-  "scripts": { 
-    "postinstall" : "cp ../../*.js ../../*.m ../../*.h ../../README.md ../../package.json ./node_modules/react-native-video && cp ../../RCTVideo.xcodeproj/project.pbxproj ./node_modules/react-native-video/RCTVideo.xcodeproj/project.pbxproj"
-  },
   "dependencies": {
-    "react-native": "^0.16.0",
-    "react-native-video": "brentvatne/react-native-video"
+    "react-native": "0.18.1",
+    "react-native-video": "../../"
   }
 }

--- a/RCTVideo.xcodeproj/project.pbxproj
+++ b/RCTVideo.xcodeproj/project.pbxproj
@@ -87,7 +87,7 @@
 		58B511D31A9E6C8500147676 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {
 					58B511DA1A9E6C8500147676 = {
@@ -144,6 +144,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;

--- a/Video.js
+++ b/Video.js
@@ -1,4 +1,6 @@
-const React = require('react-native');
+import React from 'react-native';
+import VideoResizeMode from './VideoResizeMode.js';
+
 const {
   Component,
   StyleSheet,
@@ -8,19 +10,18 @@ const {
   View,
 } = React;
 
-const VideoResizeMode = require('./VideoResizeMode');
-
 const styles = StyleSheet.create({
   base: {
     overflow: 'hidden',
   },
 });
 
-class Video extends Component {
+export default class Video extends Component {
 
   constructor(props, context) {
     super(props, context);
     this.seek = this.seek.bind(this);
+    this._assignRoot = this._assignRoot.bind(this);
     this._onLoadStart = this._onLoadStart.bind(this);
     this._onLoad = this._onLoad.bind(this);
     this._onError = this._onError.bind(this);
@@ -34,44 +35,58 @@ class Video extends Component {
   }
 
   seek(time) {
-    this.setNativeProps({ seek: parseFloat(time) });
+    this.setNativeProps({ seek: time });
+  }
+
+  _assignRoot(component) {
+    this._root = component;
   }
 
   _onLoadStart(event) {
-    this.props.onLoadStart && this.props.onLoadStart(event.nativeEvent);
+    if (this.props.onLoadStart) {
+      this.props.onLoadStart(event.nativeEvent);
+    }
   }
 
   _onLoad(event) {
-    this.props.onLoad && this.props.onLoad(event.nativeEvent);
+    if (this.props.onLoad) {
+      this.props.onLoad(event.nativeEvent);
+    }
   }
 
   _onError(event) {
-    this.props.onError && this.props.onError(event.nativeEvent);
+    if (this.props.onError) {
+      this.props.onError(event.nativeEvent);
+    }
   }
 
   _onProgress(event) {
-    this.props.onProgress && this.props.onProgress(event.nativeEvent);
+    if (this.props.onProgress) {
+      this.props.onProgress(event.nativeEvent);
+    }
   }
 
   _onSeek(event) {
-    this.props.onSeek && this.props.onSeek(event.nativeEvent);
+    if (this.props.onSeek) {
+      this.props.onSeek(event.nativeEvent);
+    }
   }
 
   _onEnd(event) {
-    this.props.onEnd && this.props.onEnd(event.nativeEvent);
+    if (this.props.onEnd) {
+      this.props.onEnd(event.nativeEvent);
+    }
   }
 
   render() {
     const {
-      style,
       source,
-      ref,
       resizeMode,
     } = this.props;
 
     let uri = source.uri;
     if (uri && uri.match(/^\//)) {
-      uri = 'file://' + uri;
+      uri = `file://${uri}`;
     }
 
     const isNetwork = !!(uri && uri.match(/^https?:/));
@@ -90,10 +105,10 @@ class Video extends Component {
 
     const nativeProps = Object.assign({}, this.props);
     Object.assign(nativeProps, {
-      style: [styles.base, style],
+      style: [styles.base, nativeProps.style],
       resizeMode: nativeResizeMode,
       src: {
-        uri: uri,
+        uri,
         isNetwork,
         isAsset,
         type: source.type || 'mp4',
@@ -108,8 +123,9 @@ class Video extends Component {
 
     return (
       <RCTVideo
-        ref={ component => this._root = component }
-        {...nativeProps} />
+        ref={this._assignRoot}
+        {...nativeProps}
+      />
     );
   }
 }
@@ -135,7 +151,7 @@ Video.propTypes = {
   onProgress: PropTypes.func,
   onSeek: PropTypes.func,
   onEnd: PropTypes.func,
-  
+
   /* Required by react-native */
   scaleX: React.PropTypes.number,
   scaleY: React.PropTypes.number,
@@ -148,8 +164,6 @@ Video.propTypes = {
 const RCTVideo = requireNativeComponent('RCTVideo', Video, {
   nativeOnly: {
     src: true,
-    seek: true
+    seek: true,
   },
 });
-
-module.exports = Video;

--- a/VideoResizeMode.js
+++ b/VideoResizeMode.js
@@ -1,11 +1,7 @@
-'use strict';
+import keyMirror from 'keymirror';
 
-var keyMirror = require('keymirror');
-
-var VideoResizeMode = keyMirror({
+export default keyMirror({
   contain: null,
   cover: null,
   stretch: null,
 });
-
-module.exports = VideoResizeMode;

--- a/package.json
+++ b/package.json
@@ -36,9 +36,16 @@
     "url": "git@github.com:brentvatne/react-native-video.git"
   },
   "devDependencies": {
-    "jest-cli": "0.2.1"
+    "jest-cli": "0.2.1",
+    "eslint": "1.10.3",
+    "babel-eslint": "5.0.0-beta8",
+    "eslint-plugin-react": "3.16.1",
+    "eslint-config-airbnb": "4.0.0"
   },
   "dependencies": {
-    "keymirror": "^0.1.1"
+    "keymirror": "0.1.1"
+  },
+  "scripts": {
+    "test": "node_modules/.bin/eslint *.js"
   }
 }


### PR DESCRIPTION
- The test script just does an eslint check. (Closes #121)
- Refactored JS code to pass the check.
- Fixed VideoPlayer example. (Closes #117)
  - Updated package.json to use local react-native-video in a simple manner.
  - Added shared scheme for target.
  - Updated poject settings.
  - Now using react-native 0.18.1.
