### PR TITLE
Prevent errors on iOS when using text tracks with caching

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -9,11 +9,13 @@ The cache is backed by [SPTPersistentCache](https://github.com/spotify/SPTPersis
 # How Does It Work
 
 The caching is based on the url of the asset.
-SPTPersistentCache is a LRU ([last recently used](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU))) cache.
+SPTPersistentCache is a LRU ([Least Recently Used](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU))) cache.
 
 # Restrictions
 
-Currenly the uri of the resource that should be cached needs to have the appropriate file extension (one of `mp4`, `m4v` or `mov`). In order to be cached. In future versions (once dependencies allow access to the `content-type` header) this will no longer be necessary. You will also receive warnings in the xcode logs by using the `debug` mode. So if you are not 100% sure if your video is cached, check your xcode logs!
+Currently, caching is only supported for URLs that end in a `.mp4`, `.m4v`, or `.mov` extension. In future versions, URLs that end in a query string (e.g. test.mp4?resolution=480p) will be support once dependencies allow access to the `Content-Type` header.  At this time, HLS playlists (.m3u8) and videos that sideload text tracks are not supported and will bypass the cache.
+
+You will also receive warnings in the Xcode logs by using the `debug` mode. So if you are not 100% sure if your video is cached, check your Xcode logs!
 
 By default files expire after 30 days and the maxmimum cache size is 100mb.
 

--- a/ios/Video/RCTVideo.h
+++ b/ios/Video/RCTVideo.h
@@ -7,7 +7,8 @@
 
 #if __has_include(<react-native-video/RCTVideoCache.h>)
 #import <react-native-video/RCTVideoCache.h>
-#import "DVURLAsset.h"
+#import <DVAssetLoaderDelegate/DVURLAsset.h>
+#import <DVAssetLoaderDelegate/DVAssetLoaderDelegate.h>
 #endif
 
 @class RCTEventDispatcher;

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -460,6 +460,7 @@ static int const RCTVideoUnset = -1;
        *  to bring in the text track code will crash. I suspect this is because the asset hasn't fully loaded.
        * Until this is fixed, we need to bypass caching when text tracks are specified.
        */
+      DebugLog(@"Caching is not supported for uri '%@' because text tracks are not compatible with the cache. Checkout https://github.com/react-native-community/react-native-video/blob/master/docs/caching.md", uri);
       [self playerItemForSourceUsingCache:uri assetOptions:assetOptions withCallback:handler];
       return;
     }

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -31,7 +31,6 @@ static int const RCTVideoUnset = -1;
   BOOL _playerLayerObserverSet;
   AVPlayerViewController *_playerViewController;
   NSURL *_videoURL;
-  AVURLAsset *_testAsset;
   
   /* Required to publish events */
   RCTEventDispatcher *_eventDispatcher;

--- a/ios/VideoCaching/RCTVideoCache.m
+++ b/ios/VideoCaching/RCTVideoCache.m
@@ -7,8 +7,7 @@
 @synthesize cacheIdentifier;
 @synthesize temporaryCachePath;
 
-+ (RCTVideoCache *) sharedInstance
-{
++ (RCTVideoCache *)sharedInstance {
   static RCTVideoCache *sharedInstance = nil;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
@@ -41,9 +40,8 @@
   return self;
 }
 
-- (void) createTemporaryPath
-{
-  NSError * error = nil;
+- (void) createTemporaryPath {
+  NSError *error = nil;
   BOOL success = [[NSFileManager defaultManager] createDirectoryAtPath:self.temporaryCachePath
                                            withIntermediateDirectories:YES
                                                             attributes:nil
@@ -77,19 +75,19 @@
 }
 
 - (AVURLAsset *)getItemFromTemporaryStorage:(NSString *)key {
-  NSString * temporaryFilePath =[self.temporaryCachePath stringByAppendingPathComponent:key];
+  NSString * temporaryFilePath = [self.temporaryCachePath stringByAppendingPathComponent:key];
   
   BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:temporaryFilePath];
   if (!fileExists) {
     return nil;
   }
-  NSURL * assetUrl = [[NSURL alloc] initFileURLWithPath:temporaryFilePath];
+  NSURL *assetUrl = [[NSURL alloc] initFileURLWithPath:temporaryFilePath];
   AVURLAsset *asset = [AVURLAsset URLAssetWithURL:assetUrl options:nil];
   return asset;
 }
 
 - (BOOL)saveDataToTemporaryStorage:(NSData *)data key:(NSString *)key {
-  NSString * temporaryFilePath = [self.temporaryCachePath stringByAppendingPathComponent:key];
+  NSString *temporaryFilePath = [self.temporaryCachePath stringByAppendingPathComponent:key];
   [data writeToFile:temporaryFilePath atomically:YES];
   return YES;
 }
@@ -159,7 +157,7 @@
   }
 }
 
