### PR TITLE
Fix UI block on iOS during initial load

### DIFF
--- a/ios/RCTVideo.m
+++ b/ios/RCTVideo.m
@@ -639,6 +639,11 @@ static NSString *const timedMetadata = @"timedMetadata";
 
 - (void)applyModifiers
 {
+  // Skip applying modifiers if the video is not ready to avoid freezing
+  if (_playerItem.status != AVPlayerItemStatusReadyToPlay) {
+    return;
+  }
+
   if (_muted) {
     [_player setVolume:0];
     [_player setMuted:YES];


### PR DESCRIPTION
Possibly related issues: #577 #1067.
I'm experiencing an issue where, if any prop that causes the applyModifiers function to be called has a value set, then the UI will block during the initial video load from a network location. This is the 'ignoreSilentSwitch', 'rate', 'volume' and 'muted' props.
I can reproduce this by pointing the player to a remote file such as 'https://www.sample-videos.com/video/mp4/720/big_buck_bunny_720p_10mb.mp4' and setting, for example, volume to 1. If the player is mounted when the app starts, then no UI will render until the video loads. Removing the volume prop prevents the issue.

I fixed the issue by adding a check that the video is ready in the applyModifiers function. The function is called again when the video state changes to ready so I don't think this causes any problems.