### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## react-native-video
 
-A <Video> component for react-native, as seen in
+A `<Video>` component for react-native, as seen in
 [react-native-login](https://github.com/brentvatne/react-native-login)!
 
 Requires react-native >= 0.19.0


### PR DESCRIPTION
Make visible the text `<Video>`  wrapping it with a code block.
Optionally could be escaped as \<Video\>
