### PR TITLE
Additional playback callbacks

### DIFF
--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -7,6 +7,7 @@
 static NSString *const statusKeyPath = @"status";
 static NSString *const playbackLikelyToKeepUpKeyPath = @"playbackLikelyToKeepUp";
 static NSString *const playbackBufferEmptyKeyPath = @"playbackBufferEmpty";
+static NSString *const readyForDisplayKeyPath = @"readyForDisplay";
 
 @implementation RCTVideo
 {
@@ -213,8 +214,7 @@ static NSString *const playbackBufferEmptyKeyPath = @"playbackBufferEmpty";
   [self addPlayerItemObservers];
 
   [_player pause];
-  [_playerLayer removeFromSuperlayer];
-  _playerLayer = nil;
+  [self removePlayerLayer];
   [_playerViewController.view removeFromSuperview];
   _playerViewController = nil;
 
@@ -504,6 +504,8 @@ static NSString *const playbackBufferEmptyKeyPath = @"playbackBufferEmpty";
       _playerLayer = [AVPlayerLayer playerLayerWithPlayer:_player];
       _playerLayer.frame = self.bounds;
       _playerLayer.needsDisplayOnBoundsChange = YES;
+        
+      [_playerLayer addObserver:self forKeyPath:readyForDisplayKeyPath options:NSKeyValueObservingOptionNew context:nil];
     
       [self.layer addSublayer:_playerLayer];
       self.layer.needsDisplayOnBoundsChange = YES;
@@ -517,8 +519,7 @@ static NSString *const playbackBufferEmptyKeyPath = @"playbackBufferEmpty";
         _controls = controls;
         if( _controls )
         {
-            [_playerLayer removeFromSuperlayer];
-            _playerLayer = nil;
+            [self removePlayerLayer];
             [self usePlayerViewController];
         }
         else
@@ -528,6 +529,13 @@ static NSString *const playbackBufferEmptyKeyPath = @"playbackBufferEmpty";
             [self usePlayerLayer];
         }
     }
+}
+
+- (void)removePlayerLayer
+{
+    [_playerLayer removeFromSuperlayer];
+    [_playerLayer removeObserver:self forKeyPath:readyForDisplayKeyPath];
+    _playerLayer = nil;
 }
 
 #pragma mark - RCTVideoPlayerViewControllerDelegate
@@ -615,8 +623,7 @@ static NSString *const playbackBufferEmptyKeyPath = @"playbackBufferEmpty";
   [_player pause];
   _player = nil;
 
-  [_playerLayer removeFromSuperlayer];
-  _playerLayer = nil;
+  [self removePlayerLayer];
   
   [_playerViewController.view removeFromSuperview];
   _playerViewController = nil;

--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -328,6 +328,7 @@ static NSString *const playbackRate = @"rate";
               [_eventDispatcher sendInputEventWithName:@"onPlaybackResume"
                                                   body:@{@"playbackRate": [NSNumber numberWithFloat:_player.rate],
                                                          @"target": self.reactTag}];
+              _playbackStalled = NO;
           }
       }
   } else {

--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -308,6 +308,13 @@ static NSString *const readyForDisplayKeyPath = @"readyForDisplay";
       }
       _playerBufferEmpty = NO;
     }
+   } else if (object == _playerLayer) {
+      if([keyPath isEqualToString:readyForDisplayKeyPath] && [change objectForKey:NSKeyValueChangeNewKey]) {
+        if([change objectForKey:NSKeyValueChangeNewKey]) {
+          [_eventDispatcher sendInputEventWithName:@"onReadyForDisplay"
+                                              body:@{@"target": self.reactTag}];
+        }
+    }
   } else {
       [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
   }

--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -322,11 +322,11 @@ static NSString *const playbackRate = @"rate";
   } else if (object == _player) {
       if([keyPath isEqualToString:playbackRate] && [change objectForKey:NSKeyValueChangeNewKey]) {
           [_eventDispatcher sendInputEventWithName:@"onPlaybackRateChange"
-                                              body:@{@"playbackRate": _player.rate,
+                                              body:@{@"playbackRate": [NSNumber numberWithFloat:_player.rate],
                                                      @"target": self.reactTag}];
           if(_playbackStalled && _player.rate > 0) {
               [_eventDispatcher sendInputEventWithName:@"onPlaybackResume"
-                                                  body:@{@"playbackRate": _player.rate,
+                                                  body:@{@"playbackRate": [NSNumber numberWithFloat:_player.rate],
                                                          @"target": self.reactTag}];
           }
       }

--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -317,6 +317,12 @@ static NSString *const playbackRate = @"rate";
                                               body:@{@"target": self.reactTag}];
         }
     }
