### PR TITLE
Reapply "Using SDK Version variables from root project""

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,10 +607,10 @@ To enable audio to play in background on iOS the audio session needs to be set t
 ### Version 3.0
 
 #### All platforms now auto-play
-Previously, on Android MediaPlayer & Android ExoPlayer if the paused prop was not set, the media would not automatically start playing. The only way it would work was if you set `paused={false}`. This has been changed to automatically play if paused is not set so that the behavior is consistent across platforms.
+Previously, on Android ExoPlayer if the paused prop was not set, the media would not automatically start playing. The only way it would work was if you set `paused={false}`. This has been changed to automatically play if paused is not set so that the behavior is consistent across platforms.
 
 #### All platforms now pause when returning from the background
-Previously, on Android MediaPlayer & Android ExoPlayer, if the media was playing and you put the app in the background, it would pause. Then if you returned to the app, it would unpause and start playing again. On iOS, returning to the app keeps the media paused. This has been changed so that all platforms stay paused when returning to the app for consistency.
+Previously, on Android MediaPlayer & Android ExoPlayer if the media was playing and you put the app in the background, it would pause. Then if you returned to the app, it would unpause and start playing again. On iOS, returning to the app keeps the media paused. This has been changed so that all platforms stay paused when returning to the app for consistency.
 
 Note, Windows does not have a concept of an app going into the background, so this doesn't apply there.
 

--- a/README.md
+++ b/README.md
@@ -609,15 +609,15 @@ To enable audio to play in background on iOS the audio session needs to be set t
 #### All platforms now auto-play
 Previously, on Android ExoPlayer if the paused prop was not set, the media would not automatically start playing. The only way it would work was if you set `paused={false}`. This has been changed to automatically play if paused is not set so that the behavior is consistent across platforms.
 
