### PR TITLE
Add requiresMainQueueSetup method

### DIFF
--- a/ios/RCTVideoManager.m
+++ b/ios/RCTVideoManager.m
@@ -62,4 +62,9 @@ RCT_EXPORT_VIEW_PROPERTY(onPlaybackRateChange, RCTBubblingEventBlock);
   };
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 @end


### PR DESCRIPTION
Since RN 0.49, `requiresMainQueueSetup` needs to be defined if the module overrides `constantsToExport`.

Closes #820 