### PR TITLE
Fix playableDuration attribute of onProgress event

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -113,7 +113,7 @@ class ReactExoplayerView extends FrameLayout implements
                             && player.getPlayWhenReady()
                             ) {
                         long pos = player.getCurrentPosition();
-                        eventEmitter.progressChanged(pos, player.getBufferedPercentage());
+                        eventEmitter.progressChanged(pos, player.getBufferedPosition());
                         msg = obtainMessage(SHOW_PROGRESS);
                         sendMessageDelayed(msg, Math.round(mProgressUpdateInterval));
                     }


### PR DESCRIPTION
Currently we emit `currentTime` and `playableDuration` values on `onProgress` event of the player, but we are incorrectly sending `getBufferedPercentage` when we should be sending `getBufferedPosition` as reflected in the`playableDuration` name.


Reference: https://google.github.io/ExoPlayer/doc/reference/com/google/android/exoplayer2/SimpleExoPlayer.html