### PR TITLE
Fix bug where useTextureView wasn't defaulting to true

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -38,7 +38,7 @@ public final class ExoPlayerView extends FrameLayout {
     private Context context;
     private ViewGroup.LayoutParams layoutParams;
 
-    private boolean useTextureView = false;
+    private boolean useTextureView = true;
     private boolean hideShutterView = false;
 
     public ExoPlayerView(Context context) {
@@ -162,8 +162,10 @@ public final class ExoPlayerView extends FrameLayout {
     }
 
     public void setUseTextureView(boolean useTextureView) {
-        this.useTextureView = useTextureView;
-        updateSurfaceView();
+        if (useTextureView != this.useTextureView) {
+            this.useTextureView = useTextureView;
+            updateSurfaceView();
+        }
     }
 
     public void setHideShutterView(boolean hideShutterView) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -131,8 +131,6 @@ class ReactExoplayerView extends FrameLayout implements
     private boolean disableFocus;
     private float mProgressUpdateInterval = 250.0f;
     private boolean playInBackground = false;
-    private boolean useTextureView = false;
-    private boolean hideShutterView = false;
     private Map<String, String> requestHeaders;
     // \ End props
 


### PR DESCRIPTION
In 4.0.0 we switched to useTextureView for ExoPlayer being true by default. However, I had thought setting the default value in ReactProp was sufficient to do this but setUseTextureView never got called. Instead we need to change the default value stored in the view.

Many thanks to @gcottrell1 for reporting this problem.