### PR TITLE
Update react-native-video.podspec so source_files points to ios/ dir

### DIFF
--- a/react-native-video.podspec
+++ b/react-native-video.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/brentvatne/react-native-video.git", :tag => "#{s.version}" }
 
-  s.source_files  = "*.{h,m}"
+  s.source_files  = "ios/*.{h,m}"
 
   s.dependency "React"
 end


### PR DESCRIPTION
When directory structure was refactored, source files were moved to `ios/` dir, but the podspec wasn't updated to reflect this.