### PR TITLE
Support react-native-dom

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,31 @@ using System.Collections.Generic;
 ```
 </details>
 
+<details>
+  <summary>DOM</summary>
+
+Make the following additions to the given files manually:
+
+**dom/bootstrap.js**
+
+Import RCTVideoManager and add it to the list of nativeModules:
+
+```javascript
+import { RNDomInstance } from "react-native-dom";
+import { name as appName } from "../app.json";
+import RCTVideoManager from 'react-native-video/dom/RCTVideoManager'; // Add this
+
+// Path to RN Bundle Entrypoint ================================================
+const rnBundlePath = "./entry.bundle?platform=dom&dev=true";
+
+// React Native DOM Runtime Options =============================================
+const ReactNativeDomOptions = {
+  enableHotReload: false,
+  nativeModules: [RCTVideoManager] // Add this
+};
+```
+</details>
+
 ## Usage
 
 ```javascript

--- a/dom/LICENSE.md
+++ b/dom/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2018 Vincent Riemer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/dom/RCTVideo.js
+++ b/dom/RCTVideo.js
@@ -15,7 +15,10 @@ class RCTVideo extends RCTView {
     super(bridge);
 
     this.videoElement = this.initializeVideoElement();
-    this.muted = true;
+    this.controls = false;
+    this.muted = false;
+    this.rate = 1.0;
+    this.volume = 1.0;
     this.childContainer.appendChild(this.videoElement);
   }
 
@@ -34,20 +37,13 @@ class RCTVideo extends RCTView {
     return elem;
   }
 
