### PR TITLE
Allow to use content:// schema as source.

### DIFF
--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -144,7 +144,12 @@ public class ReactVideoView extends ScalableVideoView implements MediaPlayer.OnP
 
                 setDataSource(mThemedReactContext, parsedUrl, headers);
             } else if (isAsset) {
-                setDataSource(uriString);
+                if (uriString.startsWith("content://")) {
+                    Uri parsedUrl = Uri.parse(uriString);
+                    setDataSource(mThemedReactContext, parsedUrl);
+                } else {
+                    setDataSource(uriString);
+                }
             } else {
                 setRawData(mThemedReactContext.getResources().getIdentifier(
                         uriString,


### PR DESCRIPTION
If I try to use content://media/external/video/media/xxx URL returned from react-native-image-picker it silently fails because setDataSource error 0x8000000

This pull request fixes that by using different setDataSource call.
[setDataSource(android.content.Context, android.net.Uri)](http://developer.android.com/reference/android/media/MediaPlayer.html#setDataSource%28android.content.Context, android.net.Uri%29)
