### PR TITLE
Remove react-native-windows as a direct dependency of react-native-video

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   },
   "dependencies": {
     "keymirror": "0.1.1",
-    "prop-types": "^15.5.10",
-    "react-native-windows": "0.41.0-rc.0"
+    "prop-types": "^15.5.10"
   },
   "scripts": {
     "test": "node_modules/.bin/eslint *.js"


### PR DESCRIPTION
Fix #729 
Fix #720 
Fix #640 
Fix #567 

Hi there, thanks for this package! When installing this package, it also bundled `react-native-windows` into my app since it's a dependency of this project. Since it's not required to have react-native-windows for this package to work, it shouldn't be required. We're also not adding react-native itself as a dependency so I don't see why the windows version should be.

Thanks in advance for reviewing!