### PR TITLE
Enable fullscreen UI mode for ExoPlayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ using System.Collections.Generic;
 
 // Later to trigger fullscreen
 this.player.presentFullscreenPlayer()
+// Disable fullscreen
+this.player.dismissFullscreenPlayer()
 
 // To set video position in seconds (seek)
 this.player.seek(0)
@@ -217,6 +219,10 @@ To see full list of available props, you can check [the propTypes](https://githu
        onError={this.videoError}    // Callback when video cannot be loaded
        style={styles.backgroundVideo} />
 
+// Later to enable fullscreen UI mode (ExoPlayer only). Combine with setting the style to be height & width from Dimensions.get('screen')
+this.player.presentFullscreenPlayer()
+// Disable fullscreen UI mode
+
 // Later on in your styles..
 var styles = Stylesheet.create({
   backgroundVideo: {
@@ -254,7 +260,11 @@ Seeks the video to the specified time (in seconds). Access using a ref to the co
 
 `presentFullscreenPlayer()`
 
-Toggles a fullscreen player. Access using a ref to the component.
+Enable the fullscreen player. Access using a ref to the component.
+
+`dimissFullscreenPlayer()`
+
+Disable the fullscreen player. Access using a ref to the component.
 
 ## Examples
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1,6 +1,7 @@
 package com.brentvatne.exoplayer;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.content.Context;
 import android.media.AudioManager;
 import android.net.Uri;
@@ -8,6 +9,8 @@ import android.os.Handler;
 import android.os.Message;
 import android.text.TextUtils;
 import android.util.Log;
+import android.view.View;
+import android.view.Window;
 import android.widget.FrameLayout;
 
 import com.brentvatne.react.R;
@@ -85,6 +88,7 @@ class ReactExoplayerView extends FrameLayout implements
     private int resumeWindow;
     private long resumePosition;
     private boolean loadVideoStarted;
+    private boolean isFullscreen;
     private boolean isPaused = true;
     private boolean isBuffering;
     private float rate = 1f;
@@ -331,6 +335,9 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private void onStopPlayback() {
+        if (isFullscreen) {
+            setFullscreen(false);
+        }
         setKeepScreenOn(false);
         audioManager.abandonAudioFocus(this);
     }
@@ -637,5 +644,38 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setDisableFocus(boolean disableFocus) {
         this.disableFocus = disableFocus;
+    }
+
+    public void setFullscreen(boolean fullscreen) {
+        if (fullscreen == isFullscreen) {
+            return; // Avoid generating events when nothing is changing
+        }
+        isFullscreen = fullscreen;
+
+        Activity activity = themedReactContext.getCurrentActivity();
+        if (activity == null) {
+            return;
+        }
+        Window window = activity.getWindow();
+        View decorView = window.getDecorView();
+        int uiOptions;
+        if (isFullscreen) {
+            if (Util.SDK_INT >= 19) { // 4.4+
+                uiOptions = SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                        | SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                        | SYSTEM_UI_FLAG_FULLSCREEN;
+            } else {
+                uiOptions = SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                        | SYSTEM_UI_FLAG_FULLSCREEN;
+            }
+            eventEmitter.fullscreenWillPresent();
+            decorView.setSystemUiVisibility(uiOptions);
+            eventEmitter.fullscreenDidPresent();
+        } else {
+            uiOptions = View.SYSTEM_UI_FLAG_VISIBLE;
+            eventEmitter.fullscreenWillDismiss();
+            decorView.setSystemUiVisibility(uiOptions);
+            eventEmitter.fullscreenDidDismiss();
+        }
     }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -31,6 +31,11 @@ class VideoEventEmitter {
     private static final String EVENT_PROGRESS = "onVideoProgress";
     private static final String EVENT_SEEK = "onVideoSeek";
     private static final String EVENT_END = "onVideoEnd";
+    private static final String EVENT_FULLSCREEN_WILL_PRESENT = "onVideoFullscreenPlayerWillPresent";
+    private static final String EVENT_FULLSCREEN_DID_PRESENT = "onVideoFullscreenPlayerDidPresent";
+    private static final String EVENT_FULLSCREEN_WILL_DISMISS = "onVideoFullscreenPlayerWillDismiss";
+    private static final String EVENT_FULLSCREEN_DID_DISMISS = "onVideoFullscreenPlayerDidDismiss";
+
     private static final String EVENT_STALLED = "onPlaybackStalled";
     private static final String EVENT_RESUME = "onPlaybackResume";
     private static final String EVENT_READY = "onReadyForDisplay";
@@ -48,6 +53,10 @@ class VideoEventEmitter {
             EVENT_PROGRESS,
             EVENT_SEEK,
             EVENT_END,
+            EVENT_FULLSCREEN_WILL_PRESENT,
+            EVENT_FULLSCREEN_DID_PRESENT,
+            EVENT_FULLSCREEN_WILL_DISMISS,
+            EVENT_FULLSCREEN_DID_DISMISS,
             EVENT_STALLED,
             EVENT_RESUME,
             EVENT_READY,
@@ -67,6 +76,10 @@ class VideoEventEmitter {
             EVENT_PROGRESS,
             EVENT_SEEK,
             EVENT_END,
+            EVENT_FULLSCREEN_WILL_PRESENT,
+            EVENT_FULLSCREEN_DID_PRESENT,
+            EVENT_FULLSCREEN_WILL_DISMISS,
+            EVENT_FULLSCREEN_DID_DISMISS,
             EVENT_STALLED,
             EVENT_RESUME,
             EVENT_READY,
@@ -173,6 +186,22 @@ class VideoEventEmitter {
 
     void end() {
         receiveEvent(EVENT_END, null);
+    }
+
+    void fullscreenWillPresent() {
+        receiveEvent(EVENT_FULLSCREEN_WILL_PRESENT, null);
+    }
+
+    void fullscreenDidPresent() {
+        receiveEvent(EVENT_FULLSCREEN_DID_PRESENT, null);
+    }
+
+    void fullscreenWillDismiss() {
+        receiveEvent(EVENT_FULLSCREEN_WILL_DISMISS, null);
+    }
+
+    void fullscreenDidDismiss() {
+        receiveEvent(EVENT_FULLSCREEN_DID_DISMISS, null);
     }
 
     void error(String errorString, Exception exception) {


### PR DESCRIPTION
Add fullscreen methods to enable and disable fullscreen controls mode for ExoPlayer. This allows you to hide the nav buttons and only show them when you slide in from the side.

At the moment, you still have to style the Video element to use the full screen dimensions because there is no equivalent of a UIViewController that can take over the entire screen like on iOS.