### PR TITLE
This is a bug, you don't need to call the local `setPaused(false)`, a…

### DIFF
--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -348,10 +348,6 @@ static NSString *const playbackRate = @"rate";
     } else if ([keyPath isEqualToString:playbackBufferEmptyKeyPath]) {
       _playerBufferEmpty = YES;
     } else if ([keyPath isEqualToString:playbackLikelyToKeepUpKeyPath]) {
-      // Continue playing (or not if paused) after being paused due to hitting an unbuffered zone.
-      if ((!_controls || _playerBufferEmpty) && _playerItem.playbackLikelyToKeepUp) {
-        [self setPaused:_paused];
-      }
       _playerBufferEmpty = NO;
     }
    } else if (object == _playerLayer) {


### PR DESCRIPTION
This is a bug, , it would not pause the video on iOS.

You don't need to call the local `setPaused(false)`, as it trigger to play the video again when paused from the native controllers. It always go to the `else` section of `setPaused()`, because `_paused` was never set to `true`

The video automatically Pause or continue to Play after it hit a stall and ready to play again
