### PR TITLE
Support for react-native-photos-framework

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -141,7 +141,7 @@ export default class Video extends Component {
     }
 
     const isNetwork = !!(uri && uri.match(/^https?:/));
-    const isAsset = !!(uri && uri.match(/^(assets-library|file|content|ms-appx|ms-appdata):/));
+    const isAsset = !!(uri && uri.match(/^(assets-library|file|photos|content|ms-appx|ms-appdata):/));
 
     let nativeResizeMode;
     if (resizeMode === VideoResizeMode.stretch) {

--- a/Video.js
+++ b/Video.js
@@ -13,7 +13,6 @@ export default class Video extends Component {
 
   constructor(props) {
     super(props);
-
     this.state = {
       showPoster: true,
     };
@@ -50,6 +49,12 @@ export default class Video extends Component {
       this.props.onLoad(event.nativeEvent);
     }
   };
+
+  _onLoadProgress = (event) => {
+    if (this.props.onLoadProgress) {
+      this.props.onLoadProgress(event.nativeEvent);
+    }
+  }
 
   _onError = (event) => {
     if (this.props.onError) {
@@ -166,6 +171,7 @@ export default class Video extends Component {
         mainVer: source.mainVer || 0,
         patchVer: source.patchVer || 0,
       },
+      onVideoLoadProgress : this._onLoadProgress,
       onVideoLoadStart: this._onLoadStart,
       onVideoLoad: this._onLoad,
       onVideoError: this._onError,
@@ -253,6 +259,7 @@ Video.propTypes = {
   progressUpdateInterval: PropTypes.number,
   onLoadStart: PropTypes.func,
   onLoad: PropTypes.func,
+  onLoadProgress : PropTypes.func,
   onError: PropTypes.func,
   onProgress: PropTypes.func,
   onSeek: PropTypes.func,

--- a/ios/RCTVideo.h
+++ b/ios/RCTVideo.h
@@ -1,4 +1,4 @@
-#import "RCTView.h"
+#import <React/RCTView.h>
 #import <AVFoundation/AVFoundation.h>
 #import "AVKit/AVKit.h"
 #import "UIView+FindUIViewController.h"

--- a/ios/RCTVideo.h
+++ b/ios/RCTVideo.h
@@ -23,6 +23,7 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onPlaybackStalled;
 @property (nonatomic, copy) RCTBubblingEventBlock onPlaybackResume;
 @property (nonatomic, copy) RCTBubblingEventBlock onPlaybackRateChange;
+@property (nonatomic, strong) NSString *loadedPhotosUri;
 
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher NS_DESIGNATED_INITIALIZER;
 

--- a/ios/RCTVideo.h
+++ b/ios/RCTVideo.h
@@ -6,7 +6,7 @@
 #import "RCTVideoPlayerViewControllerDelegate.h"
 
 @class RCTEventDispatcher;
-
+@import Photos;
 @interface RCTVideo : UIView <RCTVideoPlayerViewControllerDelegate>
 
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoLoadStart;

--- a/ios/RCTVideo.m
+++ b/ios/RCTVideo.m
@@ -1,8 +1,8 @@
-#import "RCTConvert.h"
+#import <React/RCTConvert.h>
 #import "RCTVideo.h"
-#import "RCTBridgeModule.h"
-#import "RCTEventDispatcher.h"
-#import "UIView+React.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/UIView+React.h>
 
 static NSString *const statusKeyPath = @"status";
 static NSString *const playbackLikelyToKeepUpKeyPath = @"playbackLikelyToKeepUp";

--- a/ios/RCTVideo.m
+++ b/ios/RCTVideo.m
@@ -184,7 +184,7 @@ static NSString *const playbackRate = @"rate";
    CMTime currentTime = _player.currentTime;
    const Float64 duration = CMTimeGetSeconds(playerDuration);
    const Float64 currentTimeSecs = CMTimeGetSeconds(currentTime);
-   if( currentTimeSecs >= 0) {
+   if( currentTimeSecs >= 0 && self.onVideoProgress) {
       self.onVideoProgress(@{
                              @"currentTime": [NSNumber numberWithFloat:CMTimeGetSeconds(currentTime)],
                              @"playableDuration": [self calculatePlayableDuration],
@@ -277,12 +277,15 @@ static NSString *const playbackRate = @"rate";
 
   dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
     //Perform on next run loop, otherwise onVideoLoadStart is nil
-    self.onVideoLoadStart(@{@"src": @{
-                                @"uri": [source objectForKey:@"uri"],
-                                @"type": [source objectForKey:@"type"],
-                                @"isNetwork": [NSNumber numberWithBool:(bool)[source objectForKey:@"isNetwork"]]},
-                            @"target": self.reactTag
-                            });
+      if(self.onVideoLoadStart) {
+          self.onVideoLoadStart(@{@"src": @{
+                                          @"uri": [source objectForKey:@"uri"],
+                                          @"type": [source objectForKey:@"type"],
+                                          @"isNetwork": [NSNumber numberWithBool:(bool)[source objectForKey:@"isNetwork"]]},
+                                  @"target": self.reactTag
+                                  });
+      }
+
   });
 }
 
@@ -341,25 +344,28 @@ static NSString *const playbackRate = @"rate";
           } else
             orientation = @"portrait";
         }
+          
+      if(self.onVideoLoad) {
+          self.onVideoLoad(@{@"duration": [NSNumber numberWithFloat:duration],
+                             @"currentTime": [NSNumber numberWithFloat:CMTimeGetSeconds(_playerItem.currentTime)],
+                             @"canPlayReverse": [NSNumber numberWithBool:_playerItem.canPlayReverse],
+                             @"canPlayFastForward": [NSNumber numberWithBool:_playerItem.canPlayFastForward],
+                             @"canPlaySlowForward": [NSNumber numberWithBool:_playerItem.canPlaySlowForward],
+                             @"canPlaySlowReverse": [NSNumber numberWithBool:_playerItem.canPlaySlowReverse],
+                             @"canStepBackward": [NSNumber numberWithBool:_playerItem.canStepBackward],
+                             @"canStepForward": [NSNumber numberWithBool:_playerItem.canStepForward],
+                             @"naturalSize": @{
+                                     @"width": width,
+                                     @"height": height,
+                                     @"orientation": orientation
+                                     },
+                             @"target": self.reactTag});
+      }
 
-        self.onVideoLoad(@{@"duration": [NSNumber numberWithFloat:duration],
-                           @"currentTime": [NSNumber numberWithFloat:CMTimeGetSeconds(_playerItem.currentTime)],
-                           @"canPlayReverse": [NSNumber numberWithBool:_playerItem.canPlayReverse],
-                           @"canPlayFastForward": [NSNumber numberWithBool:_playerItem.canPlayFastForward],
-                           @"canPlaySlowForward": [NSNumber numberWithBool:_playerItem.canPlaySlowForward],
-                           @"canPlaySlowReverse": [NSNumber numberWithBool:_playerItem.canPlaySlowReverse],
-                           @"canStepBackward": [NSNumber numberWithBool:_playerItem.canStepBackward],
-                           @"canStepForward": [NSNumber numberWithBool:_playerItem.canStepForward],
-                           @"naturalSize": @{
-                              @"width": width,
-                              @"height": height,
-                              @"orientation": orientation
-                           },
-                           @"target": self.reactTag});
 
         [self attachListeners];
         [self applyModifiers];
-      } else if(_playerItem.status == AVPlayerItemStatusFailed) {
+      } else if(_playerItem.status == AVPlayerItemStatusFailed && self.onVideoError) {
         self.onVideoError(@{@"error": @{@"code": [NSNumber numberWithInteger: _playerItem.error.code],
                                         @"domain": _playerItem.error.domain},
                                         @"target": self.reactTag});
@@ -375,17 +381,21 @@ static NSString *const playbackRate = @"rate";
     }
    } else if (object == _playerLayer) {
       if([keyPath isEqualToString:readyForDisplayKeyPath] && [change objectForKey:NSKeyValueChangeNewKey]) {
-        if([change objectForKey:NSKeyValueChangeNewKey]) {
+        if([change objectForKey:NSKeyValueChangeNewKey] && self.onReadyForDisplay) {
           self.onReadyForDisplay(@{@"target": self.reactTag});
         }
     }
   } else if (object == _player) {
       if([keyPath isEqualToString:playbackRate]) {
-          self.onPlaybackRateChange(@{@"playbackRate": [NSNumber numberWithFloat:_player.rate],
-                                      @"target": self.reactTag});
+          if(self.onPlaybackRateChange) {
+              self.onPlaybackRateChange(@{@"playbackRate": [NSNumber numberWithFloat:_player.rate],
+                                          @"target": self.reactTag});
+          }
           if(_playbackStalled && _player.rate > 0) {
-              self.onPlaybackResume(@{@"playbackRate": [NSNumber numberWithFloat:_player.rate],
-                                      @"target": self.reactTag});
+              if(self.onPlaybackResume) {
+                  self.onPlaybackResume(@{@"playbackRate": [NSNumber numberWithFloat:_player.rate],
+                                          @"target": self.reactTag});
+              }
               _playbackStalled = NO;
           }
       }
@@ -409,13 +419,17 @@ static NSString *const playbackRate = @"rate";
 
 - (void)playbackStalled:(NSNotification *)notification
 {
-  self.onPlaybackStalled(@{@"target": self.reactTag});
+  if(self.onPlaybackStalled) {
+    self.onPlaybackStalled(@{@"target": self.reactTag});
+  }
   _playbackStalled = YES;
 }
 
 - (void)playerItemDidReachEnd:(NSNotification *)notification
 {
-  self.onVideoEnd(@{@"target": self.reactTag});
+  if(self.onVideoEnd) {
+      self.onVideoEnd(@{@"target": self.reactTag});
+  }
 
   if (_repeat) {
     AVPlayerItem *item = [notification object];
@@ -487,9 +501,11 @@ static NSString *const playbackRate = @"rate";
 
     if (CMTimeCompare(current, cmSeekTime) != 0) {
       [_player seekToTime:cmSeekTime toleranceBefore:tolerance toleranceAfter:tolerance completionHandler:^(BOOL finished) {
-        self.onVideoSeek(@{@"currentTime": [NSNumber numberWithFloat:CMTimeGetSeconds(item.currentTime)],
-                           @"seekTime": [NSNumber numberWithFloat:seekTime],
-                           @"target": self.reactTag});
+        if(self.onVideoSeek) {
+            self.onVideoSeek(@{@"currentTime": [NSNumber numberWithFloat:CMTimeGetSeconds(item.currentTime)],
+                               @"seekTime": [NSNumber numberWithFloat:seekTime],
+                               @"target": self.reactTag});
+        }
       }];
 
       _pendingSeek = false;
@@ -571,11 +587,15 @@ static NSString *const playbackRate = @"rate";
         if( viewController )
         {
             _presentingViewController = viewController;
-            self.onVideoFullscreenPlayerWillPresent(@{@"target": self.reactTag});
+            if(self.onVideoFullscreenPlayerWillPresent) {
+                self.onVideoFullscreenPlayerWillPresent(@{@"target": self.reactTag});
+            }
             [viewController presentViewController:_playerViewController animated:true completion:^{
                 _playerViewController.showsPlaybackControls = YES;
                 _fullscreenPlayerPresented = fullscreen;
-                self.onVideoFullscreenPlayerDidPresent(@{@"target": self.reactTag});
+                if(self.onVideoFullscreenPlayerDidPresent) {
+                    self.onVideoFullscreenPlayerDidPresent(@{@"target": self.reactTag});
+                }
             }];
         }
     }
@@ -653,7 +673,7 @@ static NSString *const playbackRate = @"rate";
 
 - (void)videoPlayerViewControllerWillDismiss:(AVPlayerViewController *)playerViewController
 {
-    if (_playerViewController == playerViewController && _fullscreenPlayerPresented)
+    if (_playerViewController == playerViewController && _fullscreenPlayerPresented && self.onVideoFullscreenPlayerWillDismiss)
     {
         self.onVideoFullscreenPlayerWillDismiss(@{@"target": self.reactTag});
     }
@@ -666,7 +686,9 @@ static NSString *const playbackRate = @"rate";
         _fullscreenPlayerPresented = false;
         _presentingViewController = nil;
         [self applyModifiers];
-        self.onVideoFullscreenPlayerDidDismiss(@{@"target": self.reactTag});
+        if(self.onVideoFullscreenPlayerDidDismiss) {
+            self.onVideoFullscreenPlayerDidDismiss(@{@"target": self.reactTag});
+        }
     }
 }
 

--- a/ios/RCTVideo.xcodeproj/project.pbxproj
+++ b/ios/RCTVideo.xcodeproj/project.pbxproj
@@ -220,8 +220,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../../react-native/React/**",
-					"$(SRCROOT)/../node_modules/react-native/React/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
@@ -236,8 +234,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../../react-native/React/**",
-					"$(SRCROOT)/../node_modules/react-native/React/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";

--- a/ios/RCTVideoManager.h
+++ b/ios/RCTVideoManager.h
@@ -1,4 +1,4 @@
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 @interface RCTVideoManager : RCTViewManager
 

--- a/ios/RCTVideoManager.m
+++ b/ios/RCTVideoManager.m
@@ -1,6 +1,6 @@
 #import "RCTVideoManager.h"
 #import "RCTVideo.h"
-#import "RCTBridge.h"
+#import <React/RCTBridge.h>
 #import <AVFoundation/AVFoundation.h>
 
 @implementation RCTVideoManager


### PR DESCRIPTION
I don't know if this would belong in `react-native-video` or if it's to specialized.
But I've implemented support for playing back iCloud stored videos loaded via Apple's
Photos Framework. This gives the library out of the box support for my library [react-native-photos-framework](https://github.com/olofd/react-native-photos-framework).

Just wanted to let you know, and maybe ask if there are community support for this going into master of react-native-video or not. Otherwise it will live on my fork and I will reference people of `react-native-photos-framework` to use that fork.

Oh, and this is based on my other two PR's #442 and #444. (ie. they are in in the diff as well.)

Olof