### PR TITLE
return cached asset

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -500,7 +500,7 @@ static int const RCTVideoUnset = -1;
                 if (cachedAsset) {
                     DebugLog(@"Playing back uri '%@' from cache", uri);
                     // See note in playerItemForSource about not being able to support text tracks & caching
-                    handler([AVPlayerItem playerItemWithAsset:asset]);
+                    handler([AVPlayerItem playerItemWithAsset:cachedAsset]);
                     return;
                 }
         }


### PR DESCRIPTION
This is a fix to @n1ru4l 's implementation of caching on iOS. 

I noticed when trying out the video caching example, that when turning wifi off (on the simulator at least), the video player was not playing the cached file. Upon further investigation, xcode gave an error about `asset` not being defined. I then noticed that it was checking whether `cachedAsset` exists, and then returning `asset`.

Returning `cachedAsset` instead of `asset` gave the desired result on the example application