### PR TITLE
ExoPlayer: Don't stop playback when detaching

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -202,7 +202,10 @@ class ReactExoplayerView extends FrameLayout implements
     @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
-        stopPlayback();
+        /* We want to be able to continue playing audio when switching tabs.
+         * Leave this here in case it causes issues.
+         */
+        // stopPlayback();
     }
 
     // LifecycleEventListener implementation


### PR DESCRIPTION
This removes the code that stops playback when detaching. This was primarily happening when switching between tabs using react-navigation's TabNavigator. It prevented people from playing background audio.

On iOS, we don't pause playback when switching tabs (and I'm not sure it's possible to do that), so it makes sense to copy that behavior here and make things consistent. For Android MediaPlayer, not stopping playback will cause the video player to crash, so we have to maintain the existing behavior.

If people want to pause playback when switching tabs, they will need to use the hooks in react-navigation to do this.

Fixes #1124.