### PR TITLE
Feat/ontimedmetadata android

### DIFF
--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -83,6 +83,9 @@ public class ReactVideoView extends ScalableVideoView implements
     public static final String EVENT_PROP_HEIGHT = "height";
     public static final String EVENT_PROP_ORIENTATION = "orientation";
     public static final String EVENT_PROP_METADATA = "metadata";
+    public static final String EVENT_PROP_TARGET = "target";
+    public static final String EVENT_PROP_METADATA_IDENTIFIER = "identifier";
+    public static final String EVENT_PROP_METADATA_VALUE = "value";
 
     public static final String EVENT_PROP_ERROR = "error";
     public static final String EVENT_PROP_WHAT = "what";
@@ -557,15 +560,15 @@ public class ReactVideoView extends ScalableVideoView implements
             String rawMeta  = new String(data.getMetaData(), "UTF-8");
             WritableMap id3 = Arguments.createMap();
 
-            id3.putString("value", rawMeta.substring(rawMeta.lastIndexOf("\u0003") + 1));
-            id3.putString("identifier", "id3/TDEN");
+            id3.putString(EVENT_PROP_METADATA_VALUE, rawMeta.substring(rawMeta.lastIndexOf("\u0003") + 1));
+            id3.putString(EVENT_PROP_METADATA_IDENTIFIER, "id3/TDEN");
 
             WritableArray metadata = new WritableNativeArray();
 
             metadata.pushMap(id3);
 
             event.putArray(EVENT_PROP_METADATA, metadata);
-            event.putDouble("target", getId());
+            event.putDouble(EVENT_PROP_TARGET, getId());
         } catch(UnsupportedEncodingException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
This PR adds support for getting the id3 tag (currently support for the single timecode) in android. I have tested it and it functions identical to the other platforms in the projects.

### Notes

* Don't merge yet. The min sdk version now is 23. I have to make this optional first, otherwise this is a BC break.
* Any pointers on getting the tags in a "prettier" manner than this are welcome. I've spent a full working day on google trying to find a solution that's prettier, and all of them were worse than this one, which is more elegant in terms of performance and readability.

I'll be forking this module, with this PR merged as I can't wait for your feedback right now. I'll try to keep submitting PRs as long as I don't stray from the current codebase too far.