### PR TITLE
ExoPlayer - Add possibility to hide shutterView (black screen while loading)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Version 4.0.1
 * Add missing files to package.json [#1342](https://github.com/react-native-community/react-native-video/pull/1342)
+* Add possibility to remove black screen while video is loading in Exoplayer [#1355](https://github.com/react-native-community/react-native-video/pull/1355)
 
 ### Version 4.0.0
 * Partial support for timed metadata on Android MediaPlayer [#707](https://github.com/react-native-community/react-native-video/pull/707)

--- a/README.md
+++ b/README.md
@@ -419,10 +419,10 @@ headers={{
 Platforms: Android ExoPlayer
 
 #### hideShutterView
-Controls ExoPlayer shutterView(black screen while loading) visibility
+Controls whether the ExoPlayer shutter view (black screen while loading) is enabled.
 
-* **false (default)** - Show shutterView 
-* **true** - Hide shutterView
+* **false (default)** - Show shutter view 
+* **true** - Hide shutter view
 
 Platforms: Android ExoPlayer
 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ var styles = StyleSheet.create({
 * [fullscreenAutorotate](#fullscreenautorotate)
 * [fullscreenOrientation](#fullscreenorientation)
 * [headers](#headers)
+* [hideShutterView](#hideshutterview)
 * [id](#id)
 * [ignoreSilentSwitch](#ignoresilentswitch)
 * [muted](#muted)
@@ -282,7 +283,6 @@ var styles = StyleSheet.create({
 * [stereoPan](#stereopan)
 * [textTracks](#texttracks)
 * [useTextureView](#usetextureview)
-* [hideShutterView](#hideshutterview)
 * [volume](#volume)
 
 ### Event props
@@ -415,6 +415,14 @@ headers={{
   'X-Custom-Header': 'some value'
 }}
 ```
+
+Platforms: Android ExoPlayer
+
+#### hideShutterView
+Controls ExoPlayer shutterView(black screen while loading) visibility
+
+* **false (default)** - Show shutterView 
+* **true** - Hide shutterView
 
 Platforms: Android ExoPlayer
 
@@ -691,14 +699,6 @@ useTextureView can only be set at same time you're setting the source.
 
 * **true (default)** - Use a TextureView
 * **false** - Use a SurfaceView
-
-Platforms: Android ExoPlayer
-
-#### hideShutterView
-Controls ExoPlayer shutterView(black screen while loading) visibility
-
-* **false (default)** - Show shutterView 
-* **true** - Hide shutterView
 
 Platforms: Android ExoPlayer
 

--- a/README.md
+++ b/README.md
@@ -693,6 +693,14 @@ useTextureView can only be set at same time you're setting the source.
 
 Platforms: Android ExoPlayer
 
+#### hideShutterView
+Controls ExoPlayer shutterView(black screen while loading) visibility
+
+* **false (default)** - Show shutterView 
+* **true** - Hide shutterView
+
+Platforms: Android ExoPlayer
+
 #### volume
 Adjust the volume.
 * **1.0 (default)** - Play at full volume

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ var styles = StyleSheet.create({
 * [stereoPan](#stereopan)
 * [textTracks](#texttracks)
 * [useTextureView](#usetextureview)
+* [hideShutterView](#hideshutterview)
 * [volume](#volume)
 
 ### Event props

--- a/Video.js
+++ b/Video.js
@@ -383,6 +383,7 @@ Video.propTypes = {
   fullscreenOrientation: PropTypes.oneOf(['all','landscape','portrait']),
   progressUpdateInterval: PropTypes.number,
   useTextureView: PropTypes.bool,
+  hideShutterView: PropTypes.bool,
   onLoadStart: PropTypes.func,
   onLoad: PropTypes.func,
   onBuffer: PropTypes.func,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -39,6 +39,7 @@ public final class ExoPlayerView extends FrameLayout {
     private ViewGroup.LayoutParams layoutParams;
 
     private boolean useTextureView = false;
+    private boolean hideShutterView = false;
 
     public ExoPlayerView(Context context) {
         this(context, null);
@@ -106,6 +107,10 @@ public final class ExoPlayerView extends FrameLayout {
         }
     }
 
+    private void updateShutterViewVisibility() {
+        shutterView.setVisibility(this.hideShutterView ? View.INVISIBLE : View.VISIBLE);
+    }
+
     /**
      * Set the {@link SimpleExoPlayer} to use. The {@link SimpleExoPlayer#setTextOutput} and
      * {@link SimpleExoPlayer#setVideoListener} method of the player will be called and previous
@@ -159,6 +164,11 @@ public final class ExoPlayerView extends FrameLayout {
     public void setUseTextureView(boolean useTextureView) {
         this.useTextureView = useTextureView;
         updateSurfaceView();
+    }
+
+    public void setHideShutterView(boolean hideShutterView) {
+        this.hideShutterView = hideShutterView;
+        updateShutterViewVisibility();
     }
 
     private final Runnable measureAndLayout = new Runnable() {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -131,6 +131,7 @@ class ReactExoplayerView extends FrameLayout implements
     private float mProgressUpdateInterval = 250.0f;
     private boolean playInBackground = false;
     private boolean useTextureView = false;
+    private boolean hideShutterView = false;
     private Map<String, String> requestHeaders;
     // \ End props
 
@@ -952,6 +953,10 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setUseTextureView(boolean useTextureView) {
         exoPlayerView.setUseTextureView(useTextureView);
+    }
+
+    public void setHideShutterView(boolean hideShutterView) {
+        exoPlayerView.setHideShutterView(hideShutterView);
     }
 
     public void setBufferConfig(int newMinBufferMs, int newMaxBufferMs, int newBufferForPlaybackMs, int newBufferForPlaybackAfterRebufferMs) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -51,6 +51,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_DISABLE_FOCUS = "disableFocus";
     private static final String PROP_FULLSCREEN = "fullscreen";
     private static final String PROP_USE_TEXTURE_VIEW = "useTextureView";
+    private static final String PROP_HIDE_SHUTTER_VIEW = "hideShutterView";
 
     @Override
     public String getName() {
@@ -218,6 +219,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_USE_TEXTURE_VIEW, defaultBoolean = true)
     public void setUseTextureView(final ReactExoplayerView videoView, final boolean useTextureView) {
         videoView.setUseTextureView(useTextureView);
+    }
+
+    @ReactProp(name = PROP_HIDE_SHUTTER_VIEW, defaultBoolean = false)
+    public void setHideShutterView(final ReactExoplayerView videoView, final boolean hideShutterView) {
+        videoView.setHideShutterView(hideShutterView);
     }
 
     @ReactProp(name = PROP_BUFFER_CONFIG)


### PR DESCRIPTION
The purpose of this PR is similar to https://github.com/react-native-community/react-native-video/pull/783, it adds possibility to remove black screen in ExoPlayer while it's rendering first frame, but I made this option configurable via `hideShutterView` prop