### PR TITLE
Use FileDataSource for file:/// Uris for better handling of in-progress I/O (eg. playback during download)

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/DataSourceUtil.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/DataSourceUtil.java
@@ -2,6 +2,7 @@ package com.brentvatne.exoplayer;
 
 import android.content.Context;
 import android.content.ContextWrapper;
+import android.net.Uri;
 
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.modules.network.CookieJarContainer;
@@ -40,6 +41,10 @@ public class DataSourceUtil {
         return userAgent;
     }
 
+    public static DataSource.Factory getFileDataSourceFactory(Uri uri) {
+        return new FileDataSourceFactory(uri);
+    }
+
     public static DataSource.Factory getRawDataSourceFactory(ReactContext context) {
         if (rawDataSourceFactory == null) {
             rawDataSourceFactory = buildRawDataSourceFactory(context);
@@ -50,7 +55,6 @@ public class DataSourceUtil {
     public static void setRawDataSourceFactory(DataSource.Factory factory) {
         DataSourceUtil.rawDataSourceFactory = factory;
     }
-
 
     public static DataSource.Factory getDefaultDataSourceFactory(ReactContext context, DefaultBandwidthMeter bandwidthMeter, Map<String, String> requestHeaders) {
         if (defaultDataSourceFactory == null || (requestHeaders != null && !requestHeaders.isEmpty())) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/FileDataSourceFactory.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/FileDataSourceFactory.java
@@ -1,0 +1,31 @@
+package com.brentvatne.exoplayer;
+
+import android.content.Context;
+import android.net.Uri;
+
+import com.google.android.exoplayer2.upstream.DataSource;
+import com.google.android.exoplayer2.upstream.DataSpec;
+import com.google.android.exoplayer2.upstream.FileDataSource;
+
+class FileDataSourceFactory implements DataSource.Factory {
+
+    private final Uri uri;
+
+    FileDataSourceFactory(Uri uri) {
+        this.uri = uri;
+    }
+
+    @Override
+    public DataSource createDataSource() {
+        DataSpec dataSpec = new DataSpec(uri);
+        FileDataSource fileDataSource = new FileDataSource();
+        try {
+            fileDataSource.open(dataSpec);
+        } catch (FileDataSource.FileDataSourceException e) {
+            // file at the URI could not be found / opened
+            return null;
+        }
+
+        return fileDataSource;
+    }
+}

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -12,6 +12,7 @@ import android.util.Log;
 import android.view.View;
 import android.view.Window;
 import android.view.accessibility.CaptioningManager;
+import android.webkit.URLUtil;
 import android.widget.FrameLayout;
 
 import com.brentvatne.react.R;
@@ -705,7 +706,15 @@ class ReactExoplayerView extends FrameLayout implements
             this.srcUri = uri;
             this.extension = extension;
             this.requestHeaders = headers;
-            this.mediaDataSourceFactory = DataSourceUtil.getDefaultDataSourceFactory(this.themedReactContext, BANDWIDTH_METER, this.requestHeaders);
+            this.mediaDataSourceFactory = null;
+
+            if (URLUtil.isFileUrl(uri.toString())) {
+                this.mediaDataSourceFactory = DataSourceUtil.getFileDataSourceFactory(uri);
+            }
+
+            if (this.mediaDataSourceFactory == null) {
+                this.mediaDataSourceFactory = DataSourceUtil.getDefaultDataSourceFactory(this.themedReactContext, BANDWIDTH_METER, this.requestHeaders);
+            }
 
             if (!isOriginalSourceNull && !isSourceEqual) {
                 reloadSource();


### PR DESCRIPTION
This allows an incomplete media file loaded from the local filesystem to continuously play while it is being written to (in our use case, playback of a file while it is being downloaded). https://github.com/lbryio/lbry-android/issues/191 provides some additional context for why this was done.