### PR TITLE
Added React import to android VideoPlayer Example

### DIFF
--- a/Examples/VideoPlayer/index.android.js
+++ b/Examples/VideoPlayer/index.android.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import {
+import React, {
   Component
 } from 'react';
 


### PR DESCRIPTION
Import for React was missing in index.android.js of VideoPlayer, without which the example would not run.
