### PR TITLE
Preventing multiple observers for the same notification

### DIFF
--- a/ios/RCTVideo.m
+++ b/ios/RCTVideo.m
@@ -454,10 +454,17 @@ static NSString *const timedMetadata = @"timedMetadata";
 - (void)attachListeners
 {
   // listen for end of file
+  [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                  name:AVPlayerItemDidPlayToEndTimeNotification
+                                                object:[_player currentItem]];
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(playerItemDidReachEnd:)
                                                name:AVPlayerItemDidPlayToEndTimeNotification
                                              object:[_player currentItem]];
+
+  [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                  name:AVPlayerItemPlaybackStalledNotification
+                                                object:nil];
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(playbackStalled:)
                                                name:AVPlayerItemPlaybackStalledNotification


### PR DESCRIPTION
When a video is set to repeat the attachListeners method gets called on every cycle thus adding the same observer over and over again, which all get called at the end of a cycle which is kinda pointless. This can be mitigated by first removing the observer before adding it.
I encountered this behaviour while debugging to find out why this 'AVPlayerItemDidPlayToEndTimeNotification'-observer did not get called for the second time for repeat m3u8 videos on iOS 11. The bug report can be found [here](https://github.com/react-native-community/react-native-video/issues/831).