### PR TITLE
Removing dependency on react-native-windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "keymirror": "0.1.1",
     "prop-types": "^15.5.10",
-    "react-native-windows": "0.41.0-rc.0"
   },
   "scripts": {
     "test": "node_modules/.bin/eslint *.js"


### PR DESCRIPTION
At best, this should have a peer dependency on react-native-windows (in the manner that [other packages](https://github.com/kmagiera/react-native-gesture-handler/blob/master/package.json#L38) do for react-native). In the past, I've added react-native-windows even as a dev dependency for compatible modules.  However, it absolutely should not be a strict dependency (much in the same way that react-native is not a dependency here.