-#### All platforms now pause when returning from the background
-Previously, on Android MediaPlayer & Android ExoPlayer if the media was playing and you put the app in the background, it would pause. Then if you returned to the app, it would unpause and start playing again. On iOS, returning to the app keeps the media paused. This has been changed so that all platforms stay paused when returning to the app for consistency.
+#### All platforms now keep their paused state when returning from the background
+Previously, on Android MediaPlayer if you setup an AppState event when the app went into the background and set a paused prop so that when you returned to the app the video would be paused it would be ignored.
 
 Note, Windows does not have a concept of an app going into the background, so this doesn't apply there.
 
 #### Use Android SDK 27 by default
 Version 3.0 updates the Android build tools and SDK to version 27. React Native is in the process of [switchting over](https://github.com/facebook/react-native/issues/18095#issuecomment-395596130) to SDK 27 in preparation for Google's requirement that new Android apps [use SDK 26](https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html) by August 2018.
 
-You will either need to install the version 27 SDK and version 27.0.3 buildtools or modify your build.gradle file to configure react-native-video to use the same build settings as the rest of your app.
+You will either need to install the version 27 SDK and version 27.0.3 buildtools or modify your build.gradle file to configure react-native-video to use the same build settings as the rest of your app as described below.
 
 ##### Using app build settings
 You will need to create a `project.ext` section in the top-level build.gradle file (not app/build.gradle). Fill in the values from the example below using the values found in your app/build.gradle file.
@@ -643,7 +643,6 @@ allprojects {
 
 ## TODOS
 
-- [ ] Add support for captions
 - [ ] Add support for playing multiple videos in a sequence (will interfere with current `repeat` implementation)
 - [x] Callback to get buffering progress for remote videos
 - [ ] Bring API closer to HTML5 `<Video>` [reference](http://devdocs.io/html/element/video)

--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@ A `<Video>` component for react-native, as seen in
 
 Requires react-native >= 0.40.0, for RN support of 0.19.0 - 0.39.0 please use a pre 1.0 version.
 
+### Version 3.0 breaking changes
+Version 3.0 features a number of changes to existing behavior. See [Updating](#updating) for changes.
+
 ## TOC
 
 * [Installation](#installation)
 * [Usage](#usage)
+* [Updating](#updating)
 
 ## Installation
 
@@ -597,6 +601,45 @@ To enable audio to play in background on iOS the audio session needs to be set t
    Then `Cmd+R` to start the React Packager, build and run the project in the simulator.
 
 - [Lumpen Radio](https://github.com/jhabdas/lumpen-radio) contains another example integration using local files and full screen background video.
+
+## Updating
+
+### Version 3.0
+
+#### All platforms now auto-play
+Previously, on Android MediaPlayer & Android ExoPlayer if the paused prop was not set, the media would not automatically start playing. The only way it would work was if you set `paused={false}`. This has been changed to automatically play if paused is not set so that the behavior is consistent across platforms.
+
+#### All platforms now pause when returning from the background
+Previously, on Android MediaPlayer & Android ExoPlayer, if the media was playing and you put the app in the background, it would pause. Then if you returned to the app, it would unpause and start playing again. On iOS, returning to the app keeps the media paused. This has been changed so that all platforms stay paused when returning to the app for consistency.
+
+Note, Windows does not have a concept of an app going into the background, so this doesn't apply there.
+
+#### Use Android SDK 27 by default
+Version 3.0 updates the Android build tools and SDK to version 27. React Native is in the process of [switchting over](https://github.com/facebook/react-native/issues/18095#issuecomment-395596130) to SDK 27 in preparation for Google's requirement that new Android apps [use SDK 26](https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html) by August 2018.
+
+You will either need to install the version 27 SDK and version 27.0.3 buildtools or modify your build.gradle file to configure react-native-video to use the same build settings as the rest of your app.
+
+##### Using app build settings
+You will need to create a `project.ext` section in the top-level build.gradle file (not app/build.gradle). Fill in the values from the example below using the values found in your app/build.gradle file.
+```
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+buildscript {
+    ... // Various other settings go here
+}
+
+allprojects {
+    ... // Various other settings go here
+
+    project.ext {
+        compileSdkVersion = 23
+        buildToolsVersion = "23.0.1"
+
+        minSdkVersion = 16
+        targetSdkVersion = 22
+    }
+}
+```
 
 ## TODOS
 

--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -1,17 +1,28 @@
 apply plugin: 'com.android.library'
 
+def _ext = rootProject.ext
+
+def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+'
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 27
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '27.0.3'
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 27
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "25.0.2"
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion _buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 23
+        minSdkVersion _minSdkVersion
+        targetSdkVersion _targetSdkVersion
+        versionCode 1
+        versionName "1.0"
     }
 }
 
 dependencies {
-    provided 'com.facebook.react:react-native:+'
+    //noinspection GradleDynamicVersion
+    provided "com.facebook.react:react-native:${_reactNativeVersion}"
     compile 'com.google.android.exoplayer:exoplayer:2.7.3'
     compile('com.google.android.exoplayer:extension-okhttp:2.7.3') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,20 @@
 apply plugin: 'com.android.library'
 
+def _ext = rootProject.ext
+
+def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+'
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 27
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '27.0.3'
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 27
+
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion _buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 25
+        minSdkVersion _minSdkVersion
+        targetSdkVersion _targetSdkVersion
         versionCode 1
         versionName "1.0"
         ndk {
@@ -17,6 +25,6 @@ android {
 
 dependencies {
     //noinspection GradleDynamicVersion
-    provided 'com.facebook.react:react-native:+'
+    provided "com.facebook.react:react-native:${_reactNativeVersion}"
     compile 'com.yqritc:android-scalablevideoview:1.0.4'
 }


### PR DESCRIPTION
This behavior causes people to need to have SDK 27 installed, so it was backed out in #1080. We can re-merge it as part of 3.0 as long as we fully document it.

Originally created in #999 