### PR TITLE
Fix swiping on video show black screen

### DIFF
--- a/ios/RCTVideoPlayerViewController.m
+++ b/ios/RCTVideoPlayerViewController.m
@@ -6,6 +6,24 @@
 
 @implementation RCTVideoPlayerViewController
 
+BOOL _viewWillAppearCalled = NO;
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    _viewWillAppearCalled = NO;
+}
+
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+    if (_rctDelegate == nil || _viewWillAppearCalled)
+    {
+        [self dismissViewControllerAnimated:YES completion:nil];
+    }
+    _viewWillAppearCalled = YES;
+}
+
 - (void)viewDidDisappear:(BOOL)animated
 {
     [super viewDidDisappear:animated];


### PR DESCRIPTION
In iOS 11, Apple added a feature to close the Video Player via a swipe gesture. So when swiping, the viewWillAppear function gets called again but black screen shows. This approach fixes the issue by dismissing the video player when viewWillAppear called again.