### PR TITLE
Take out auto-resume behavior on Android

### DIFF
--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -553,10 +553,9 @@ public class ReactVideoView extends ScalableVideoView implements MediaPlayer.OnP
     @Override
     public void onHostPause() {
         if (mMediaPlayer != null && !mPlayInBackground) {
-            mActiveStatePauseStatus = mPaused;
-
             // Pause the video in background
             setPausedModifier(true);
+            mActiveStatePauseStatus = mPaused;
         }
     }
 


### PR DESCRIPTION
Upon pausing the video by backgrounding the app the video would restart upon bringing it to the foreground.  This was due to using mActiveStatePauseStatus which is false after pausing via onHostPause().  This behavior is undesirable for our media playing app and also not the behavior on iOS.  An alternative to this would have been to use mPaused as the boolean in onHostResume().