### PR TITLE
[Android] Resize the video correctly on layout changes

### DIFF
--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -1,6 +1,7 @@
 package com.brentvatne.react;
 
 import android.content.res.AssetFileDescriptor;
+import android.graphics.Matrix;
 import android.media.MediaPlayer;
 import android.net.Uri;
 import android.os.Handler;
@@ -19,6 +20,8 @@ import com.yqritc.scalablevideoview.ScalableVideoView;
 
 import com.android.vending.expansion.zipfile.APKExpansionSupport;
 import com.android.vending.expansion.zipfile.ZipResourceFile;
+import com.yqritc.scalablevideoview.ScaleManager;
+import com.yqritc.scalablevideoview.Size;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -138,6 +141,30 @@ public class ReactVideoView extends ScalableVideoView implements MediaPlayer.OnP
         }
 
         return super.onTouchEvent(event);
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+
+        if (!changed || !mMediaPlayerValid) {
+            return;
+        }
+
+        int videoWidth = getVideoWidth();
+        int videoHeight = getVideoHeight();
+
+        if (videoWidth == 0 || videoHeight == 0) {
+            return;
+        }
+
+        Size viewSize = new Size(getWidth(), getHeight());
+        Size videoSize = new Size(videoWidth, videoHeight);
+        ScaleManager scaleManager = new ScaleManager(viewSize, videoSize);
+        Matrix matrix = scaleManager.getScaleMatrix(mScalableType);
+        if (matrix != null) {
+            setTransform(matrix);
+        }
     }
 
     private void initializeMediaPlayerIfNeeded() {


### PR DESCRIPTION
The transform matrix was not being recalculated when the View
dimensions changed. Fixed by copying the code from the scaleVideoSize
method from the ScalableVideoView.

https://github.com/yqritc/Android-ScalableVideoView/blob/master/library/src/main/java/com/yqritc/scalablevideoview/ScalableVideoView.java#L95