### PR TITLE
Fix repeat for exoplayer

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -404,9 +404,14 @@ class ReactExoplayerView extends FrameLayout implements
                 videoLoaded();
                 break;
             case ExoPlayer.STATE_ENDED:
-                text += "ended";
-                eventEmitter.end();
-                onStopPlayback();
+                if(repeat) {
+                    playerNeedsSource =  true;
+                    startPlayback();
+                } else {
+                    text += "ended";
+                    eventEmitter.end();
+                    onStopPlayback();
+                }
                 break;
             default:
                 text += "unknown";

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "eslint-config-airbnb": "4.0.0"
   },
   "dependencies": {
-    "keymirror": "0.1.1",
-    "react-native-windows": "0.41.0-rc.0"
+    "keymirror": "0.1.1"
   },
   "scripts": {
     "test": "node_modules/.bin/eslint *.js"


### PR DESCRIPTION
Repeat was not working for me when using exoplayer. I found the reason: `setRepeatModifier` method was called after [this line](https://github.com/react-native-community/react-native-video/blob/master/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java#L208) in `initializePlayer`. This might not be the best solution here, so I'm waiting for any suggestions.