+  } else if (object == _player) {
+      if([keyPath isEqualToString:playbackRate] && [change objectForKey:NSKeyValueChangeNewKey]) {
+          [_eventDispatcher sendInputEventWithName:@"onPlaybackRateChange"
+                                              body:@{@"playbackRate": _player.rate,
+                                                     @"target": self.reactTag}];
+      }
   } else {
       [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
   }

--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -8,6 +8,7 @@ static NSString *const statusKeyPath = @"status";
 static NSString *const playbackLikelyToKeepUpKeyPath = @"playbackLikelyToKeepUp";
 static NSString *const playbackBufferEmptyKeyPath = @"playbackBufferEmpty";
 static NSString *const readyForDisplayKeyPath = @"readyForDisplay";
+static NSString *const playbackRate = @"rate";
 
 @implementation RCTVideo
 {
@@ -220,6 +221,7 @@ static NSString *const readyForDisplayKeyPath = @"readyForDisplay";
 
   _player = [AVPlayer playerWithPlayerItem:_playerItem];
   _player.actionAtItemEnd = AVPlayerActionAtItemEndNone;
+  [_player addObserver:self forKeyPath:playbackRate options:0 context:nil];
 
   const Float64 progressUpdateIntervalMS = _progressUpdateInterval / 1000;
   // @see endScrubbing in AVPlayerDemoPlaybackViewController.m of https://developer.apple.com/library/ios/samplecode/AVPlayerDemo/Introduction/Intro.html
@@ -628,6 +630,7 @@ static NSString *const readyForDisplayKeyPath = @"readyForDisplay";
 - (void)removeFromSuperview
 {
   [_player pause];
+  [_player removeObserver:self forKeyPath:playbackRate];
   _player = nil;
 
   [self removePlayerLayer];

--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -320,7 +320,7 @@ static NSString *const playbackRate = @"rate";
         }
     }
   } else if (object == _player) {
-      if([keyPath isEqualToString:playbackRate] && [change objectForKey:NSKeyValueChangeNewKey]) {
+      if([keyPath isEqualToString:playbackRate]) {
           [_eventDispatcher sendInputEventWithName:@"onPlaybackRateChange"
                                               body:@{@"playbackRate": [NSNumber numberWithFloat:_player.rate],
                                                      @"target": self.reactTag}];

--- a/RCTVideoManager.m
+++ b/RCTVideoManager.m
@@ -29,7 +29,8 @@ RCT_EXPORT_MODULE();
     @"onVideoFullscreenPlayerDidPresent",
     @"onVideoFullscreenPlayerWillDismiss",
     @"onVideoFullscreenPlayerDidDismiss",
-    @"onReadyForDisplay"
+    @"onReadyForDisplay",
+    @"onPlaybackRateChange"
   ];
 }
 

--- a/RCTVideoManager.m
+++ b/RCTVideoManager.m
@@ -30,6 +30,8 @@ RCT_EXPORT_MODULE();
     @"onVideoFullscreenPlayerWillDismiss",
     @"onVideoFullscreenPlayerDidDismiss",
     @"onReadyForDisplay",
+    @"onPlaybackStalled",
+    @"onPlaybackResume",
     @"onPlaybackRateChange"
   ];
 }

