### PR TITLE
[Android] naturalSize callback to match iOS version.

### DIFF
--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -48,6 +48,10 @@ public class ReactVideoView extends ScalableVideoView implements MediaPlayer.OnP
     public static final String EVENT_PROP_PLAYABLE_DURATION = "playableDuration";
     public static final String EVENT_PROP_CURRENT_TIME = "currentTime";
     public static final String EVENT_PROP_SEEK_TIME = "seekTime";
+    public static final String EVENT_PROP_NATURALSIZE = "naturalSize";
+    public static final String EVENT_PROP_WIDTH = "width";
+    public static final String EVENT_PROP_HEIGHT = "height";
+    public static final String EVENT_PROP_ORIENTATION = "orientation";
 
     public static final String EVENT_PROP_ERROR = "error";
     public static final String EVENT_PROP_WHAT = "what";
@@ -249,9 +253,18 @@ public class ReactVideoView extends ScalableVideoView implements MediaPlayer.OnP
         mMediaPlayerValid = true;
         mVideoDuration = mp.getDuration();
 
+        WritableMap naturalSize = Arguments.createMap();
+        naturalSize.putInt(EVENT_PROP_WIDTH, mp.getVideoWidth());
+        naturalSize.putInt(EVENT_PROP_HEIGHT, mp.getVideoHeight());
+        if (mp.getVideoWidth() > mp.getVideoHeight())
+            naturalSize.putString(EVENT_PROP_ORIENTATION, "landscape");
+        else
+            naturalSize.putString(EVENT_PROP_ORIENTATION, "portrait");
+
         WritableMap event = Arguments.createMap();
         event.putDouble(EVENT_PROP_DURATION, mVideoDuration / 1000.0);
         event.putDouble(EVENT_PROP_CURRENT_TIME, mp.getCurrentPosition() / 1000.0);
+        event.putMap(EVENT_PROP_NATURALSIZE, naturalSize);
         // TODO: Actually check if you can.
         event.putBoolean(EVENT_PROP_FAST_FORWARD, true);
         event.putBoolean(EVENT_PROP_SLOW_FORWARD, true);


### PR DESCRIPTION
onLoad event now returns naturalSize object containing width, height and orientation on Android.
Closes https://github.com/brentvatne/react-native-video/issues/203
