### PR TITLE
Update RCTVideoManager.m

### DIFF
--- a/ios/RCTVideoManager.m
+++ b/ios/RCTVideoManager.m
@@ -62,4 +62,8 @@ RCT_EXPORT_VIEW_PROPERTY(onPlaybackRateChange, RCTBubblingEventBlock);
   };
 }
 
++(BOOL) requiresMainQueueSetup {
+  return YES;
+}
+
 @end


### PR DESCRIPTION
Using this module with React Native .50.4 results in warning messages: "Module RCTVideoManager requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of." To alleviate this issue, I'm proposing adding the needed method. My change returns YES, assuming that is the safest path to use.