### PR TITLE
add seekableDuration

### DIFF
--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -110,6 +110,17 @@ static NSString *const playbackRate = @"rate";
     return(kCMTimeInvalid);
 }
 
+- (CMTimeRange)playerItemSeekableTimeRange
+{
+    AVPlayerItem *playerItem = [_player currentItem];
+    if (playerItem.status == AVPlayerItemStatusReadyToPlay)
+    {
+        return [playerItem seekableTimeRanges].firstObject.CMTimeRangeValue;
+    }
+    
+    return (kCMTimeRangeZero);
+}
+
 
 /* Cancels the previously registered time observer. */
 -(void)removePlayerTimeObserver
@@ -171,14 +182,15 @@ static NSString *const playbackRate = @"rate";
    CMTime currentTime = _player.currentTime;
    const Float64 duration = CMTimeGetSeconds(playerDuration);
    const Float64 currentTimeSecs = CMTimeGetSeconds(currentTime);
-   if( currentTimeSecs >= 0 && currentTimeSecs <= duration) {
+   if( currentTimeSecs >= 0) {
         [_eventDispatcher sendInputEventWithName:@"onVideoProgress"
                                             body:@{
                                                      @"currentTime": [NSNumber numberWithFloat:CMTimeGetSeconds(currentTime)],
                                                      @"playableDuration": [self calculatePlayableDuration],
                                                      @"atValue": [NSNumber numberWithLongLong:currentTime.value],
                                                      @"atTimescale": [NSNumber numberWithInt:currentTime.timescale],
-                                                     @"target": self.reactTag
+                                                     @"target": self.reactTag,
+                                                     @"seekableDuration": [NSNumber numberWithFloat:CMTimeGetSeconds([self playerItemSeekableTimeRange].duration)],
                                                  }];
    }
 }


### PR DESCRIPTION
When playing a live HLS videos, duration of the video is returning indefinite.  seekableDuration will give you the beginning and up most bound of the live video.  The seekable duration time will increase as the live stream continues, and stop when the video source is done live streaming.  
