### PR TITLE
Fix/494

### DIFF
--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -94,6 +94,7 @@ public class ReactVideoView extends ScalableVideoView implements MediaPlayer.OnP
     private float mRate = 1.0f;
     private boolean mPlayInBackground = false;
     private boolean mActiveStatePauseStatus = false;
+    private boolean mActiveStatePauseStatusInitialized = false;
 
     private int mMainVer = 0;
     private int mPatchVer = 0;
@@ -324,6 +325,11 @@ public class ReactVideoView extends ScalableVideoView implements MediaPlayer.OnP
     public void setPausedModifier(final boolean paused) {
 
         mPaused = paused;
+
+        if ( !mActiveStatePauseStatusInitialized ) {
+            mActiveStatePauseStatus = mPaused;
+            mActiveStatePauseStatusInitialized = true;
+        }
 
         if (!mMediaPlayerValid) {
             return;

--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -237,7 +237,7 @@ public class ReactVideoView extends ScalableVideoView implements MediaPlayer.OnP
                     headers.put("Cookie", cookie);
                 }
 
-                setDataSource(mThemedReactContext, parsedUrl, headers);
+                setDataSource(uriString);
             } else if (isAsset) {
                 if (uriString.startsWith("content://")) {
                     Uri parsedUrl = Uri.parse(uriString);


### PR DESCRIPTION
In order to address #494 and #530 

two fixes are introduced with this pull request:
1. as suggested by @devmaster72 the auto-start of the video is fixed, by taking into the account the 'paused' prop passed
2. An IOException was constantly being thrown from the android Media player classes, because instead of only a URL, the media player, for a dataSource was expecting a whole ContentProvider initialised with context