### PR TITLE
solve the memory leak on Android and avoid the crash on kitkat

### DIFF
--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -232,11 +232,18 @@ public class ReactVideoView extends ScalableVideoView implements
             mediaController.hide();
         }
         if ( mMediaPlayer != null ) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                mMediaPlayer.setOnTimedMetaDataAvailableListener(null);
+            }
             mMediaPlayerValid = false;
             release();
         }
         if (mIsFullscreen) {
             setFullscreen(false);
+        }
+        if (mThemedReactContext != null) {
+            mThemedReactContext.removeLifecycleEventListener(this);
+            mThemedReactContext = null;
         }
     }
 
@@ -565,7 +572,10 @@ public class ReactVideoView extends ScalableVideoView implements
         }
 
         // Select track (so we can use it to listen to timed meta data updates)
-        mp.selectTrack(0);
+        try{
+            mp.selectTrack(0);
+        }catch (Throwable t){
+        }
     }
 
     @Override
@@ -601,7 +611,10 @@ public class ReactVideoView extends ScalableVideoView implements
     @Override
     public void onBufferingUpdate(MediaPlayer mp, int percent) {
         // Select track (so we can use it to listen to timed meta data updates)
-        mp.selectTrack(0);
+        try{
+            mp.selectTrack(0);
+        }catch (Throwable t){
+        }
 
         mVideoBufferedDuration = (int) Math.round((double) (mVideoDuration * percent) / 100.0);
     }

--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -571,11 +571,7 @@ public class ReactVideoView extends ScalableVideoView implements
             });
         }
 
-        // Select track (so we can use it to listen to timed meta data updates)
-        try{
-            mp.selectTrack(0);
-        }catch (Throwable t){
-        }
+        selectTimedMetadataTrack(mp);
     }
 
     @Override
@@ -610,12 +606,7 @@ public class ReactVideoView extends ScalableVideoView implements
 
     @Override
     public void onBufferingUpdate(MediaPlayer mp, int percent) {
-        // Select track (so we can use it to listen to timed meta data updates)
-        try{
-            mp.selectTrack(0);
-        }catch (Throwable t){
-        }
-
+        selectTimedMetadataTrack(mp);
         mVideoBufferedDuration = (int) Math.round((double) (mVideoDuration * percent) / 100.0);
     }
 
@@ -767,5 +758,21 @@ public class ReactVideoView extends ScalableVideoView implements
         }
 
         return result;
+    }
+        
+    // Select track (so we can use it to listen to timed meta data updates)
+    private void selectTimedMetadataTrack(MediaPlayer mp) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return;
+        }
+        try {
+            MediaPlayer.TrackInfo[] trackInfo = mp.getTrackInfo();
+            for (int i = 0; i < trackInfo.length; ++i) {
+                if (trackInfo[i].getTrackType() == MediaPlayer.TrackInfo.MEDIA_TRACK_TYPE_TIMEDTEXT) {
+                    mp.selectTrack(i);
+                    break;
+                }
+            }
+        } catch (Exception e) {}
     }
 }

--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -765,7 +765,7 @@ public class ReactVideoView extends ScalableVideoView implements
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             return;
         }
-        try {
+        try { // It's possible this could throw an exception if the framework doesn't support getting track info
             MediaPlayer.TrackInfo[] trackInfo = mp.getTrackInfo();
             for (int i = 0; i < trackInfo.length; ++i) {
                 if (trackInfo[i].getTrackType() == MediaPlayer.TrackInfo.MEDIA_TRACK_TYPE_TIMEDTEXT) {


### PR DESCRIPTION
Solve the memory leak on Android and avoid the crash on Xiaomi Phone M4's kitkat rom when call mp.selectTrack(0);