### PR TITLE
[Android] App crash when unmounting video

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,5 +17,5 @@ android {
 
 dependencies {
     provided 'com.facebook.react:react-native:+'
-    compile 'com.yqritc:android-scalablevideoview:1.0.1'
+    compile 'com.yqritc:android-scalablevideoview:1.0.4'
 }

--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -294,9 +294,8 @@ public class ReactVideoView extends ScalableVideoView implements MediaPlayer.OnP
         event.putMap(ReactVideoViewManager.PROP_SRC, src);
         mEventEmitter.receiveEvent(getId(), Events.EVENT_LOAD_START.toString(), event);
 
-        // not async to prevent random crashes on Android playback from local resource due to race conditions
         try {
-          prepare(this);
+          prepareAsync(this);
         } catch (Exception e) {
           e.printStackTrace();
         }

--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -193,8 +193,7 @@ public class ReactVideoView extends ScalableVideoView implements MediaPlayer.OnP
         }
         if ( mMediaPlayer != null ) {
             mMediaPlayerValid = false;
-            mMediaPlayer.stop();
-            mMediaPlayer.release();
+            release();
         }
     }
 


### PR DESCRIPTION
Fixes #492.

The problem is that `ScalableVideoView` and `ReactVideoView` were calling `mMediaPlayer.release()` on unmount, but were not resetting `mMediaPlayer = null`. The next time around (e.g. when `isPlaying()` is called), `mMediaPlayer` is in an invalid (released) state, but the null-checks do not get hit (because `mMediaPlayer != null`), which causes an exception to be thrown.

The issue has since been fixed in the `release()` method of `ScalableVideoView` (version 1.0.4). So I've bumped up the dependencies in `build.gradle` to use that. I've also changed `cleanupMediaPlayerResources` in `ReactVideoView` to use that method as well.