### PR TITLE
[Podspec] Set podspec version from the package.json and fix git source in the Podspec

### DIFF
--- a/react-native-video.podspec
+++ b/react-native-video.podspec
@@ -3,12 +3,12 @@ Pod::Spec.new do |s|
   s.version      = "0.7.1"
   s.summary      = "A <Video /> element for react-native"
 
-  s.homepage     = "https://github.com:brentvatne/react-native-video"
+  s.homepage     = "https://github.com/brentvatne/react-native-video"
 
   s.license      = "MIT"
   s.platform     = :ios, "8.0"
 
-  s.source       = { :git => "https://github.com:brentvatne/react-native-video" }
+  s.source       = { :git => "https://github.com/brentvatne/react-native-video" }
 
   s.source_files  = "*.{h,m}"
 

--- a/react-native-video.podspec
+++ b/react-native-video.podspec
@@ -1,16 +1,21 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
 Pod::Spec.new do |s|
   s.name         = "react-native-video"
-  s.version      = "0.7.1"
+  s.version      = package["version"]
   s.summary      = "A <Video /> element for react-native"
+  s.author       = "Brent Vatne <brentvatne@gmail.com> (https://github.com/brentvatne)"
 
   s.homepage     = "https://github.com/brentvatne/react-native-video"
 
   s.license      = "MIT"
   s.platform     = :ios, "8.0"
 
-  s.source       = { :git => "https://github.com/brentvatne/react-native-video" }
+  s.source       = { :git => "https://github.com/brentvatne/react-native-video.git", :tag => "#{s.version}" }
 
   s.source_files  = "*.{h,m}"
 
-  s.dependency 'React'
+  s.dependency "React"
 end

--- a/react-native-video.podspec
+++ b/react-native-video.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/brentvatne/react-native-video"
 
   s.license      = "MIT"
-  s.platform     = :ios, "8.0"
+  s.platform     = :ios, "7.0"
 
   s.source       = { :git => "https://github.com/brentvatne/react-native-video.git", :tag => "#{s.version}" }
 


### PR DESCRIPTION
React Native recently started reading the version from the package.json file which I think is a great addition. I also fixed the git source link (was erroring before) and added the git tag (cocoapods recommends setting one and I agree).

@brentvatne I added the author field since it was required by cocoapods, let me know if you want different text in there (I used the same field from the package.json, maybe we should just grab this info from there?)

lastly, the platform was set at 8.0, I was able to run this on our project which has a 7.0 deployment target so I lowered the platform value here, let me know if any of the implementation uses iOS 8 specific APIs.

thanks!
