### PR TITLE
Fix crash when clearing playerLayer observer after already unset

### DIFF
--- a/ios/RCTVideo.m
+++ b/ios/RCTVideo.m
@@ -18,6 +18,7 @@ static NSString *const timedMetadata = @"timedMetadata";
   BOOL _playerItemObserversSet;
   BOOL _playerBufferEmpty;
   AVPlayerLayer *_playerLayer;
+  BOOL _playerLayerObserverSet;
   AVPlayerViewController *_playerViewController;
   NSURL *_videoURL;
 
@@ -794,6 +795,7 @@ static NSString *const timedMetadata = @"timedMetadata";
       // resize mode must be set before layer is added
       [self setResizeMode:_resizeMode];
       [_playerLayer addObserver:self forKeyPath:readyForDisplayKeyPath options:NSKeyValueObservingOptionNew context:nil];
+      _playerLayerObserverSet = YES;
 
       [self.layer addSublayer:_playerLayer];
       self.layer.needsDisplayOnBoundsChange = YES;
@@ -832,7 +834,10 @@ static NSString *const timedMetadata = @"timedMetadata";
 - (void)removePlayerLayer
 {
     [_playerLayer removeFromSuperlayer];
-    [_playerLayer removeObserver:self forKeyPath:readyForDisplayKeyPath];
+    if (_playerLayerObserverSet) {
+      [_playerLayer removeObserver:self forKeyPath:readyForDisplayKeyPath];
+      _playerLayerObserverSet = NO;
+    }
     _playerLayer = nil;
 }
 


### PR DESCRIPTION
Fixes #907 by checking to ensure the playerLayer observer is set. Otherwise we crash. 

During the teardown process, it's possible to call removePlayerLayer multiple times. If this happens, the library will crash due to attempting to remove an observer that doesn't exist.