### PR TITLE
Show iOS controls without using present full screen

### DIFF
--- a/ios/RCTVideo.m
+++ b/ios/RCTVideo.m
@@ -90,7 +90,7 @@ static NSString *const timedMetadata = @"timedMetadata";
 
 - (AVPlayerViewController*)createPlayerViewController:(AVPlayer*)player withPlayerItem:(AVPlayerItem*)playerItem {
     RCTVideoPlayerViewController* playerLayer= [[RCTVideoPlayerViewController alloc] init];
-    playerLayer.showsPlaybackControls = NO;
+    playerLayer.showsPlaybackControls = YES;
     playerLayer.rctDelegate = self;
     playerLayer.view.frame = self.bounds;
     playerLayer.player = _player;


### PR DESCRIPTION
This allows you to show the controls without calling the present full screen method.