### PR TITLE
Pausing progress if it was playing and the stating again

### DIFF
--- a/ios/RCTVideo.m
+++ b/ios/RCTVideo.m
@@ -532,9 +532,12 @@ static NSString *const timedMetadata = @"timedMetadata";
     CMTime current = item.currentTime;
     // TODO figure out a good tolerance level
     CMTime tolerance = CMTimeMake(1000, timeScale);
+    BOOL wasPaused = _paused;
 
     if (CMTimeCompare(current, cmSeekTime) != 0) {
+      if (!wasPaused) [_player pause];
       [_player seekToTime:cmSeekTime toleranceBefore:tolerance toleranceAfter:tolerance completionHandler:^(BOOL finished) {
+        if (!wasPaused) [_player play];
         if(self.onVideoSeek) {
             self.onVideoSeek(@{@"currentTime": [NSNumber numberWithFloat:CMTimeGetSeconds(item.currentTime)],
                                @"seekTime": [NSNumber numberWithFloat:seekTime],


### PR DESCRIPTION
When loading a network resource, when seeking the player has really weird behavior of it continuing to play till it has buffered enough to play. Also when it is buffering, it doesn't notify that it is buffering. At least this way, some logic can be added to `onProgress` to track when the audio is not actually playing.