### PR TITLE
Manual Installation (iOS) - Update onVideoSaved

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -321,6 +321,7 @@ Video.propTypes = {
   onVideoFullscreenPlayerDidPresent: PropTypes.func,
   onVideoFullscreenPlayerWillDismiss: PropTypes.func,
   onVideoFullscreenPlayerDidDismiss: PropTypes.func,
+  onVideoSaved: PropTypes.func,
 
   /* Wrapper component */
   source: PropTypes.oneOfType([


### PR DESCRIPTION
this missing proptype was throwing an error with the packager, not sure if this is because I elected to manually install instead of taking the cocoa pods route. in either case, there is an onVideoSaved method declaration in RCTVideoManager that I cant seem to find anywhere else (in the docs or Video.js)