### PR TITLE
Warn that iOS needs a distant url to use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ using System.Collections.Generic;
 // "background.mp4" in your project. You can include multiple videos
 // on a single screen if you like.
 
-<Video source={{uri: "background"}}   // Can be a URL or a local file.
+<Video source={{uri: "background"}}   // Can be a URL or a local file. URL must be on a https scheme on iOS.
        ref={(ref) => {
          this.player = ref
        }}                                      // Store reference


### PR DESCRIPTION
I tried to load a distant mp4 video for about an hour before realizing that iOS 10 requires all the webservices and files loaded in the apps to use https.
I think a warning about that can be a good thing.