### PR TITLE
Exoplayer drm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ var styles = StyleSheet.create({
 * [textTracks](#texttracks)
 * [useTextureView](#usetextureview)
 * [volume](#volume)
+* [drm](#drm)
 
 ### Event props
 * [onAudioBecomingNoisy](#onaudiobecomingnoisy)
@@ -664,6 +665,19 @@ Adjust the volume.
 * **Other values** - Reduce volume
 
 Platforms: all
+
+#### drm
+To configure DRM it is necessary to add the poperties
+drmName="widevine"
+            drmUrl={playerInfo.license}
+            drmHeader={headers}
+`drmName` Which is the DRM type. It can take a value of these DRM's
+* **widevine**
+* **playready**
+* **cenc**
+
+`drmUrl` Which is the license server URL
+`drmHeader` Which are the DRM custom headers.
 
 ### Event props
 

--- a/README.md
+++ b/README.md
@@ -674,7 +674,8 @@ To configure DRM it is necessary to add the poperties:
 * **playready**
 * **cenc**
 
-`drmUrl` Which is the license server URL
+`drmUrl` Which is the license server URL.
+
 `drmHeader` Which are the DRM custom headers.
 
 Platforms: Android ExoPlayer

--- a/README.md
+++ b/README.md
@@ -667,17 +667,17 @@ Adjust the volume.
 Platforms: all
 
 #### drm
-To configure DRM it is necessary to add the poperties
-drmName="widevine"
-            drmUrl={playerInfo.license}
-            drmHeader={headers}
-`drmName` Which is the DRM type. It can take a value of these DRM's
+To configure DRM it is necessary to add the poperties:
+
+`drmName` Which is the DRM type. It can take a value of these DRM's:
 * **widevine**
 * **playready**
 * **cenc**
 
 `drmUrl` Which is the license server URL
 `drmHeader` Which are the DRM custom headers.
+
+Platforms: Android ExoPlayer
 
 ### Event props
 

--- a/Video.js
+++ b/Video.js
@@ -26,17 +26,17 @@ export default class Video extends Component {
   setNativeProps(nativeProps) {
     this._root.setNativeProps(nativeProps);
   }
-  
+
   toTypeString(x) {
     switch (typeof x) {
       case "object":
-        return x instanceof Date 
-          ? x.toISOString() 
+        return x instanceof Date
+          ? x.toISOString()
           : JSON.stringify(x); // object, null
       case "undefined":
         return "";
       default: // boolean, number, string
-        return x.toString();      
+        return x.toString();
     }
   }
 
@@ -172,7 +172,7 @@ export default class Video extends Component {
       this.props.onPlaybackRateChange(event.nativeEvent);
     }
   };
-  
+
   _onExternalPlaybackChange = (event) => {
     if (this.props.onExternalPlaybackChange) {
       this.props.onExternalPlaybackChange(event.nativeEvent);
@@ -339,6 +339,9 @@ Video.propTypes = {
   paused: PropTypes.bool,
   muted: PropTypes.bool,
   volume: PropTypes.number,
+  drmUrl: PropTypes.string,
+  drmName: PropTypes.string,
+  drmHeader: PropTypes.object,
   bufferConfig: PropTypes.shape({
     minBufferMs: PropTypes.number,
     maxBufferMs: PropTypes.number,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -273,9 +273,7 @@ class ReactExoplayerView extends FrameLayout implements
                     return;
                 }
             }
-            DefaultRenderersFactory renderersFactory = new DefaultRenderersFactory(getContext(),
-                drmSessionManager, DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF);
-            player = ExoPlayerFactory.newSimpleInstance(renderersFactory, trackSelector, defaultLoadControl);
+            player = ExoPlayerFactory.newSimpleInstance(getContext(), trackSelector, defaultLoadControl, drmSessionManager);
             player.addListener(this);
             player.setMetadataOutput(this);
             exoPlayerView.setPlayer(player);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -328,7 +328,7 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private HttpDataSource.Factory buildHttpDataSourceFactory(boolean useBandwidthMeter) {
-        return new DefaultHttpDataSourceFactory("sctv", useBandwidthMeter ? BANDWIDTH_METER : null);
+        return new DefaultHttpDataSourceFactory("ExoPlayer/2.0.18 (Linux;Android 7.0) ExoPlayerLib/2.2.0", useBandwidthMeter ? BANDWIDTH_METER : null);
     }
 
     private MediaSource buildMediaSource(Uri uri, String overrideExtension) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -326,6 +326,7 @@ class ReactExoplayerView extends FrameLayout implements
         return new DefaultDrmSessionManager<>(uuid,
                 FrameworkMediaDrm.newInstance(uuid), drmCallback, null, mainHandler, this);
     }
+
     private HttpDataSource.Factory buildHttpDataSourceFactory(boolean useBandwidthMeter) {
         return new DefaultHttpDataSourceFactory("sctv", useBandwidthMeter ? BANDWIDTH_METER : null);
     }
@@ -998,6 +999,7 @@ class ReactExoplayerView extends FrameLayout implements
 
     @Override
     public void onDrmSessionManagerError(Exception e) {
+        Log.e("DRM Error", "exception", e);
         Log.d("DRM Info", "onDrmSessionManagerError");
     }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -3,10 +3,12 @@ package com.brentvatne.exoplayer;
 import android.content.Context;
 import android.net.Uri;
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
@@ -15,6 +17,7 @@ import com.google.android.exoplayer2.DefaultLoadControl;
 import com.google.android.exoplayer2.upstream.RawResourceDataSource;
 
 import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.Map;
 
 import javax.annotation.Nullable;
@@ -48,6 +51,9 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SEEK = "seek";
     private static final String PROP_RATE = "rate";
     private static final String PROP_PLAY_IN_BACKGROUND = "playInBackground";
+    private static final String PROP_DRM_LICENSE_URL = "drmUrl";
+    private static final String PROP_DRM_LICENSE_HEADER = "drmHeader";
+    private static final String PROP_DRM_NAME = "drmName";
     private static final String PROP_DISABLE_FOCUS = "disableFocus";
     private static final String PROP_FULLSCREEN = "fullscreen";
     private static final String PROP_USE_TEXTURE_VIEW = "useTextureView";
@@ -236,6 +242,34 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
             bufferForPlaybackAfterRebufferMs = bufferConfig.hasKey(PROP_BUFFER_CONFIG_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS)
                     ? bufferConfig.getInt(PROP_BUFFER_CONFIG_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS) : bufferForPlaybackAfterRebufferMs;
             videoView.setBufferConfig(minBufferMs, maxBufferMs, bufferForPlaybackMs, bufferForPlaybackAfterRebufferMs);
+        }
+    }
+
+    @ReactProp(name = PROP_DRM_LICENSE_URL)
+    public void setDrmUrl(final ReactExoplayerView videoView, @Nullable String licenseUrl){
+        Log.d("setDrmUrl", licenseUrl);
+        videoView.setDrmLicenseUrl(licenseUrl);
+    }
+
+    @ReactProp(name = PROP_DRM_LICENSE_HEADER)
+    public void setDrmHeader(final ReactExoplayerView videoView, @Nullable ReadableMap headers){
+        ArrayList<String> drmKeyRequestPropertiesList = new ArrayList<>();
+        ReadableMapKeySetIterator itr = headers.keySetIterator();
+        while (itr.hasNextKey()) {
+            String key = itr.nextKey();
+            drmKeyRequestPropertiesList.add(key);
+            drmKeyRequestPropertiesList.add(headers.getString(key));
+        }
+        videoView.setDrmLicenseHeader(drmKeyRequestPropertiesList.toArray(new String[0]));
+    }
+    
+    @ReactProp(name = PROP_DRM_NAME)
+    public void setDrmName(final ReactExoplayerView videoView, final String drmName){
+        try {
+            videoView.setDrmName(drmName);
+        }
+        catch (Exception ex){
+            Log.e("DRM Info", ex.toString());
         }
     }
 

--- a/android-exoplayer/src/main/res/values/strings.xml
+++ b/android-exoplayer/src/main/res/values/strings.xml
@@ -11,4 +11,10 @@
 
   <string name="unrecognized_media_format">Unrecognized media format</string>
 
+  <string name="error_drm_not_supported">Protected content not supported on API levels below 18</string>
+
+  <string name="error_drm_unsupported_scheme">This device does not support the required DRM scheme</string>
+
+  <string name="error_drm_unknown">An unknown DRM error occurred</string>
+
 </resources>


### PR DESCRIPTION
This adds DRM support for Android Exoplayer, for widevine playready and cenc. 

To use this it is necessary to add these three properties:
`drmName` which determines the DRM type.
`drmUrl` which takes the license server URL.
`drmHeader` which takes custom headers for the DRM implementation.

Here is a usage example.

```
<Video 
    source={{uri}} 
    onBuffer={this.onBuffer} 
    onError={this.videoError}
    style={styles.backgroundVideo}
    drmName="widevine"
    drmUrl={licenseServer}
    drmHeader={headers}
/>
```

You can test with dashjs custom DRM implementation:

widevine: https://github.com/Dash-Industry-Forum/dash.js/blob/development/samples/drm/widevine.html

playready: https://github.com/Dash-Industry-Forum/dash.js/blob/development/samples/drm/playready.html