### PR TITLE
Fix: volume should not change on onAudioFocusChange event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add fullscreenOrientation option for iOS [#1215](https://github.com/react-native-community/react-native-video/pull/1215)
 * Update to ExoPlayer 2.9.0 [#1285](https://github.com/react-native-community/react-native-video/pull/1285)
 * Switch useTextureView to default to `true` [#1286](https://github.com/react-native-community/react-native-video/pull/1286)
+* Fix: volume should not change on onAudioFocusChange event [#1327](https://github.com/react-native-community/react-native-video/pull/1327)
 
 ### Version 3.2.0
 * Basic fullscreen support for Android MediaPlayer [#1138](https://github.com/react-native-community/react-native-video/pull/1138)

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -109,6 +109,7 @@ class ReactExoplayerView extends FrameLayout implements
     private boolean isPaused;
     private boolean isBuffering;
     private float rate = 1f;
+    private float audioVolume = 1f;
 
     private int minBufferMs = DefaultLoadControl.DEFAULT_MIN_BUFFER_MS;
     private int maxBufferMs = DefaultLoadControl.DEFAULT_MAX_BUFFER_MS;
@@ -454,10 +455,10 @@ class ReactExoplayerView extends FrameLayout implements
         if (player != null) {
             if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
                 // Lower the volume
-                player.setVolume(0.8f);
+                player.setVolume(audioVolume * 0.8f);
             } else if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
                 // Raise it back to normal
-                player.setVolume(1);
+                player.setVolume(audioVolume * 1);
             }
         }
     }
@@ -875,15 +876,17 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     public void setMutedModifier(boolean muted) {
+        audioVolume = muted ? 0.f : 1.f;
         if (player != null) {
-            player.setVolume(muted ? 0 : 1);
+            player.setVolume(audioVolume);
         }
     }
 
 
     public void setVolumeModifier(float volume) {
+        audioVolume = volume;
         if (player != null) {
-            player.setVolume(volume);
+            player.setVolume(audioVolume);
         }
     }
 


### PR DESCRIPTION
#### Update the documentation
Not a new feature

#### Update the changelog
Updated.

#### Provide an example of how to test the change
1. Set muted property to "true" or volume to anything other than 1.f
2. Play the video, make the audio focus change (e.g. other notification sound playing)
Result: volume is set to 0.8f for a while and then resets to 1.0f
Expected: volume should set to 0.8 of current volume, and then get back to previous volume

#### Describe the changes
I'm saving current volume in a field, and make audio focus change listener use the current volume value instead of harcoded levels.
