### PR TITLE
View.propTypes -> ViewPropTypes

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {StyleSheet, requireNativeComponent, NativeModules, View, Image} from 'react-native';
+import {StyleSheet, requireNativeComponent, NativeModules, View, ViewPropTypes, Image} from 'react-native';
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 import VideoResizeMode from './VideoResizeMode.js';
 
@@ -308,7 +308,7 @@ Video.propTypes = {
   translateX: PropTypes.number,
   translateY: PropTypes.number,
   rotation: PropTypes.number,
-  ...View.propTypes,
+  ...ViewPropTypes,
 };
 
 const RCTVideo = requireNativeComponent('RCTVideo', Video, {

--- a/ViewPropTypes
+++ b/ViewPropTypes
@@ -1,0 +1,1 @@
+M	Video.js


### PR DESCRIPTION
View.propTypes has been removed in the latest versions of RN, and replaced with ViewPropTypes. This is currently not breaking anything, I think because of the way it's used here, with ``` { ...View.propTypes } ``` translating to ```{ ...undefined } ```, which doesn't break anything. But with the latest versions of RN, the propTypes from View are not getting properly applied. This PR addresses that issue.