### PR TITLE
disable airplay when sideloaded captions

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,8 @@ uri | URL for the text track. Currently, only tracks hosted on a webserver are s
 
 On iOS, sidecar text tracks are only supported for individual files, not HLS playlists. For HLS, you should include the text tracks as part of the playlist.
 
+NOTE:  Due to iOS limitations, sidecar textTracks are not available for Airplay. If textTracks are specified for video that is airplayed, the visual content of the video is disabled (only audio will stream).
+
 Example:
 ```
 import { TextTrackType }, Video from 'react-native-video';

--- a/README.md
+++ b/README.md
@@ -603,7 +603,7 @@ uri | URL for the text track. Currently, only tracks hosted on a webserver are s
 
 On iOS, sidecar text tracks are only supported for individual files, not HLS playlists. For HLS, you should include the text tracks as part of the playlist.
 
-NOTE:  Due to iOS limitations, sidecar textTracks are not available for Airplay. If textTracks are specified for video that is airplayed, the visual content of the video is disabled (only audio will stream).
+Note: Due to iOS limitations, sidecar text tracks are not compatible with Airplay. If textTracks are specified, AirPlay support will be automatically disabled.
 
 Example:
 ```

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -397,10 +397,13 @@ static int const RCTVideoUnset = -1;
 
 - (void)playerItemPrepareText:(AVAsset *)asset assetOptions:(NSDictionary * __nullable)assetOptions withCallback:(void(^)(AVPlayerItem *))handler
 {
-  if (!_textTracks) {
+  if (!_textTracks || _textTracks.count==0) {
     handler([AVPlayerItem playerItemWithAsset:asset]);
     return;
   }
+  
+  // AVPlayer can't airplay AVMutableCompositions
+  _allowsExternalPlayback = NO;
 
   // sideload text tracks
   AVMutableComposition *mixComposition = [[AVMutableComposition alloc] init];


### PR DESCRIPTION
For sideloaded captions on iOS, we have to use an AVMutableComposition.  Unfortunately AVMutableComposition is not playable on Airplay.  This code turns off video playback (sets external playback to false).

Additional check on textTracks also returns the default AVPlayerItem if textTracks is not null, but is empty.