### PR TITLE
[WIP] Fix android subtitle issue caused by using rawdatasource

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -731,7 +731,7 @@ class ReactExoplayerView extends FrameLayout implements
 
             this.srcUri = uri;
             this.extension = extension;
-            this.mediaDataSourceFactory = DataSourceUtil.getRawDataSourceFactory(this.themedReactContext);
+            this.mediaDataSourceFactory = buildDataSourceFactory(true);
 
             if (!isOriginalSourceNull && !isSourceEqual) {
                 reloadSource();


### PR DESCRIPTION
I could reproduce the issue described in #1371 and fixed the issue. I'm not sure if this breaks some other functionality.

When testing, I received the following error message:

```
E/ExoPlayerImplInternal( 5534): Source error.
E/ExoPlayerImplInternal( 5534): com.google.android.exoplayer2.upstream.RawResourceDataSource$RawResourceDataSourceException: com.google.android.exoplayer2.upstream.RawResourceDataSource$RawResourceDataSourceException: URI must use scheme rawresource
```
Tested on Android Emulator API 28 and 18. Release and Debug builds.

Project used: [https://github.com/reime005/VideoPlayerTest](https://github.com/reime005/VideoPlayerTest)

Fixes issue #1371