### PR TITLE
use react native asset resolving

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -1,18 +1,7 @@
-import React from 'react';
-import ReactNative from 'react-native';
+import React, {Component, PropTypes} from 'react';
+import {StyleSheet, requireNativeComponent, NativeModules, View} from 'react-native';
+import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 import VideoResizeMode from './VideoResizeMode.js';
-
-const {
-  Component,
-  PropTypes,
-} = React;
-
-const {
-  StyleSheet,
-  requireNativeComponent,
-  NativeModules,
-  View,
-} = ReactNative;
 
 const styles = StyleSheet.create({
   base: {
@@ -149,10 +138,8 @@ export default class Video extends Component {
   }
 
   render() {
-    const {
-      source,
-      resizeMode,
-    } = this.props;
+    const resizeMode = this.props.resizeMode;
+    const source = resolveAssetSource(this.props.source) || {};
 
     let uri = source.uri;
     if (uri && uri.match(/^\//)) {
@@ -215,7 +202,13 @@ Video.propTypes = {
   fullscreen: PropTypes.bool,
 
   /* Wrapper component */
-  source: PropTypes.object,
+  source: PropTypes.oneOfType([
+    PropTypes.shape({
+      uri: PropTypes.string
+    }),
+    // Opaque type returned by require('./video.mp4')
+    PropTypes.number
+  ]),
   resizeMode: PropTypes.string,
   repeat: PropTypes.bool,
   paused: PropTypes.bool,
@@ -242,11 +235,11 @@ Video.propTypes = {
   onPlaybackRateChange: PropTypes.func,
 
   /* Required by react-native */
-  scaleX: React.PropTypes.number,
-  scaleY: React.PropTypes.number,
-  translateX: React.PropTypes.number,
-  translateY: React.PropTypes.number,
-  rotation: React.PropTypes.number,
+  scaleX: PropTypes.number,
+  scaleY: PropTypes.number,
+  translateX: PropTypes.number,
+  translateY: PropTypes.number,
+  rotation: PropTypes.number,
   ...View.propTypes,
 };
 


### PR DESCRIPTION
As described [here](https://github.com/brentvatne/react-native-video/issues/246) before, the React Native `Image` allows you to directly require assets in source prop. That's possible because of the React Native asset resolving mechanism. For `Video` that's currently not possible, this PR adds this capability.

I also cleaned up the imports, sorry for that :-)
