### PR TITLE
restored autorotate to fullscreen options

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ var styles = StyleSheet.create({
 * [bufferConfig](#bufferconfig)
 * [controls](#controls)
 * [fullscreen](#fullscreen)
+* [fullscreenAutorotate](#fullscreenautorotate)
 * [fullscreenOrientation](#fullscreenorientation)
 * [headers](#headers)
 * [id](#id)
@@ -355,6 +356,11 @@ Platforms: iOS, react-native-dom
 Controls whether the player enters fullscreen on play.
 * **false (default)** - Don't display the video in fullscreen
 * **true** - Display the video in fullscreen
+
+Platforms: iOS
+
+#### fullscreenAutorotate
+If a preferred [fullscreenOrientation](#fullscreenorientation) is set, causes the video to rotate to that orientation but permits rotation of the screen to orientation held by user. Defaults to TRUE.
 
 Platforms: iOS
 

--- a/Video.js
+++ b/Video.js
@@ -354,6 +354,7 @@ Video.propTypes = {
   controls: PropTypes.bool,
   audioOnly: PropTypes.bool,
   currentTime: PropTypes.number,
+  fullscreenAutorotate: PropTypes.bool,
   fullscreenOrientation: PropTypes.oneOf(['all','landscape','portrait']),
   progressUpdateInterval: PropTypes.number,
   useTextureView: PropTypes.bool,

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -64,6 +64,7 @@ static int const RCTVideoUnset = -1;
   NSString * _ignoreSilentSwitch;
   NSString * _resizeMode;
   BOOL _fullscreen;
+  BOOL _fullscreenAutorotate;
   NSString * _fullscreenOrientation;
   BOOL _fullscreenPlayerPresented;
   UIViewController * _presentingViewController;
@@ -83,6 +84,7 @@ static int const RCTVideoUnset = -1;
     _rate = 1.0;
     _volume = 1.0;
     _resizeMode = @"AVLayerVideoGravityResizeAspectFill";
+    _fullscreenAutorotate = YES;
     _fullscreenOrientation = @"all";
     _pendingSeek = false;
     _pendingSeekTime = 0.0f;
@@ -1136,6 +1138,7 @@ static int const RCTVideoUnset = -1;
       [viewController presentViewController:_playerViewController animated:true completion:^{
         _playerViewController.showsPlaybackControls = YES;
         _fullscreenPlayerPresented = fullscreen;
+        _playerViewController.autorotate = _fullscreenAutorotate;
         if(self.onVideoFullscreenPlayerDidPresent) {
           self.onVideoFullscreenPlayerDidPresent(@{@"target": self.reactTag});
         }
@@ -1148,6 +1151,13 @@ static int const RCTVideoUnset = -1;
     [_presentingViewController dismissViewControllerAnimated:true completion:^{
       [self videoPlayerViewControllerDidDismiss:_playerViewController];
     }];
+  }
+}
+
+- (void)setFullscreenAutorotate:(BOOL)autorotate {
+  _fullscreenAutorotate = autorotate;
+  if (_fullscreenPlayerPresented) {
+    _playerViewController.autorotate = autorotate;
   }
 }
 

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -37,6 +37,7 @@ RCT_EXPORT_VIEW_PROPERTY(rate, float);
 RCT_EXPORT_VIEW_PROPERTY(seek, NSDictionary);
 RCT_EXPORT_VIEW_PROPERTY(currentTime, float);
 RCT_EXPORT_VIEW_PROPERTY(fullscreen, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(fullscreenAutorotate, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(fullscreenOrientation, NSString);
 RCT_EXPORT_VIEW_PROPERTY(progressUpdateInterval, float);
 /* Should support: onLoadStart, onLoad, and onError to stay consistent with Image */

--- a/ios/Video/RCTVideoPlayerViewController.h
+++ b/ios/Video/RCTVideoPlayerViewController.h
@@ -15,5 +15,6 @@
 
 // Optional paramters
 @property (nonatomic, weak) NSString* preferredOrientation;
+@property (nonatomic) BOOL autorotate;
 
 @end

--- a/ios/Video/RCTVideoPlayerViewController.m
+++ b/ios/Video/RCTVideoPlayerViewController.m
@@ -7,7 +7,8 @@
 @implementation RCTVideoPlayerViewController
 
 - (BOOL)shouldAutorotate {
-  if (self.preferredOrientation.lowercaseString == nil || [self.preferredOrientation.lowercaseString isEqualToString:@"all"])
+
+  if (self.autorotate || self.preferredOrientation.lowercaseString == nil || [self.preferredOrientation.lowercaseString isEqualToString:@"all"])
     return YES;
   
   return NO;


### PR DESCRIPTION
Restores the fullscreen autorotate variable back to the codebase.  By default, autorotate is true for fullscreen.