### PR TITLE
prevent 'cover' resizeMode animation

### DIFF
--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -578,6 +578,9 @@ static NSString *const playbackRate = @"rate";
     if( _player )
     {
         _playerViewController = [self createPlayerViewController:_player withPlayerItem:_playerItem];
+        // to prevent video from being animated when resizeMode is 'cover'
+        // resize mode must be set before subview is added
+        [self setResizeMode:_resizeMode];
         [self addSubview:_playerViewController.view];
     }
 }
@@ -589,6 +592,10 @@ static NSString *const playbackRate = @"rate";
       _playerLayer = [AVPlayerLayer playerLayerWithPlayer:_player];
       _playerLayer.frame = self.bounds;
       _playerLayer.needsDisplayOnBoundsChange = YES;
+
+      // to prevent video from being animated when resizeMode is 'cover'
+      // resize mode must be set before layer is added
+      [self setResizeMode:_resizeMode];
         
       [_playerLayer addObserver:self forKeyPath:readyForDisplayKeyPath options:NSKeyValueObservingOptionNew context:nil];
     


### PR DESCRIPTION
Prevent ‘cover’ resizeMode from animating the video to the correct size (when component is created).
