### PR TITLE
Use setSeek instead of unreliable seek on reference

### DIFF
--- a/ios/RCTVideo.m
+++ b/ios/RCTVideo.m
@@ -485,8 +485,8 @@ static NSString *const timedMetadata = @"timedMetadata";
   }
 
   if (_repeat) {
-    AVPlayerItem *item = [notification object];
-    [item seekToTime:kCMTimeZero];
+    [self setSeek:0.0];
+    // Not sure this is needed:
     [self applyModifiers];
   }
 }


### PR DESCRIPTION
I was expecting repeat to be endless. However the AVPlayerItemDidPlayToEndTimeNotification wasnt fired after the second run. So all this does is to use the class method setSeek instead of the seek on the notification object reference.