### PR TITLE
make the SHOW_PROGRESS as a single event

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -151,6 +151,7 @@ class ReactExoplayerView extends FrameLayout implements
                         long bufferedDuration = player.getBufferedPercentage() * player.getDuration() / 100;
                         eventEmitter.progressChanged(pos, bufferedDuration, player.getDuration());
                         msg = obtainMessage(SHOW_PROGRESS);
+                        removeMessages(SHOW_PROGRESS);
                         sendMessageDelayed(msg, Math.round(mProgressUpdateInterval));
                     }
                     break;


### PR DESCRIPTION
#### Provide an example of how to test the change

Like below React-Native source code

```
....
render() {
<Video .... />
}
show_progress_test = () => {
    this.setState({test_progress: !test_progress});
}
....
```

**React-Native(render) --> Video component refresh --> `ExoPlayer.STATE_READY` comming --> `sendEmptyMessage(SHOW_PROGRESS)`**

the `SHOW_PROGRESS` event count **in**  `progressHandler`  was increased , 
and there are many `handleMessage`  was called.  and this may be caused  OOM issue 

#### Describe the changes
make the SHOW_PROGRESS as a single event
