### PR TITLE
Fix paused prop doesn't work when init the Video

### DIFF
--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -326,6 +326,7 @@ public class ReactVideoView extends ScalableVideoView implements MediaPlayer.OnP
     public void setPausedModifier(final boolean paused) {
 
         mPaused = paused;
+        mActiveStatePauseStatus = paused;
 
         if ( !mActiveStatePauseStatusInitialized ) {
             mActiveStatePauseStatus = mPaused;


### PR DESCRIPTION
It caused by onResume life cycle method. when the first time to run onResume, the mActiveStatePauseStatus always be false, so it always play the video.

now we can use paused prop to control the video playing status.