### PR TITLE
Remove unused onVideoSaved event

### DIFF
--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -59,7 +59,6 @@ RCT_EXPORT_VIEW_PROPERTY(onPlaybackStalled, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onPlaybackResume, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onPlaybackRateChange, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoExternalPlaybackChange, RCTBubblingEventBlock);
-RCT_EXPORT_VIEW_PROPERTY(onVideoSaved, RCTBubblingEventBlock);
 RCT_REMAP_METHOD(save,
         options:(NSDictionary *)options
         reactTag:(nonnull NSNumber *)reactTag


### PR DESCRIPTION
This was included in the save support PR and looks to be some leftover code that didn't up being used in the final version, so it's safe to remove. Pointed out in #1346