-  set source(value: VideoSource) {
-    let uri = value.uri;
-
-    if (uri.startsWith("blob:")) {
-      let blob = this.bridge.blobManager.resolveURL(uri);
-      if (blob.type === "text/xml") {
-        blob = new Blob([blob], { type: "video/mp4" });
-      }
-      uri = URL.createObjectURL(blob);
-    }
-
-    this.videoElement.setAttribute("src", uri);
-    if (!this._paused) {
-      this.playPromise = this.videoElement.play();
+  set controls(value: boolean) {
+    if (value) {
+      this.videoElement.setAttribute("controls", "true");
+      this.videoElement.controls = true;
+    } else {
+      this.videoElement.removeAttribute("controls");
+      this.videoElement.controls = false;
     }
   }
 
@@ -59,6 +55,21 @@ class RCTVideo extends RCTView {
       this.videoElement.removeAttribute("muted");
       this.videoElement.muted = false;
     }
+  }
+
+  set paused(value: boolean) {
+    this.playPromise.then(() => {
+      if (value) {
+        this.videoElement.pause();
+      } else {
+        this.playPromise = this.videoElement.play().catch(console.error);
+      }
+    });
+    this._paused = value;
+  }
+
+  set rate(value: number) {
+    this.videoElement.setAttribute("playbackRate", value);
   }
 
   set repeat(value: boolean) {
@@ -90,15 +101,30 @@ class RCTVideo extends RCTView {
     }
   }
 
-  set paused(value: boolean) {
-    this.playPromise.then(() => {
-      if (value) {
-        this.videoElement.pause();
-      } else {
-        this.playPromise = this.videoElement.play().catch(console.error);
+  set source(value: VideoSource) {
+    let uri = value.uri;
+
+    if (uri.startsWith("blob:")) {
+      let blob = this.bridge.blobManager.resolveURL(uri);
+      if (blob.type === "text/xml") {
+        blob = new Blob([blob], { type: "video/mp4" });
       }
-    });
-    this._paused = value;
+      uri = URL.createObjectURL(blob);
+    }
+
+    this.videoElement.setAttribute("src", uri);
+    if (!this._paused) {
+      this.playPromise = this.videoElement.play();
+    }
+  }
+
+  set volume(value: number) {
+    this.videoElement.setAttribute("volume", value);
+    if (this.value === 0) {
+      this.muted = true;
+    } else {
+      this.muted = false;
+    }
   }
 }
 

--- a/dom/RCTVideo.js
+++ b/dom/RCTVideo.js
@@ -69,7 +69,10 @@ class RCTVideo extends RCTView {
   }
 
   set rate(value: number) {
+    this.videoElement.setAttribute("defaultPlaybackRate", value);
     this.videoElement.setAttribute("playbackRate", value);
+    this.videoElement.defaultPlaybackRate = value; // playbackRate doesn't work on Chrome
+    this.videoElement.playbackRate = value;
   }
 
   set repeat(value: boolean) {

--- a/dom/RCTVideo.js
+++ b/dom/RCTVideo.js
@@ -1,0 +1,107 @@
+// @flow
+
+import { RCTView, type RCTBridge } from "react-native-dom";
+
+import resizeModes from "./resizeModes";
+import type { VideoSource } from "./types";
+
+class RCTVideo extends RCTView {
+  playPromise: Promise<void> = Promise.resolve();
+  videoElement: HTMLVideoElement;
+
+  _paused: boolean = false;
+
+  constructor(bridge: RCTBridge) {
+    super(bridge);
+
+    this.videoElement = this.initializeVideoElement();
+    this.muted = true;
+    this.childContainer.appendChild(this.videoElement);
+  }
+
+  initializeVideoElement() {
+    const elem = document.createElement("video");
+
+    Object.assign(elem.style, {
+      display: "block",
+      position: "absolute",
+      top: "0",
+      left: "0",
+      width: "100%",
+      height: "100%",
+    });
+
+    return elem;
+  }
+
+  set source(value: VideoSource) {
+    let uri = value.uri;
+
+    if (uri.startsWith("blob:")) {
+      let blob = this.bridge.blobManager.resolveURL(uri);
+      if (blob.type === "text/xml") {
+        blob = new Blob([blob], { type: "video/mp4" });
+      }
+      uri = URL.createObjectURL(blob);
+    }
+
+    this.videoElement.setAttribute("src", uri);
+    if (!this._paused) {
+      this.playPromise = this.videoElement.play();
+    }
+  }
+
+  set muted(value: boolean) {
+    if (value) {
+      this.videoElement.setAttribute("muted", "true");
+      this.videoElement.muted = true;
+    } else {
+      this.videoElement.removeAttribute("muted");
+      this.videoElement.muted = false;
+    }
+  }
+
+  set repeat(value: boolean) {
+    if (value) {
+      this.videoElement.setAttribute("loop", "true");
+    } else {
+      this.videoElement.removeAttribute("loop");
+    }
+  }
+
+  set resizeMode(value: number) {
+    switch (value) {
+      case resizeModes.ScaleNone: {
+        this.videoElement.style.objectFit = "none";
+        break;
+      }
+      case resizeModes.ScaleToFill: {
+        this.videoElement.style.objectFit = "fill";
+        break;
+      }
+      case resizeModes.ScaleAspectFit: {
+        this.videoElement.style.objectFit = "contain";
+        break;
+      }
+      case resizeModes.ScaleAspectFill: {
+        this.videoElement.style.objectFit = "cover";
+        break;
+      }
+    }
+  }
+
+  set paused(value: boolean) {
+    this.playPromise.then(() => {
+      if (value) {
+        this.videoElement.pause();
+      } else {
+        this.playPromise = this.videoElement.play().catch(console.error);
+      }
+    });
+    this._paused = value;
+  }
+}
+
+customElements.define("rct-video", RCTVideo);
+
+export default RCTVideo;

--- a/dom/RCTVideoEvent.js
+++ b/dom/RCTVideoEvent.js
@@ -1,0 +1,56 @@
+// import { RCTEvent } from "react-native-dom";
+
+interface RCTEvent {
+    viewTag: number;
+    eventName: string;
+    coalescingKey: number;
+  
+    canCoalesce(): boolean;
+    coalesceWithEvent(event: RCTEvent): RCTEvent;
+  
+    moduleDotMethod(): string;
+    arguments(): Array<any>;
+  }
+
+export default class RCTVideoEvent implements RCTEvent {
+  viewTag: number;
+  eventName: string;
+  coalescingKey: number;
+
+  constructor(
+    eventName: string,
+    reactTag: number,
+    coalescingKey: number,
+    data: ?Object
+  ) {
+    this.viewTag = reactTag;
+    this.eventName = eventName;
+    this.coalescingKey = coalescingKey;
+    this.data = data;
+  }
+
+  canCoalesce(): boolean {
+    return false;
+  }
+
+  coalesceWithEvent(event: RCTEvent): RCTEvent {
+    return;
+  }
+
+  moduleDotMethod(): string {
+    return "RCTEventEmitter.receiveEvent";
+  }
+
+  arguments(): Array<any> {
+    const args = [
+      this.viewTag,
+      this.eventName,
+      this.data
+    ];
+    return args;
+  }
+
+  coalescingKey(): number {
+    return this.coalescingKey;
+  }
+}

--- a/dom/RCTVideoManager.js
+++ b/dom/RCTVideoManager.js
@@ -17,31 +17,42 @@ class RCTVideoManager extends RCTViewManager {
   describeProps() {
     return super
       .describeProps()
-      .addObjectProp("src", this.setSource)
-      .addNumberProp("resizeMode", this.setResizeMode)
-      .addBooleanProp("repeat", this.setRepeat)
+      .addBooleanProp("controls", this.setControls)
+      .addBooleanProp("muted", this.setMuted)
       .addBooleanProp("paused", this.setPaused)
-      .addBooleanProp("muted", this.setMuted);
+      .addBooleanProp("rate", this.setRate)
+      .addBooleanProp("repeat", this.setRepeat)
+      .addNumberProp("resizeMode", this.setResizeMode)
+      .addObjectProp("src", this.setSource)
+      .addNumberProp("volume", this.setVolume);
   }
 
-  setSource(view: RCTVideo, value: VideoSource) {
-    view.source = value;
+  setControls(view: RCTVideo, value: boolean) {
+    view.controls = value;
   }
 
-  setResizeMode(view: RCTVideo, value: number) {
-    view.resizeMode = value;
-  }
-
-  setRepeat(view: RCTVideo, value: boolean) {
-    view.repeat = value;
+  setMuted(view: RCTVideo, value: boolean) {
+    view.muted = value;
   }
 
   setPaused(view: RCTVideo, value: boolean) {
     view.paused = value;
   }
 
-  setMuted(view: RCTVideo, value: boolean) {
-    view.muted = value;
+  setRate(view: RCTVideo, value: number) {
+    view.rate = value;
+  }
+
+  setRepeat(view: RCTVideo, value: boolean) {
+    view.repeat = value;
+  }
+  
+  setResizeMode(view: RCTVideo, value: number) {
+    view.resizeMode = value;
+  }
+
+  setSource(view: RCTVideo, value: VideoSource) {
+    view.source = value;
   }
 
   constantsToExport() {

--- a/dom/RCTVideoManager.js
+++ b/dom/RCTVideoManager.js
@@ -1,0 +1,52 @@
+// @flow
+
+import { RCTViewManager } from "react-native-dom";
+
+import RCTVideo from "./RCTVideo";
+import resizeModes from "./resizeModes";
+
+import type { VideoSource } from "./types";
+
+class RCTVideoManager extends RCTViewManager {
+  static moduleName = "RCTVideoManager";
+
+  view() {
+    return new RCTVideo(this.bridge);
+  }
+
+  describeProps() {
+    return super
+      .describeProps()
+      .addObjectProp("src", this.setSource)
+      .addNumberProp("resizeMode", this.setResizeMode)
+      .addBooleanProp("repeat", this.setRepeat)
+      .addBooleanProp("paused", this.setPaused)
+      .addBooleanProp("muted", this.setMuted);
+  }
+
+  setSource(view: RCTVideo, value: VideoSource) {
+    view.source = value;
+  }
+
+  setResizeMode(view: RCTVideo, value: number) {
+    view.resizeMode = value;
+  }
+
+  setRepeat(view: RCTVideo, value: boolean) {
+    view.repeat = value;
+  }
+
+  setPaused(view: RCTVideo, value: boolean) {
+    view.paused = value;
+  }
+
+  setMuted(view: RCTVideo, value: boolean) {
+    view.muted = value;
+  }
+
+  constantsToExport() {
+    return { ...resizeModes };
+  }
+}
+
+export default RCTVideoManager;

--- a/dom/RCTVideoManager.js
+++ b/dom/RCTVideoManager.js
@@ -20,11 +20,21 @@ class RCTVideoManager extends RCTViewManager {
       .addBooleanProp("controls", this.setControls)
       .addBooleanProp("muted", this.setMuted)
       .addBooleanProp("paused", this.setPaused)
+      .addNumberProp("progressUpdateInterval", this.setProgressUpdateInterval)
       .addBooleanProp("rate", this.setRate)
       .addBooleanProp("repeat", this.setRepeat)
       .addNumberProp("resizeMode", this.setResizeMode)
+      .addNumberProp("seek", this.setSeek)
       .addObjectProp("src", this.setSource)
-      .addNumberProp("volume", this.setVolume);
+      .addNumberProp("volume", this.setVolume)
+      .addDirectEvent("onVideoEnd")
+      .addDirectEvent("onVideoLoad")
+      .addDirectEvent("onVideoLoadStart")
+      .addDirectEvent("onVideoProgress");
+  }
+
+  presentFullscreenPlayer() {
+    // not currently working
   }
 
   setControls(view: RCTVideo, value: boolean) {
@@ -46,9 +56,13 @@ class RCTVideoManager extends RCTViewManager {
   setRepeat(view: RCTVideo, value: boolean) {
     view.repeat = value;
   }
-  
+
   setResizeMode(view: RCTVideo, value: number) {
     view.resizeMode = value;
+  }
+
+  setSeek(view: RCTVideo, value: number) {
+    view.seek = value;
   }
 
   setSource(view: RCTVideo, value: VideoSource) {

--- a/dom/index.js
+++ b/dom/index.js
@@ -1,0 +1,3 @@
+// @flow
+
+module.exports = require("./RCTVideoManager");

--- a/dom/resizeModes.js
+++ b/dom/resizeModes.js
@@ -1,0 +1,8 @@
+// @flow
+
+export default {
+  ScaleNone: 0,
+  ScaleToFill: 1,
+  ScaleAspectFit: 2,
+  ScaleAspectFill: 3,
+};

--- a/dom/types.js
+++ b/dom/types.js
@@ -1,0 +1,10 @@
+// @flow
+
+export type VideoSource = {
+  uri: string,
+  type: string,
+  mainVer: number,
+  patchVer: number,
+  isNetwork: boolean,
+  isAsset: boolean,
+};


### PR DESCRIPTION
This adds support for using react-native-video using the [react-native-dom](https://github.com/vincentriemer/react-native-dom) platform. react-native-dom is a complete implementation of React Native for the web.

Most props are implemented & working.

Remaining todo items:
* Add event handlers
* Document supported props
* Test on browsers other than Chrome
* If possible, make controls hide & appear by clicking on the video
* Add fullscreen support