### PR TITLE
Avoid crash on ExoPlayer when there are no tracks to choose from

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -830,6 +830,10 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private int getTrackIndexForDefaultLocale(TrackGroupArray groups) {
+        if (groups.length == 0) { // Avoid a crash if we try to select a non-existant group
+            return C.INDEX_UNSET;
+        }
+
         int trackIndex = 0; // default if no match
         String locale2 = Locale.getDefault().getLanguage(); // 2 letter code
         String locale3 = Locale.getDefault().getISO3Language(); // 3 letter code


### PR DESCRIPTION
Fixes #1190 

What was happening is that the video contained no audio tracks, it would still attempt to select the audio track with index 0. We now check that there are tracks to choose from and if there aren't return the unset constant so that we turn of the renderer for that type of track.