### PR TITLE
Allow ExoPlayer media to continue to play after being detached from view

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -342,6 +342,7 @@ Video.propTypes = {
   playWhenInactive: PropTypes.bool,
   ignoreSilentSwitch: PropTypes.oneOf(['ignore', 'obey']),
   disableFocus: PropTypes.bool,
+  doNotDetach: PropTypes.bool,
   controls: PropTypes.bool,
   audioOnly: PropTypes.bool,
   currentTime: PropTypes.number,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -120,6 +120,7 @@ class ReactExoplayerView extends FrameLayout implements
     private float mProgressUpdateInterval = 250.0f;
     private boolean playInBackground = false;
     private boolean useTextureView = false;
+    private boolean doNotDetach = false;
     private Map<String, String> requestHeaders;
     // \ End props
 
@@ -193,7 +194,9 @@ class ReactExoplayerView extends FrameLayout implements
     @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
-        stopPlayback();
+        if(!doNotDetach) {
+          stopPlayback();
+        }
     }
 
     // LifecycleEventListener implementation
@@ -842,6 +845,10 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setDisableFocus(boolean disableFocus) {
         this.disableFocus = disableFocus;
+    }
+
+    public void setDoNotDetach(boolean doNotDetach) {
+        this.doNotDetach = doNotDetach;
     }
 
     public void setFullscreen(boolean fullscreen) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -40,6 +40,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_RATE = "rate";
     private static final String PROP_PLAY_IN_BACKGROUND = "playInBackground";
     private static final String PROP_DISABLE_FOCUS = "disableFocus";
+    private static final String PROP_DO_NOT_DETACH = "doNotDetach";
     private static final String PROP_FULLSCREEN = "fullscreen";
     private static final String PROP_USE_TEXTURE_VIEW = "useTextureView";
 
@@ -185,6 +186,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_DISABLE_FOCUS, defaultBoolean = false)
     public void setDisableFocus(final ReactExoplayerView videoView, final boolean disableFocus) {
         videoView.setDisableFocus(disableFocus);
+    }
+
+    @ReactProp(name = PROP_DO_NOT_DETACH, defaultBoolean = false)
+    public void setDoNotDetach(final ReactExoplayerView videoView, final boolean doNotDetach) {
+        videoView.setDoNotDetach(doNotDetach);
     }
 
     @ReactProp(name = PROP_FULLSCREEN, defaultBoolean = false)


### PR DESCRIPTION
I am currently building an app where I need audio/video to continue playing after I push a new screen onto the navigation stack. This currently works out of the box in iOS, but not in android.

For context of a use case, think about an app like Spotify, where you can navigate away from the media player and continue to control that media being played in the background as you browse different screens.

I added a prop called "doNotDetach" (I'm not sure how I feel about this naming) that allows a consumer to control whether they would like this behavior or not in Exo Player. 

Let me know your thoughts/suggestions! 