### PR TITLE
Change react-windows become optional package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,13 @@
     "eslint": "1.10.3",
     "babel-eslint": "5.0.0-beta8",
     "eslint-plugin-react": "3.16.1",
-    "eslint-config-airbnb": "4.0.0"
+    "eslint-config-airbnb": "4.0.0",
+    "react-native-windows": "0.41.0-rc.0"
   },
   "dependencies": {
-    "keymirror": "0.1.1",
+    "keymirror": "0.1.1"
+  },
+  "optionalDependencies": {
     "react-native-windows": "0.41.0-rc.0"
   },
   "scripts": {


### PR DESCRIPTION
It's really excited that `react-native-video` supports Windows. But I believe that makes more sense to put `react-native-windows` as an optional dependency. By doing this, if users don't build app for Windows, they don't have to install `react-native-windows`.