### PR TITLE
Add ability to save streamed video

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ using System.Collections.Generic;
        onLoad={this.setDuration}               // Callback when video loads
        onProgress={this.setTime}               // Callback every ~250ms with currentTime
        onEnd={this.onEnd}                      // Callback when playback finishes
+       onSaved={this.onSaved}                  // Callback when video gets saved
        onError={this.videoError}               // Callback when video cannot be loaded
        onBuffer={this.onBuffer}                // Callback when remote video is buffering
        onTimedMetadata={this.onTimedMetadata}  // Callback when the stream receive some metadata
@@ -210,6 +211,7 @@ var styles = StyleSheet.create({
        onLoad={this.setDuration}    // Callback when video loads
        onProgress={this.setTime}    // Callback every ~250ms with currentTime
        onEnd={this.onEnd}           // Callback when playback finishes
+       onSaved={this.onSaved}       // Callback when video gets saved
        onError={this.videoError}    // Callback when video cannot be loaded
        style={styles.backgroundVideo} />
 

--- a/Video.js
+++ b/Video.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {StyleSheet, requireNativeComponent, NativeModules, View, ViewPropTypes, Image} from 'react-native';
+import {StyleSheet, requireNativeComponent, NativeModules, View, Image} from 'react-native';
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 import VideoResizeMode from './VideoResizeMode.js';
 
@@ -77,6 +77,12 @@ export default class Video extends Component {
   _onEnd = (event) => {
     if (this.props.onEnd) {
       this.props.onEnd(event.nativeEvent);
+    }
+  };
+
+  _onSaved = (event) => {
+    if (this.props.onSaved) {
+      this.props.onSaved(event.nativeEvent);
     }
   };
 
@@ -197,6 +203,7 @@ export default class Video extends Component {
       onVideoProgress: this._onProgress,
       onVideoSeek: this._onSeek,
       onVideoEnd: this._onEnd,
+      onVideoSaved: this._onSaved,
       onVideoBuffer: this._onBuffer,
       onTimedMetadata: this._onTimedMetadata,
       onVideoFullscreenPlayerWillPresent: this._onFullscreenPlayerWillPresent,
@@ -256,6 +263,7 @@ Video.propTypes = {
   onVideoProgress: PropTypes.func,
   onVideoSeek: PropTypes.func,
   onVideoEnd: PropTypes.func,
+  onVideoSaved: PropTypes.func,
   onTimedMetadata: PropTypes.func,
   onVideoFullscreenPlayerWillPresent: PropTypes.func,
   onVideoFullscreenPlayerDidPresent: PropTypes.func,
@@ -291,6 +299,7 @@ Video.propTypes = {
   onProgress: PropTypes.func,
   onSeek: PropTypes.func,
   onEnd: PropTypes.func,
+  onSaved: PropTypes.func,
   onFullscreenPlayerWillPresent: PropTypes.func,
   onFullscreenPlayerDidPresent: PropTypes.func,
   onFullscreenPlayerWillDismiss: PropTypes.func,
@@ -308,7 +317,7 @@ Video.propTypes = {
   translateX: PropTypes.number,
   translateY: PropTypes.number,
   rotation: PropTypes.number,
-  ...ViewPropTypes,
+  ...View.propTypes,
 };
 
 const RCTVideo = requireNativeComponent('RCTVideo', Video, {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -31,6 +31,7 @@ class VideoEventEmitter {
     private static final String EVENT_PROGRESS = "onVideoProgress";
     private static final String EVENT_SEEK = "onVideoSeek";
     private static final String EVENT_END = "onVideoEnd";
+    private static final String EVENT_SAVED = "onVideoSaved";
     private static final String EVENT_STALLED = "onPlaybackStalled";
     private static final String EVENT_RESUME = "onPlaybackResume";
     private static final String EVENT_READY = "onReadyForDisplay";

--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -39,6 +39,7 @@ public class ReactVideoView extends ScalableVideoView implements MediaPlayer.OnP
         EVENT_PROGRESS("onVideoProgress"),
         EVENT_SEEK("onVideoSeek"),
         EVENT_END("onVideoEnd"),
+        EVENT_SAVED("onVideoSaved"),
         EVENT_STALLED("onPlaybackStalled"),
         EVENT_RESUME("onPlaybackResume"),
         EVENT_READY_FOR_DISPLAY("onReadyForDisplay");

--- a/ios/RCTVideo.h
+++ b/ios/RCTVideo.h
@@ -7,7 +7,7 @@
 
 @class RCTEventDispatcher;
 
-@interface RCTVideo : UIView <RCTVideoPlayerViewControllerDelegate>
+@interface RCTVideo : UIView <RCTVideoPlayerViewControllerDelegate, AVAssetResourceLoaderDelegate>
 
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoLoadStart;
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoLoad;
@@ -16,6 +16,7 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoProgress;
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoSeek;
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoEnd;
+@property (nonatomic, copy) RCTBubblingEventBlock onVideoSaved;
 @property (nonatomic, copy) RCTBubblingEventBlock onTimedMetadata;
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoFullscreenPlayerWillPresent;
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoFullscreenPlayerDidPresent;

--- a/ios/RCTVideoManager.m
+++ b/ios/RCTVideoManager.m
@@ -42,6 +42,7 @@ RCT_EXPORT_VIEW_PROPERTY(onVideoError, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoProgress, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoSeek, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoEnd, RCTBubblingEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onVideoSaved, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onTimedMetadata, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoFullscreenPlayerWillPresent, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoFullscreenPlayerDidPresent, RCTBubblingEventBlock);

--- a/windows/ReactNativeVideo.Net46/ReactVideoEventTypeExtensions.cs
+++ b/windows/ReactNativeVideo.Net46/ReactVideoEventTypeExtensions.cs
@@ -21,6 +21,8 @@ namespace ReactNativeVideo
                     return "onVideoSeek";
                 case ReactVideoEventType.End:
                     return "onVideoEnd";
+                case ReactVideoEventType.Saved:
+                    return "onVideoSaved";
                 case ReactVideoEventType.Stalled:
                     return "onPlaybackStalled";
                 case ReactVideoEventType.Resume:

--- a/windows/ReactNativeVideo/ReactVideoEventTypeExtensions.cs
+++ b/windows/ReactNativeVideo/ReactVideoEventTypeExtensions.cs
@@ -21,6 +21,8 @@ namespace ReactNativeVideo
                     return "onVideoSeek";
                 case ReactVideoEventType.End:
                     return "onVideoEnd";
+                case ReactVideoEventType.Saved:
+                    return "onVideoSaved";
                 case ReactVideoEventType.Stalled:
                     return "onPlaybackStalled";
                 case ReactVideoEventType.Resume:


### PR DESCRIPTION
I have only implemented iOS part since I am no good with Java for such a task. If onVideoSaved is set in props video is exported to documents directory and the path is returned as a string. If the callback prop is not set the video is not exported. This helps developers prevent downloading the same data multiple times.

Possibly and partially addresses follwing issues: #869 #516