### PR TITLE
Fix src type=nil NSDictionary crash

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -153,7 +153,7 @@ export default class Video extends Component {
     const resizeMode = this.props.resizeMode;
     const source = resolveAssetSource(this.props.source) || {};
 
-    let uri = source.uri;
+    let uri = source.uri || '';
     if (uri && uri.match(/^\//)) {
       uri = `file://${uri}`;
     }
@@ -180,7 +180,7 @@ export default class Video extends Component {
         uri,
         isNetwork,
         isAsset,
-        type: source.type,
+        type: source.type || '',
         mainVer: source.mainVer || 0,
         patchVer: source.patchVer || 0,
       },

--- a/ios/RCTVideo.m
+++ b/ios/RCTVideo.m
@@ -277,9 +277,11 @@ static NSString *const playbackRate = @"rate";
 
   dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
     //Perform on next run loop, otherwise onVideoLoadStart is nil
+    id uri = [source objectForKey:@"uri"];
+    id type = [source objectForKey:@"type"];
     self.onVideoLoadStart(@{@"src": @{
-                                @"uri": [source objectForKey:@"uri"],
-                                @"type": [source objectForKey:@"type"],
+                                @"uri": uri ? uri : [NSNull null],
+                                @"type": type ? type : [NSNull null],
                                 @"isNetwork": [NSNumber numberWithBool:(bool)[source objectForKey:@"isNetwork"]]},
                             @"target": self.reactTag
                             });


### PR DESCRIPTION
- Use NSNull object in NSDictionary when type (or URI) missing from supplied
  src object.
- In addition, defensively supply valid strings for URI and type from JS.

Looks like this should help with https://github.com/react-native-community/react-native-video/issues/449 and possibly https://github.com/react-native-community/react-native-video/issues/443. I'm seeing the crash behavior in a full external app, not just the example app. Credit to @smkhalsa (https://github.com/react-native-community/react-native-video/pull/454) and @LiuCao (https://github.com/react-native-community/react-native-video/issues/449#issuecomment-272760480) for separately suggesting these fixes; I'm just putting the suggestions together here with some minor tweaks.