### PR TITLE
Update ExoPlayer to version 2.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ A `<Video>` component for react-native, as seen in
 
 Requires react-native >= 0.40.0, for RN support of 0.19.0 - 0.39.0 please use a pre 1.0 version.
 
-### Version 3.0 breaking changes
+### Version 4.0.0 breaking changes
+Version 4.0 now requires Android SDK 26 or higher to use ExoPlayer. This is the default version as of React Native 0.56 and will be required by Google for all apps in October 2018.
+
+### Version 3.0.0 breaking changes
 Version 3.0 features a number of changes to existing behavior. See [Updating](#updating) for changes.
 
 ## TOC

--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -19,8 +19,8 @@ android {
 dependencies {
     //noinspection GradleDynamicVersion
     provided "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    compile 'com.google.android.exoplayer:exoplayer:2.7.3'
-    compile('com.google.android.exoplayer:extension-okhttp:2.7.3') {
+    compile 'com.google.android.exoplayer:exoplayer:2.8.2'
+    compile('com.google.android.exoplayer:extension-okhttp:2.8.2') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     }
     compile 'com.squareup.okhttp3:okhttp:3.9.1'

--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -19,9 +19,18 @@ android {
 dependencies {
     //noinspection GradleDynamicVersion
     provided "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    compile 'com.google.android.exoplayer:exoplayer:2.8.2'
+    compile('com.google.android.exoplayer:exoplayer:2.8.2') {
+        exclude group: 'com.android.support'
+    }
+
+    // All support libs must use the same version
+    compile "com.android.support:support-annotations:${safeExtGet('supportLibVersion', '+')}"
+    compile "com.android.support:support-compat:${safeExtGet('supportLibVersion', '+')}"
+    compile "com.android.support:support-media-compat:${safeExtGet('supportLibVersion', '+')}"
+
     compile('com.google.android.exoplayer:extension-okhttp:2.8.2') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     }
-    compile 'com.squareup.okhttp3:okhttp:3.9.1'
+    compile 'com.squareup.okhttp3:okhttp:3.11.0'
+
 }


### PR DESCRIPTION
Updates us to the latest ExoPlayer version. This version requires a newer Android SDK version to compile, so it will be a BC (breaking change) release.