### PR TITLE
Avoid crash setting rate with some devices on Android MediaPlayer 

### DIFF
--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -410,8 +410,16 @@ public class ReactVideoView extends ScalableVideoView implements MediaPlayer.OnP
         if (mMediaPlayerValid) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 if (!mPaused) { // Applying the rate while paused will cause the video to start
-                    mMediaPlayer.setPlaybackParams(mMediaPlayer.getPlaybackParams().setSpeed(rate));
-                    mActiveRate = rate;
+                    /* Per https://stackoverflow.com/questions/39442522/setplaybackparams-causes-illegalstateexception
+                     * Some devices throw an IllegalStateException if you set the rate without first calling reset()
+                     * TODO: Call reset() then reinitialize the player
+                     */
+                    try {
+                        mMediaPlayer.setPlaybackParams(mMediaPlayer.getPlaybackParams().setSpeed(rate));
+                        mActiveRate = rate;
+                    } catch (Exception e) {
+                        Log.e(ReactVideoViewManager.REACT_CLASS, "Unable to set rate, unsupported on this device");
+                    }
                 }
             } else {
                 Log.e(ReactVideoViewManager.REACT_CLASS, "Setting playback rate is not yet supported on Android versions below 6.0");


### PR DESCRIPTION
Fixes #1061. When using Android MediaPlayer on some devices like an Oppo phone running Android 7.1, setting the rate will throw an IllegalStateException. Per https://stackoverflow.com/questions/39442522/setplaybackparams-causes-illegalstateexception, this is because those devices require that you call `mMediaPlayer.reset()` before setting the rate. Doing that would require re-initializing the media player. Since we are deprecating MediaPlayer in favor of ExoPlayer,  it's not worth the extra work. Instead we catch the exception and hope for the best.

If someone wants to do the elegant fix down the road, they are more than welcome to.