### PR TITLE
Fix missing TargetApi import

### DIFF
--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -1,6 +1,7 @@
 package com.brentvatne.react;
 
 import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.res.AssetFileDescriptor;
 import android.graphics.Matrix;


### PR DESCRIPTION
The build was producing a "cannot find symbol class TargetApi" error without that line.