### PR TITLE
Remove createJSModules @override - RN 0.47 compatibility

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/react/ReactVideoPackage.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/react/ReactVideoPackage.java
@@ -17,7 +17,7 @@ public class ReactVideoPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
-    // Depreciated RN 0.47
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/react/ReactVideoPackage.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/react/ReactVideoPackage.java
@@ -17,7 +17,6 @@ public class ReactVideoPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/react/ReactVideoPackage.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/react/ReactVideoPackage.java
@@ -16,7 +16,7 @@ public class ReactVideoPackage implements ReactPackage {
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }
-    
+
     // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();

--- a/android-exoplayer/src/main/java/com/brentvatne/react/ReactVideoPackage.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/react/ReactVideoPackage.java
@@ -17,7 +17,7 @@ public class ReactVideoPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
-    // Deprecated RN 0.47
+    // Depreciated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/react/ReactVideoPackage.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/react/ReactVideoPackage.java
@@ -16,7 +16,8 @@ public class ReactVideoPackage implements ReactPackage {
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }
-
+    
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/brentvatne/react/ReactVideoPackage.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoPackage.java
@@ -18,7 +18,6 @@ public class ReactVideoPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/brentvatne/react/ReactVideoPackage.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoPackage.java
@@ -18,6 +18,7 @@ public class ReactVideoPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/brentvatne/react/ReactVideoPackage.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoPackage.java
@@ -18,7 +18,7 @@ public class ReactVideoPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
-    // Deprecated RN 0.47
+    // Depreciated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/brentvatne/react/ReactVideoPackage.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoPackage.java
@@ -18,7 +18,7 @@ public class ReactVideoPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
-    // Depreciated RN 0.47
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. I actually can't build an app on RN 0.47 without removing this method. There is similar PR (#717), but my solution is backwards compatible.