### PR TITLE
Text track cleanups

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -520,9 +520,9 @@ class ReactExoplayerView extends FrameLayout implements
              Format format = groups.get(i).getFormat(0);
              WritableMap textTrack = Arguments.createMap();
              textTrack.putInt("index", i);
-             textTrack.putString("title", format.id);
+             textTrack.putString("title", format.id != null ? format.id : "");
              textTrack.putString("type", format.sampleMimeType);
-             textTrack.putString("language", format.language);
+             textTrack.putString("language", format.language != null ? format.language : "");
              textTracks.pushMap(textTrack);
         }
         return textTracks;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -126,10 +126,14 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_SELECTED_TEXT_TRACK)
     public void setSelectedTextTrack(final ReactExoplayerView videoView,
                                      @Nullable ReadableMap selectedTextTrack) {
-        String typeString = selectedTextTrack.hasKey(PROP_SELECTED_TEXT_TRACK_TYPE)
-                ? selectedTextTrack.getString(PROP_SELECTED_TEXT_TRACK_TYPE) : null;
-        Dynamic value = selectedTextTrack.hasKey(PROP_SELECTED_TEXT_TRACK_VALUE)
-                ? selectedTextTrack.getDynamic(PROP_SELECTED_TEXT_TRACK_VALUE) : null;
+        String typeString = null;
+        Dynamic value = null;
+        if (selectedTextTrack != null) {
+            typeString = selectedTextTrack.hasKey(PROP_SELECTED_TEXT_TRACK_TYPE)
+                    ? selectedTextTrack.getString(PROP_SELECTED_TEXT_TRACK_TYPE) : null;
+            value = selectedTextTrack.hasKey(PROP_SELECTED_TEXT_TRACK_VALUE)
+                    ? selectedTextTrack.getDynamic(PROP_SELECTED_TEXT_TRACK_VALUE) : null;
+        }
         videoView.setSelectedTextTrack(typeString, value);
     }
 

--- a/ios/RCTVideo.m
+++ b/ios/RCTVideo.m
@@ -702,13 +702,16 @@ static NSString *const timedMetadata = @"timedMetadata";
                                   mediaSelectionGroupForMediaCharacteristic:AVMediaCharacteristicLegible];
   for (int i = 0; i < group.options.count; ++i) {
     AVMediaSelectionOption *currentOption = [group.options objectAtIndex:i];
-    NSString *title = [[[currentOption commonMetadata]
-                        valueForKey:@"value"]
-                       objectAtIndex:0];
+    NSString *title = @"";
+    NSArray *values = [[currentOption commonMetadata] valueForKey:@"value"];
+    if (values.count > 0) {
+      title = [values objectAtIndex:0];
+    }
+    NSString *language = [currentOption extendedLanguageTag] ? [currentOption extendedLanguageTag] : @"";
     NSDictionary *textTrack = @{
                                 @"index": [NSNumber numberWithInt:i],
                                 @"title": title,
-                                @"language": [currentOption extendedLanguageTag]
+                                @"language": language
                                 };
     [textTracks addObject:textTrack];
   }


### PR DESCRIPTION
Addresses a number of issues with the new text track support:
- Fix a crash on iOS when the text track title is not present. For example:
http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8
- Set title & language in onLoad to an empty string on ExoPlayer if those fields are not set
- Fix crash when selectedTextTrack is null on ExoPlayer