### PR TITLE
fix(ios): crash due to persistent keyPath observer

### DIFF
--- a/ios/RCTVideo.m
+++ b/ios/RCTVideo.m
@@ -238,6 +238,9 @@ static NSString *const timedMetadata = @"timedMetadata";
  * observer set */
 - (void)removePlayerItemObservers
 {
+  if (_playerLayer) {
+    [_playerLayer removeObserver:self forKeyPath:readyForDisplayKeyPath];
+  }
   if (_playerItemObserversSet) {
     [_playerItem removeObserver:self forKeyPath:statusKeyPath];
     [_playerItem removeObserver:self forKeyPath:playbackBufferEmptyKeyPath];


### PR DESCRIPTION
@nicolai86 discovered a bug where the video player was crashing our application.