### PR TITLE
Fixes #963

### DIFF
--- a/ios/RCTVideo.m
+++ b/ios/RCTVideo.m
@@ -140,8 +140,8 @@ static NSString *const timedMetadata = @"timedMetadata";
 - (void)dealloc
 {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
-  [self removePlayerItemObservers];
   [self removePlayerLayer];
+  [self removePlayerItemObservers];
   [_player removeObserver:self forKeyPath:playbackRate context:nil];
 }
 
@@ -252,9 +252,6 @@ static NSString *const timedMetadata = @"timedMetadata";
  * observer set */
 - (void)removePlayerItemObservers
 {
-  if (_playerLayer) {
-    [_playerLayer removeObserver:self forKeyPath:readyForDisplayKeyPath];
-  }
   if (_playerItemObserversSet) {
     [_playerItem removeObserver:self forKeyPath:statusKeyPath];
     [_playerItem removeObserver:self forKeyPath:playbackBufferEmptyKeyPath];
@@ -268,13 +265,13 @@ static NSString *const timedMetadata = @"timedMetadata";
 
 - (void)setSrc:(NSDictionary *)source
 {
+  [self removePlayerLayer];
   [self removePlayerTimeObserver];
   [self removePlayerItemObservers];
   _playerItem = [self playerItemForSource:source];
   [self addPlayerItemObservers];
 
   [_player pause];
-  [self removePlayerLayer];
   [_playerViewController.view removeFromSuperview];
   _playerViewController = nil;
 


### PR DESCRIPTION
Fixes #963 
Bug happens when uri is changed for a video that is already rendered. This is because `[_playerLayer removeObserver:self forKeyPath:readyForDisplayKeyPath]` is called twice because the `_playerItemObserversSet` variable isn't properly set in sequence.

## The fix:
Remove player layer before addPlayerItemObservers so `_playerItemObserversSet` is still set to `NO` if observers have already been removed.