### PR TITLE
[ExoPlayer]  Value of `paused` prop should be respected when resuming the app

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -166,7 +166,7 @@ class ReactExoplayerView extends FrameLayout implements
 
     @Override
     public void onHostResume() {
-        startPlayback();
+        setPlayWhenReady(!isPaused);
     }
 
     @Override


### PR DESCRIPTION
Before, when you resumed the app the player would **always** just start playing again.

After this changed the `paused` prop of the `Video` component (which is the `isPaused` variable internally)
is consulted on resume, for whether or not the playback should resume as well.

I'm not an Android/Java expert but this has worked for me.