### PR TITLE
Automatically play on ExoPlayer when the paused prop is not set

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -102,7 +102,7 @@ class ReactExoplayerView extends FrameLayout implements
     private boolean loadVideoStarted;
     private boolean isFullscreen;
     private boolean isInBackground;
-    private boolean isPaused = true;
+    private boolean isPaused;
     private boolean isBuffering;
     private float rate = 1f;
 


### PR DESCRIPTION
Change the behavior so that ExoPlayer starts playing the video automatically without needing to set `paused={false}`