-- (NSString *) generateHashForUrl:(NSString *)string {
+- (NSString *)generateHashForUrl:(NSString *)string {
   const char *cStr = [string UTF8String];
   unsigned char result[CC_MD5_DIGEST_LENGTH];
   CC_MD5( cStr, (CC_LONG)strlen(cStr), result );

--- a/ios/VideoCaching/RCTVideoCache.m
+++ b/ios/VideoCaching/RCTVideoCache.m
@@ -105,7 +105,7 @@
 
   NSString * pathExtension = [uriWithoutQueryParams pathExtension];
   NSArray * supportedExtensions = @[@"m4v", @"mp4", @"mov"];
-  if ([supportedExtensions containsObject:pathExtension] == NO) {
+  if ([pathExtension isEqualToString:@""]) {
     NSDictionary *userInfo = @{
                                NSLocalizedDescriptionKey: NSLocalizedString(@"Missing file extension.", nil),
                                NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"Missing file extension.", nil),
@@ -114,11 +114,12 @@
     NSError *error = [NSError errorWithDomain:@"RCTVideoCache"
                                          code:RCTVideoCacheStatusMissingFileExtension userInfo:userInfo];
     @throw error;
-  } else if ([pathExtension isEqualToString:@"m3u8"]) {
+  } else if (![supportedExtensions containsObject:pathExtension]) {
+    // Notably, we don't currently support m3u8 (HLS playlists)
     NSDictionary *userInfo = @{
-                               NSLocalizedDescriptionKey: NSLocalizedString(@"Missing file extension.", nil),
-                               NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"Missing file extension.", nil),
-                               NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Missing file extension.", nil)
+                               NSLocalizedDescriptionKey: NSLocalizedString(@"Unsupported file extension.", nil),
+                               NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"Unsupported file extension.", nil),
+                               NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Unsupported file extension.", nil)
                                };
     NSError *error = [NSError errorWithDomain:@"RCTVideoCache"
                                          code:RCTVideoCacheStatusUnsupportedFileExtension userInfo:userInfo];


### PR DESCRIPTION
This PR is intended to fix a crash that happens when you attempt to mix in text tracks. Also fixes issues where the right error code wasn't returned when the file couldn't be cached.

@n1ru4l I did some refactors to make it a bit easier to read. IMO, putting all of the caching code into a separate function so you don't have to parse all the ifdefs is a lot easier to digest. For future PRs, I'd suggest breaking it into pieces. Giant PRs are make it more challenging to figure out what changed and also are a bit harder to merge since everything needs to be tested and evaluated all at once.

I did some investigation into the text track issue and have it mostly isolated. In the text track code https://github.com/react-native-community/react-native-video/blob/86d655c3d1c8a81f6b841d7379ba624903440b32/ios/Video/RCTVideo.m#L393 it is bombing at the line for:

`AVAssetTrack *videoAsset = [asset tracksWithMediaType:AVMediaTypeVideo].firstObject;`

Which throws an error in the debugger of:
```
error: warning: got name from symbols: AVMediaTypeVideo
error: cannot initialize a parameter of type 'id' with an lvalue of type 'void *'
```

I was thinking maybe DVURLAsset didn't subclass AVURLAsset and was missing the `tracksWithMediaType` method and manually created the AVURLAsset. However, that didn't fix it and it turns out it does subclass it. 

I ran out of time today to finish investigating but will see if I can figure out that error this evening or tomorrow.

@n1ru4l A few other questions for you. Can we also cache the audio & text tracks? Also, I'm assuming that if you watch a video for a second time and part of the video is in the cache, it will pull any other parts that aren't cached from the network, right? Just wanted to be sure.