### PR TITLE
Set fullScreenPlayer's orientation [iOS]

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ using System.Collections.Generic;
        onError={this.videoError}               // Callback when video cannot be loaded
        onBuffer={this.onBuffer}                // Callback when remote video is buffering
        onTimedMetadata={this.onTimedMetadata}  // Callback when the stream receive some metadata
+       autoRotate={false}                      // [iOS] Determines if FullScreenPlayer can be rotated (default true).
+       fullScreenOrientation={Video.Constants.landscape} // [iOS] Determines FullScreenPlayer's orientation.
        style={styles.backgroundVideo} />
 
 // Later to trigger fullscreen

--- a/Video.js
+++ b/Video.js
@@ -271,6 +271,8 @@ Video.propTypes = {
     PropTypes.number
   ]),
   resizeMode: PropTypes.string,
+  fullScreenOrientation: PropTypes.string,
+  autoRotate: PropTypes.bool,
   poster: PropTypes.string,
   repeat: PropTypes.bool,
   paused: PropTypes.bool,
@@ -309,6 +311,16 @@ Video.propTypes = {
   translateY: PropTypes.number,
   rotation: PropTypes.number,
   ...View.propTypes,
+};
+
+Video.Constants = {
+  all: 'all',
+  allButUpsideDown: 'allButUpsideDown',
+  portrait: 'portrait',
+  portraitUpsideDown: 'portraitUpsideDown',
+  landscape: 'landscape',
+  landscapeLeft: 'landscapeLeft',
+  landscapeRight: 'landscapeRight'
 };
 
 const RCTVideo = requireNativeComponent('RCTVideo', Video, {

--- a/ios/RCTVideoManager.m
+++ b/ios/RCTVideoManager.m
@@ -34,6 +34,8 @@ RCT_EXPORT_VIEW_PROPERTY(seek, float);
 RCT_EXPORT_VIEW_PROPERTY(currentTime, float);
 RCT_EXPORT_VIEW_PROPERTY(fullscreen, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(progressUpdateInterval, float);
+RCT_EXPORT_VIEW_PROPERTY(autoRotate, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(fullScreenOrientation, NSString);
 /* Should support: onLoadStart, onLoad, and onError to stay consistent with Image */
 RCT_EXPORT_VIEW_PROPERTY(onVideoLoadStart, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoLoad, RCTBubblingEventBlock);

--- a/ios/RCTVideoPlayerViewController.h
+++ b/ios/RCTVideoPlayerViewController.h
@@ -12,4 +12,8 @@
 
 @interface RCTVideoPlayerViewController : AVPlayerViewController
 @property (nonatomic, weak) id<RCTVideoPlayerViewControllerDelegate> rctDelegate;
+@property (nonatomic, assign) BOOL autoRotate;
+#if !TARGET_OS_TV
+@property (nonatomic, assign) UIInterfaceOrientationMask fullScreenOrientation;
+#endif
 @end

--- a/ios/RCTVideoPlayerViewController.m
+++ b/ios/RCTVideoPlayerViewController.m
@@ -17,4 +17,18 @@
     [super viewWillDisappear:animated];
 }
 
+- (BOOL)shouldAutorotate
+{
+    return _autoRotate;
+}
+
+#if !TARGET_OS_TV
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+    return _fullScreenOrientation;
+}
+
+#endif
+
 @end


### PR DESCRIPTION
Pass `autoRotate` (default true) and `screenOrientation` prop to FullScreenVideoPlayer.

```
<Video
            source={{ uri: 'some_source_here' }}
            .....
            autoRotate={false}
            fullScreenOrientation={Video.Constants.landscape}
          />
```
`fullScreenOrientation` can be one of these values (default is `all`). 
```
    all,
    allButUpsideDown,
    portrait,
    portraitUpsideDown,
    landscape,
    landscapeLeft,
    landscapeRight
```
fullScreenOrientation affects even when device's `rotation lock` is enabled