### PR TITLE
Disable HTTP headers on iOS since it uses a private API

### DIFF
--- a/ios/RCTVideo.m
+++ b/ios/RCTVideo.m
@@ -334,9 +334,12 @@ static NSString *const timedMetadata = @"timedMetadata";
 
   if (isNetwork) {
     NSMutableDictionary *assetOptions = [[NSMutableDictionary alloc]init];
+    /* Per #1091, this is not a public API. We need to either get approval from Apple to use this
+     * or use a different approach.
     if ([headers count] > 0) {
       [assetOptions setObject:headers forKey:@"AVURLAssetHTTPHeaderFieldsKey"];
     }
+    */
     NSArray *cookies = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookies];
     [assetOptions setObject:cookies forKey:AVURLAssetHTTPCookiesKey];
 


### PR DESCRIPTION
Fixes #1091. Currently, we are using a private API to set the HTTP headers which could result in apps being rejected by Apple.

This can be re-enabled as soon as we have an alternate approach that doesn't use private APIs.