### PR TITLE
employ onPlaybackRateChange instead to smooth the poster disappearance

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -58,10 +58,6 @@ export default class Video extends Component {
   };
 
   _onProgress = (event) => {
-    if (this.state.showPoster) {
-      this.setState({showPoster: false});
-    }
-
     if (this.props.onProgress) {
       this.props.onProgress(event.nativeEvent);
     }
@@ -126,6 +122,10 @@ export default class Video extends Component {
   };
 
   _onPlaybackRateChange = (event) => {
+    if (this.state.showPoster && (event.nativeEvent.playbackRate === 1)) {
+      this.setState({showPoster: false});
+    }
+
     if (this.props.onPlaybackRateChange) {
       this.props.onPlaybackRateChange(event.nativeEvent);
     }


### PR DESCRIPTION
This is to enhance the user experience by smoothing the poster disappearance. With `onProgress` it could lead to unexpected video flash/stall, and with `onPlaybackRateChange` it works much better.

This is related to my previous PR #400.

@mattapperson Could you please help to review this? Thanks.