### PR TITLE
Allow other audio recorders in the same app to run nicely while the video player is playing.

### DIFF
--- a/ios/RCTVideo.m
+++ b/ios/RCTVideo.m
@@ -529,9 +529,9 @@ static NSString *const timedMetadata = @"timedMetadata";
     [_player setRate:0.0];
   } else {
     if([_ignoreSilentSwitch isEqualToString:@"ignore"]) {
-      [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
+      [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback withOptions:AVAudioSessionCategoryOptionMixWithOthers error:nil];
     } else if([_ignoreSilentSwitch isEqualToString:@"obey"]) {
-      [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:nil];
+      [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient withOptions:AVAudioSessionCategoryOptionMixWithOthers error:nil];
     }
     [_player play];
     [_player setRate:_rate];

--- a/ios/RCTVideo.m
+++ b/ios/RCTVideo.m
@@ -732,7 +732,9 @@ static NSString *const timedMetadata = @"timedMetadata";
 - (void)removePlayerLayer
 {
     [_playerLayer removeFromSuperlayer];
-    [_playerLayer removeObserver:self forKeyPath:readyForDisplayKeyPath];
+    @try {
+      [_playerLayer removeObserver:self forKeyPath:readyForDisplayKeyPath];
+    } @catch (NSException *e) { }
     _playerLayer = nil;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "react-native-video",
+    "name": "in1t-react-native-video",
     "version": "2.0.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "in1t-react-native-video",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "A <Video /> element for react-native",
     "main": "Video.js",
     "license": "MIT",


### PR DESCRIPTION
Allow other audio recorders in the same app to run nicely while the video player is playing.

The problem is without the option `AVAudioSessionCategoryOptionMixWithOthers` to allow mixing with others, the video player will automatically interrupt any other audio session (recording activity for example).

This PR will let the player play, and if the app need to record something, it will be able to do without interruption.