### PR TITLE
Make seek() throw an exception when using NaN value

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -51,6 +51,8 @@ export default class Video extends Component {
   }
 
   seek = (time, tolerance = 100) => {
+    if (isNaN(time)) throw new Error('Specified time is not a number');
+    
     if (Platform.OS === 'ios') {
       this.setNativeProps({
         seek: {


### PR DESCRIPTION
When `seek()` is used with a `NaN` value, a very hard to debug error is generated somewhere deep in React Native, which makes it hard to find the cause of the error (especially when the seek value is the result of a calculation that goes wrong in some cases but not others):

<img width="355" alt="image" src="https://user-images.githubusercontent.com/1285584/46880370-5ab76f80-ce40-11e8-97ac-ca1b80524457.png">

This pull request improves this by throwing an error early, which makes the issue clearer and provides a stack trace in user space:

<img width="349" alt="image" src="https://user-images.githubusercontent.com/1285584/46880489-ab2ecd00-ce40-11e8-991f-ef172dd5b091.png">
