### PR TITLE
Android bug fixes on how the video progress was being handled.

### DIFF
--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -115,16 +115,18 @@ public class ReactVideoView extends ScalableVideoView implements MediaPlayer.OnP
             @Override
             public void run() {
 
-                if (mMediaPlayerValid && !isCompleted) {
+                if (mMediaPlayerValid && !isCompleted &&!mPaused) {
                     WritableMap event = Arguments.createMap();
                     event.putDouble(EVENT_PROP_CURRENT_TIME, mMediaPlayer.getCurrentPosition() / 1000.0);
                     event.putDouble(EVENT_PROP_PLAYABLE_DURATION, mVideoBufferedDuration / 1000.0); //TODO:mBufferUpdateRunnable
                     mEventEmitter.receiveEvent(getId(), Events.EVENT_PROGRESS.toString(), event);
+
+                    // Check for update after an interval
+                    // TODO: The update interval is fixed at 250. There is a property in React component that defines this value. Totally ignored !!!
+                    mProgressUpdateHandler.postDelayed(mProgressUpdateRunnable, 250);
                 }
-                mProgressUpdateHandler.postDelayed(mProgressUpdateRunnable, 250);
             }
         };
-        mProgressUpdateHandler.post(mProgressUpdateRunnable);
     }
 
     @Override
@@ -298,6 +300,9 @@ public class ReactVideoView extends ScalableVideoView implements MediaPlayer.OnP
         } else {
             if (!mMediaPlayer.isPlaying()) {
                 start();
+
+                // Also Start the Progress Update Handler
+                mProgressUpdateHandler.post(mProgressUpdateRunnable);
             }
         }
     }

--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -90,6 +90,7 @@ public class ReactVideoView extends ScalableVideoView implements MediaPlayer.OnP
     private float mVolume = 1.0f;
     private float mRate = 1.0f;
     private boolean mPlayInBackground = false;
+    private boolean mActiveStatePauseStatus = false;
 
     private int mMainVer = 0;
     private int mPatchVer = 0;
@@ -504,14 +505,26 @@ public class ReactVideoView extends ScalableVideoView implements MediaPlayer.OnP
 
     @Override
     public void onHostPause() {
-
         if (mMediaPlayer != null && !mPlayInBackground) {
-            mMediaPlayer.pause();
+            mActiveStatePauseStatus = mPaused;
+
+            // Pause the video in background
+            setPausedModifier(true);
         }
     }
 
     @Override
     public void onHostResume() {
+        if (mMediaPlayer != null && !mPlayInBackground) {
+            new Handler().post(new Runnable() {
+                @Override
+                public void run() {
+                    // Restore original state
+                    setPausedModifier(mActiveStatePauseStatus);
+                }
+            });
+
+        }
     }
 
     @Override


### PR DESCRIPTION
1. There was a code leak on the way the Progress Handler was being used.
2. When the host state resumed back, the player didn't remember the original state (paused/playing) of the video playback.
