### PR TITLE
Fix ExoPlayer: avoid stretching of HLS when aspect ratio changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Changelog
 
 ### Next Version
+
+* Fix ExoPlayer: avoid stretching of HLS when aspect ratio changes [#1302](https://github.com/react-native-community/react-native-video/pull/1302)
 * Partial support for timed metadata on Android MediaPlayer [#707](https://github.com/react-native-community/react-native-video/pull/707)
 * Support video caching for iOS [#955](https://github.com/react-native-community/react-native-video/pull/955)
 * Video caching cleanups [#1172](https://github.com/react-native-community/react-native-video/pull/1172)

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -205,9 +205,7 @@ public final class ExoPlayerView extends FrameLayout {
             layout.setAspectRatio(height == 0 ? 1 : (width * pixelWidthHeightRatio) / height);
 
             // React native workaround for measuring and layout on initial load.
-            if (isInitialRatio) {
-                post(measureAndLayout);
-            }
+            post(measureAndLayout);
         }
 
         @Override

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -201,10 +201,7 @@ public final class ExoPlayerView extends FrameLayout {
 
         @Override
         public void onVideoSizeChanged(int width, int height, int unappliedRotationDegrees, float pixelWidthHeightRatio) {
-            boolean isInitialRatio = layout.getAspectRatio() == 0;
             layout.setAspectRatio(height == 0 ? 1 : (width * pixelWidthHeightRatio) / height);
-
-            // React native workaround for measuring and layout on initial load.
             post(measureAndLayout);
         }
 


### PR DESCRIPTION
The ExoPlayer implementation was not properly handling anamorphic HLS playlists, i.e. videos that change size or aspect ratio during playback.  iOS already handled this complexity fine.

Here is an HLS that exhibits this anamorphic behavior:  
https://hls.ted.com/talks/93.m3u8

## before fix
https://hls.ted.com/talks/93.m3u8
![stretched-video](https://user-images.githubusercontent.com/399135/47458786-71e34f00-d7a8-11e8-8143-c3809190ae85.gif)

## after fix
![fixed-stretch-video](https://user-images.githubusercontent.com/399135/47459193-7f4d0900-d7a9-11e8-8b66-83837c82f7b5.gif)

Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

#### Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

#### Update the changelog
After you open the PR, update the CHANGELOG.md file with an entry pointing to your PR.

#### Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

#### Focus the PR on only one area
Testing multiple features takes longer than isolated changes and if there is a bug in one feature, prevents the other parts of your PR from getting merged until it gets fixed.
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

#### Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
