### PR TITLE
[iOS] Added orientation to onLoad event.

### DIFF
--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -270,9 +270,19 @@ static NSString *const playbackBufferEmptyKeyPath = @"playbackBufferEmpty";
           
         NSObject *width = @"undefined";
         NSObject *height = @"undefined";
+        NSString *orientation = @"undefined";
+        AVAssetTrack *vT = nil;
+
         if ([_playerItem.asset tracksWithMediaType:AVMediaTypeVideo].count > 0) {
-          width = [NSNumber numberWithFloat:[_playerItem.asset tracksWithMediaType:AVMediaTypeVideo][0].naturalSize.width];
-          height = [NSNumber numberWithFloat:[_playerItem.asset tracksWithMediaType:AVMediaTypeVideo][0].naturalSize.height];
+          vT = [[_playerItem.asset tracksWithMediaType:AVMediaTypeVideo] objectAtIndex:0];
+          width = [NSNumber numberWithFloat:vT.naturalSize.width];
+          height = [NSNumber numberWithFloat:vT.naturalSize.height];
+          CGAffineTransform txf = [vT preferredTransform];
+
+          if ((vT.naturalSize.width == txf.tx && vT.naturalSize.height == txf.ty) | (txf.tx == 0 && txf.ty == 0))
+            orientation = @"landscape";
+          else
+            orientation = @"portrait";
         }
 
         [_eventDispatcher sendInputEventWithName:@"onVideoLoad"
@@ -286,7 +296,8 @@ static NSString *const playbackBufferEmptyKeyPath = @"playbackBufferEmpty";
                                                    @"canStepForward": [NSNumber numberWithBool:_playerItem.canStepForward],
                                                    @"naturalSize": @{
                                                         @"width": width,
-                                                        @"height": height
+                                                        @"height": height,
+                                                        @"orientation": orientation
                                                         },
                                                    @"target": self.reactTag}];
 

--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -271,17 +271,19 @@ static NSString *const playbackBufferEmptyKeyPath = @"playbackBufferEmpty";
         NSObject *width = @"undefined";
         NSObject *height = @"undefined";
         NSString *orientation = @"undefined";
-        AVAssetTrack *vT = nil;
 
         if ([_playerItem.asset tracksWithMediaType:AVMediaTypeVideo].count > 0) {
-          vT = [[_playerItem.asset tracksWithMediaType:AVMediaTypeVideo] objectAtIndex:0];
-          width = [NSNumber numberWithFloat:vT.naturalSize.width];
-          height = [NSNumber numberWithFloat:vT.naturalSize.height];
-          CGAffineTransform txf = [vT preferredTransform];
+          AVAssetTrack *videoTrack = [[_playerItem.asset tracksWithMediaType:AVMediaTypeVideo] objectAtIndex:0];
+          width = [NSNumber numberWithFloat:videoTrack.naturalSize.width];
+          height = [NSNumber numberWithFloat:videoTrack.naturalSize.height];
+          CGAffineTransform preferredTransform = [videoTrack preferredTransform];
 
-          if ((vT.naturalSize.width == txf.tx && vT.naturalSize.height == txf.ty) | (txf.tx == 0 && txf.ty == 0))
+          if ((videoTrack.naturalSize.width == preferredTransform.tx
+            && videoTrack.naturalSize.height == preferredTransform.ty)
+            || (preferredTransform.tx == 0 && preferredTransform.ty == 0))
+          {
             orientation = @"landscape";
-          else
+          } else
             orientation = @"portrait";
         }
 


### PR DESCRIPTION
Width and height values are unreliable without the orientation information.
In a vertical video, `width` value may return higher than `height` value. So you must know the correct orientation.

So I appended the orientation information to response.

**Note:** That was my first objective c experience. I referenced the link below.
http://stackoverflow.com/questions/11282283/naturalsize-returning-wrong-orientation-from-avurlasset
I tested and it works pretty well, anyway please check the code carefully before merging.
