### PR TITLE
Instead of crashing, show a warning and return

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -436,7 +436,7 @@ static int const RCTVideoUnset = -1;
   bool isAsset = [RCTConvert BOOL:[source objectForKey:@"isAsset"]];
   NSString *uri = [source objectForKey:@"uri"];
   NSString *type = [source objectForKey:@"type"];
-  if([uri isEqualToString:@""] || [type isEqualToString:@""]) {
+  if([uri isEqualToString:@""] && [type isEqualToString:@""]) {
     DebugLog(@"Could not find video URL in source '%@'", source);
     return;
   }

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -436,7 +436,7 @@ static int const RCTVideoUnset = -1;
   bool isAsset = [RCTConvert BOOL:[source objectForKey:@"isAsset"]];
   NSString *uri = [source objectForKey:@"uri"];
   NSString *type = [source objectForKey:@"type"];
-  if([uri isEqualToString:@""] && [type isEqualToString:@""]) {
+  if (!uri || [uri isEqualToString:@""]) {
     DebugLog(@"Could not find video URL in source '%@'", source);
     return;
   }

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -436,6 +436,10 @@ static int const RCTVideoUnset = -1;
   bool isAsset = [RCTConvert BOOL:[source objectForKey:@"isAsset"]];
   NSString *uri = [source objectForKey:@"uri"];
   NSString *type = [source objectForKey:@"type"];
+  if([uri isEqualToString:@""] || [type isEqualToString:@""]) {
+    DebugLog(@"Could not find video URL in source '%@'", source);
+    return;
+  }
 
   NSURL *url = isNetwork || isAsset
     ? [NSURL URLWithString:uri]


### PR DESCRIPTION
I was having an issue with iOS crashing in RCTVideo.m line 446 because sometimes my data wasn't as I thought it should be. pathForResource is nullable, yet initFileURLWithPath cannot take a null-parameter. This patch makes sure we don't get a null at all on bad input.