### PR TITLE
If uriString starts with "file://" scheme handle it as a Uri

### DIFF
--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -241,7 +241,7 @@ public class ReactVideoView extends ScalableVideoView implements MediaPlayer.OnP
 
                 setDataSource(uriString);
             } else if (isAsset) {
-                if (uriString.startsWith("content://")) {
+                if (uriString.startsWith("content://") || uriString.startsWith("file://")) {
                     Uri parsedUrl = Uri.parse(uriString);
                     setDataSource(mThemedReactContext, parsedUrl);
                 } else {


### PR DESCRIPTION
Use setDataSource(Context, Uri) instead of setDataSource(String path) when uriString starts with "file://" scheme. Strictly speaking, in such case uriString represents an Uri object and to convert it to the path the scheme should be removed.