--- a/RCTVideoManager.m
+++ b/RCTVideoManager.m
@@ -28,7 +28,8 @@ RCT_EXPORT_MODULE();
     @"onVideoFullscreenPlayerWillPresent",
     @"onVideoFullscreenPlayerDidPresent",
     @"onVideoFullscreenPlayerWillDismiss",
-    @"onVideoFullscreenPlayerDidDismiss"
+    @"onVideoFullscreenPlayerDidDismiss",
+    @"onReadyForDisplay"
   ];
 }
 

--- a/Video.js
+++ b/Video.js
@@ -34,6 +34,10 @@ export default class Video extends Component {
     this._onFullscreenPlayerDidPresent = this._onFullscreenPlayerDidPresent.bind(this);
     this._onFullscreenPlayerWillDismiss = this._onFullscreenPlayerWillDismiss.bind(this);
     this._onFullscreenPlayerDidDismiss = this._onFullscreenPlayerDidDismiss.bind(this);
+    this._onReadyForDisplay = this._onReadyForDisplay.bind(this);
+    this._onPlaybackStalled = this._onPlaybackStalled.bind(this);
+    this._onPlaybackResume = this._onPlaybackResume.bind(this);
+    this._onPlaybackRateChange = this._onPlaybackRateChange.bind(this);
   }
 
   setNativeProps(nativeProps) {
@@ -116,6 +120,30 @@ export default class Video extends Component {
     }
   }
 
+  _onReadyForDisplay(event) {
+    if (this.props.onReadyForDisplay) {
+      this.props.onReadyForDisplay(event.nativeEvent);
+    }
+  }
+
+  _onPlaybackStalled(event) {
+    if (this.props.onPlaybackStalled) {
+      this.props.onPlaybackStalled(event.nativeEvent);
+    }
+  }
+
+  _onPlaybackResume(event) {
+    if (this.props.onPlaybackResume) {
+      this.props.onPlaybackResume(event.nativeEvent);
+    }
+  }
+
+  _onPlaybackRateChange(event) {
+    if (this.props.onPlaybackRateChange) {
+      this.props.onPlaybackRateChange(event.nativeEvent);
+    }
+  }
+
   render() {
     const {
       source,
@@ -161,6 +189,10 @@ export default class Video extends Component {
       onVideoFullscreenPlayerDidPresent: this._onFullscreenPlayerDidPresent,
       onVideoFullscreenPlayerWillDismiss: this._onFullscreenPlayerWillDismiss,
       onVideoFullscreenPlayerDidDismiss: this._onFullscreenPlayerDidDismiss,
+      onReadyForDisplay: this._onReadyForDisplay,
+      onPlaybackStalled: this._onPlaybackStalled,
+      onPlaybackResume: this._onPlaybackResume,
+      onPlaybackRateChange: this._onPlaybackRateChange,
     });
 
     return (
@@ -198,6 +230,10 @@ Video.propTypes = {
   onFullscreenPlayerDidPresent: PropTypes.func,
   onFullscreenPlayerWillDismiss: PropTypes.func,
   onFullscreenPlayerDidDismiss: PropTypes.func,
+  onReadyForDisplay: PropTypes.func,
+  onPlaybackStalled: PropTypes.func,
+  onPlaybackResume: PropTypes.func,
+  onPlaybackRateChange: PropTypes.func,
 
   /* Required by react-native */
   scaleX: React.PropTypes.number,


### PR DESCRIPTION
Added [`onReadyForDisplay`](https://developer.apple.com/library/ios/documentation/AVFoundation/Reference/AVPlayerLayer_Class/#//apple_ref/occ/instp/AVPlayerLayer/readyForDisplay), [`onPlaybackRateChange`](https://developer.apple.com/library/ios/documentation/AVFoundation/Reference/AVPlayer_Class/index.html#//apple_ref/occ/instp/AVPlayer/rate), [`onPlaybackStalled`](https://developer.apple.com/library/ios/documentation/AVFoundation/Reference/AVPlayerItem_Class/index.html#//apple_ref/c/data/AVPlayerItemPlaybackStalledNotification) and `onPlaybackResume` (resume after being stalled) callbacks.
