### PR TITLE
Fix partial swipe on video in fullscreen shows a black screen

### DIFF
--- a/ios/RCTVideoPlayerViewController.m
+++ b/ios/RCTVideoPlayerViewController.m
@@ -8,13 +8,9 @@
 
 - (void)viewDidDisappear:(BOOL)animated
 {
-    [super viewDidDisappear:animated];
-    [_rctDelegate videoPlayerViewControllerDidDismiss:self];
-}
-
-- (void)viewWillDisappear:(BOOL)animated {
-    [_rctDelegate videoPlayerViewControllerWillDismiss:self];
-    [super viewWillDisappear:animated];
+  [super viewDidDisappear:animated];
+  [_rctDelegate videoPlayerViewControllerWillDismiss:self];
+  [_rctDelegate videoPlayerViewControllerDidDismiss:self];
 }
 
 @end


### PR DESCRIPTION
In iOS 11, Apple added a feature to close the Video Player via a swipe gesture. So when partially swiping, the viewWillDisappear function gets called but viewDidDisappear is not called which shows a black screen.