### PR TITLE
Add track selection (iOS, Android) and useTextureView prop for ExoPlayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,10 @@ Seeks the video to the specified time (in seconds). Access using a ref to the co
 
 Toggles a fullscreen player. Access using a ref to the component.
 
+`overrideTrack({ rendererIndex: number,  groupIndex: number trackIndex: number })`
+
+Overrides currently playing track (video, audio, text, etc.)  
+
 ## Examples
 
 - See an [Example integration][1] in `react-native-login` *note that this example uses an older version of this library, before we used `export default` -- if you use `require` you will need to do `require('react-native-video').default` as per instructions above.*

--- a/Video.js
+++ b/Video.js
@@ -253,6 +253,7 @@ Video.propTypes = {
   src: PropTypes.object,
   seek: PropTypes.number,
   trackOverride: PropTypes.object,
+  useTextureView: PropTypes.bool,
   fullscreen: PropTypes.bool,
   onVideoLoadStart: PropTypes.func,
   onVideoLoad: PropTypes.func,

--- a/Video.js
+++ b/Video.js
@@ -36,6 +36,10 @@ export default class Video extends Component {
     this.setNativeProps({ fullscreen: false });
   };
 
+  overrideTrack = (overrideOptions) => {
+    this.setNativeProps({ trackOverride: overrideOptions });
+  };
+
   _assignRoot = (component) => {
     this._root = component;
   };
@@ -248,6 +252,7 @@ Video.propTypes = {
   /* Native only */
   src: PropTypes.object,
   seek: PropTypes.number,
+  trackOverride: PropTypes.object,
   fullscreen: PropTypes.bool,
   onVideoLoadStart: PropTypes.func,
   onVideoLoad: PropTypes.func,
@@ -316,5 +321,6 @@ const RCTVideo = requireNativeComponent('RCTVideo', Video, {
     src: true,
     seek: true,
     fullscreen: true,
+    trackOverride: true,
   },
 });

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -31,12 +31,16 @@ import java.util.List;
 @TargetApi(16)
 public final class ExoPlayerView extends FrameLayout {
 
-    private final View surfaceView;
+    private View surfaceView;
     private final View shutterView;
     private final SubtitleView subtitleLayout;
     private final AspectRatioFrameLayout layout;
     private final ComponentListener componentListener;
     private SimpleExoPlayer player;
+    private Context context;
+    private ViewGroup.LayoutParams layoutParams;
+
+    private boolean useTextureView = false;
 
     public ExoPlayerView(Context context) {
         this(context, null);
@@ -49,9 +53,9 @@ public final class ExoPlayerView extends FrameLayout {
     public ExoPlayerView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
 
-        boolean useTextureView = true;
+        this.context = context;
 
-        ViewGroup.LayoutParams params = new ViewGroup.LayoutParams(
+        layoutParams = new ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT);
 
@@ -65,23 +69,43 @@ public final class ExoPlayerView extends FrameLayout {
         layout.setLayoutParams(aspectRatioParams);
 
         shutterView = new View(getContext());
-        shutterView.setLayoutParams(params);
+        shutterView.setLayoutParams(layoutParams);
         shutterView.setBackgroundColor(ContextCompat.getColor(context, android.R.color.black));
 
         subtitleLayout = new SubtitleView(context);
-        subtitleLayout.setLayoutParams(params);
+        subtitleLayout.setLayoutParams(layoutParams);
         subtitleLayout.setUserDefaultStyle();
         subtitleLayout.setUserDefaultTextSize();
 
-        View view = useTextureView ? new TextureView(context) : new SurfaceView(context);
-        view.setLayoutParams(params);
-        surfaceView = view;
+        updateSurfaceView();
 
-        layout.addView(surfaceView, 0, params);
-        layout.addView(shutterView, 1, params);
-        layout.addView(subtitleLayout, 2, params);
+        layout.addView(shutterView, 1, layoutParams);
+        layout.addView(subtitleLayout, 2, layoutParams);
 
         addViewInLayout(layout, 0, aspectRatioParams);
+    }
+
+    private void setVideoView() {
+        if (surfaceView instanceof TextureView) {
+            player.setVideoTextureView((TextureView) surfaceView);
+        } else if (surfaceView instanceof SurfaceView) {
+            player.setVideoSurfaceView((SurfaceView) surfaceView);
+        }
+    }
+
+    private void updateSurfaceView() {
+        View view = useTextureView ? new TextureView(context) : new SurfaceView(context);
+        view.setLayoutParams(layoutParams);
+
+        surfaceView = view;
+        if (layout.getChildAt(0) != null) {
+            layout.removeViewAt(0);
+        }
+        layout.addView(surfaceView, 0, layoutParams);
+
+        if (this.player != null) {
+            setVideoView();
+        }
     }
 
     /**
@@ -105,11 +129,7 @@ public final class ExoPlayerView extends FrameLayout {
         this.player = player;
         shutterView.setVisibility(VISIBLE);
         if (player != null) {
-            if (surfaceView instanceof TextureView) {
-                player.setVideoTextureView((TextureView) surfaceView);
-            } else if (surfaceView instanceof SurfaceView) {
-                player.setVideoSurfaceView((SurfaceView) surfaceView);
-            }
+            setVideoView();
             player.setVideoListener(componentListener);
             player.addListener(componentListener);
             player.setTextOutput(componentListener);
@@ -138,6 +158,11 @@ public final class ExoPlayerView extends FrameLayout {
      */
     public View getVideoSurfaceView() {
         return surfaceView;
+    }
+
+    public void setUseTextureView(boolean useTextureView) {
+        this.useTextureView = useTextureView;
+        updateSurfaceView();
     }
 
     private final Runnable measureAndLayout = new Runnable() {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -49,7 +49,7 @@ public final class ExoPlayerView extends FrameLayout {
     public ExoPlayerView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
 
-        boolean useTextureView = false;
+        boolean useTextureView = true;
 
         ViewGroup.LayoutParams params = new ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -595,6 +595,10 @@ class ReactExoplayerView extends FrameLayout implements
         trackSelector.setSelectionOverride(rendererIndex, trackGroups, override);
     }
 
+    public void setUseTextureView(boolean useTectureView) {
+        exoPlayerView.setUseTextureView(useTectureView);
+    }
+
     public void setResizeModeModifier(@ResizeMode.Mode int resizeMode) {
         exoPlayerView.setResizeMode(resizeMode);
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -32,6 +32,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_RATE = "rate";
     private static final String PROP_PLAY_IN_BACKGROUND = "playInBackground";
     private static final String PROP_DISABLE_FOCUS = "disableFocus";
+    private static final String PROP_TRACK_OVERRIDE = "trackOverride";
 
     @Override
     public String getName() {
@@ -153,6 +154,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_DISABLE_FOCUS, defaultBoolean = false)
     public void setDisableFocus(final ReactExoplayerView videoView, final boolean disableFocus) {
         videoView.setDisableFocus(disableFocus);
+    }
+
+   @ReactProp(name = PROP_TRACK_OVERRIDE)
+    public void setTrackOverride(final ReactExoplayerView videoView, final ReadableMap options) {
+        videoView.setTrackOverride(options);
     }
 
     private boolean startsWithValidScheme(String uriString) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -33,6 +33,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_PLAY_IN_BACKGROUND = "playInBackground";
     private static final String PROP_DISABLE_FOCUS = "disableFocus";
     private static final String PROP_TRACK_OVERRIDE = "trackOverride";
+    private static final String PROP_USE_TEXTURE_VIEW = "useTextureView";
 
     @Override
     public String getName() {
@@ -159,6 +160,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
    @ReactProp(name = PROP_TRACK_OVERRIDE)
     public void setTrackOverride(final ReactExoplayerView videoView, final ReadableMap options) {
         videoView.setTrackOverride(options);
+    }
+
+    @ReactProp(name = PROP_USE_TEXTURE_VIEW, defaultBoolean = false)
+    public void setUseTextureView(final ReactExoplayerView videoView, final boolean useTextureView) {
+        videoView.setUseTextureView(useTextureView);
     }
 
     private boolean startsWithValidScheme(String uriString) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/TrackHelper.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/TrackHelper.java
@@ -1,0 +1,57 @@
+package com.brentvatne.exoplayer;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.source.TrackGroup;
+import com.google.android.exoplayer2.source.TrackGroupArray;
+import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
+
+public class TrackHelper {
+
+    private static final String TAG = TrackHelper.class.getSimpleName();
+
+    private MappingTrackSelector trackSelector;
+
+    public TrackHelper(MappingTrackSelector trackSelector) {
+        this.trackSelector = trackSelector;
+    }
+
+    public WritableArray parseTracks() {
+        WritableArray trackData = Arguments.createArray();
+        MappingTrackSelector.MappedTrackInfo trackInfo = trackSelector.getCurrentMappedTrackInfo();
+
+        for (int rendererIndex = 0; rendererIndex < trackInfo.length; rendererIndex++) {
+            WritableArray rendererArray = Arguments.createArray();
+            TrackGroupArray trackGroupArray = trackInfo.getTrackGroups(rendererIndex);
+
+            for (int trackGroupIndex = 0; trackGroupIndex < trackGroupArray.length; trackGroupIndex++) {
+                WritableArray formats = Arguments.createArray();
+                TrackGroup trackGroup = trackGroupArray.get(trackGroupIndex);
+
+                for (int formatIndex = 0; formatIndex < trackGroup.length; formatIndex++) {
+                    Format format = trackGroup.getFormat(formatIndex);
+                    WritableMap formatMap = mapFormatData(format);
+
+                    formats.pushMap(formatMap);
+                }
+
+                rendererArray.pushArray(formats);
+            }
+
+            trackData.pushArray(rendererArray);
+        }
+
+        return trackData;
+    }
+
+    private WritableMap mapFormatData(Format format) {
+        WritableMap formatMap = Arguments.createMap();
+        formatMap.putString("id", format.id);
+        formatMap.putString("sampleMimeType", format.sampleMimeType);
+        formatMap.putString("language", format.language);
+        return formatMap;
+    }
+
+}

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -105,6 +105,7 @@ class VideoEventEmitter {
 
     private static final String EVENT_PROP_TIMED_METADATA = "metadata";
 
+    private static final String EVENT_PROP_TRACKS = "tracks";
 
     void setViewId(int viewId) {
         this.viewId = viewId;
@@ -114,7 +115,7 @@ class VideoEventEmitter {
         receiveEvent(EVENT_LOAD_START, null);
     }
 
-    void load(double duration, double currentPosition, int videoWidth, int videoHeight) {
+    void load(double duration, double currentPosition, int videoWidth, int videoHeight, WritableArray tracks) {
         WritableMap event = Arguments.createMap();
         event.putDouble(EVENT_PROP_DURATION, duration / 1000D);
         event.putDouble(EVENT_PROP_CURRENT_TIME, currentPosition / 1000D);
@@ -128,6 +129,7 @@ class VideoEventEmitter {
             naturalSize.putString(EVENT_PROP_ORIENTATION, "portrait");
         }
         event.putMap(EVENT_PROP_NATURAL_SIZE, naturalSize);
+        event.putArray(EVENT_PROP_TRACKS, tracks);
 
         // TODO: Actually check if you can.
         event.putBoolean(EVENT_PROP_FAST_FORWARD, true);

--- a/android/src/main/java/com/brentvatne/react/ReactVideoViewManager.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoViewManager.java
@@ -35,6 +35,7 @@ public class ReactVideoViewManager extends SimpleViewManager<ReactVideoView> {
     public static final String PROP_RATE = "rate";
     public static final String PROP_PLAY_IN_BACKGROUND = "playInBackground";
     public static final String PROP_CONTROLS = "controls";
+    private static final String PROP_TRACK_OVERRIDE = "trackOverride";
 
     @Override
     public String getName() {
@@ -147,5 +148,10 @@ public class ReactVideoViewManager extends SimpleViewManager<ReactVideoView> {
     @ReactProp(name = PROP_CONTROLS, defaultBoolean = false)
     public void setControls(final ReactVideoView videoView, final boolean controls) {
         videoView.setControls(controls);
+    }
+
+    @ReactProp(name = PROP_TRACK_OVERRIDE)
+    public void setTrackOverride(final ReactVideoView videoView, final ReadableMap options) {
+
     }
 }

--- a/android/src/main/java/com/brentvatne/react/ReactVideoViewManager.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoViewManager.java
@@ -35,7 +35,7 @@ public class ReactVideoViewManager extends SimpleViewManager<ReactVideoView> {
     public static final String PROP_RATE = "rate";
     public static final String PROP_PLAY_IN_BACKGROUND = "playInBackground";
     public static final String PROP_CONTROLS = "controls";
-    private static final String PROP_TRACK_OVERRIDE = "trackOverride";
+    public static final String PROP_TRACK_OVERRIDE = "trackOverride";
 
     @Override
     public String getName() {

--- a/android/src/main/java/com/brentvatne/react/ReactVideoViewManager.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoViewManager.java
@@ -36,6 +36,7 @@ public class ReactVideoViewManager extends SimpleViewManager<ReactVideoView> {
     public static final String PROP_PLAY_IN_BACKGROUND = "playInBackground";
     public static final String PROP_CONTROLS = "controls";
     public static final String PROP_TRACK_OVERRIDE = "trackOverride";
+    public static final String PROP_USE_TEXTURE_VIEW = "useTextureView";
 
     @Override
     public String getName() {
@@ -152,6 +153,12 @@ public class ReactVideoViewManager extends SimpleViewManager<ReactVideoView> {
 
     @ReactProp(name = PROP_TRACK_OVERRIDE)
     public void setTrackOverride(final ReactVideoView videoView, final ReadableMap options) {
-
+        // Only implemented for ExoPlayer
     }
+
+    @ReactProp(name = PROP_USE_TEXTURE_VIEW, defaultBoolean = false)
+    public void setUseTextureView(final ReactVideoView videoView, final boolean useTextureView) {
+        // Only needed for ExoPlayer
+    }
+
 }

--- a/ios/RCTVideoManager.m
+++ b/ios/RCTVideoManager.m
@@ -34,6 +34,7 @@ RCT_EXPORT_VIEW_PROPERTY(seek, float);
 RCT_EXPORT_VIEW_PROPERTY(currentTime, float);
 RCT_EXPORT_VIEW_PROPERTY(fullscreen, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(progressUpdateInterval, float);
+RCT_EXPORT_VIEW_PROPERTY(trackOverride, NSDictionary);
 /* Should support: onLoadStart, onLoad, and onError to stay consistent with Image */
 RCT_EXPORT_VIEW_PROPERTY(onVideoLoadStart, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoLoad, RCTBubblingEventBlock);


### PR DESCRIPTION
This adds the ability to select media tracks during video playback. It is achieved by adding a new `overrideTrack` static method. It works for both iOS and Android (ExoPlayer).
A `useTextureView` prop has also been added to enable smooth transforming of the <Video/> view when using ExoPlayer on Android.