### PR TITLE
Videos Without Text Tracks Should Be Cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## Changelog
 
-### Version 4.2.1
-* Fix cache being bypassed when no text tracks are passed.
-
 ### Version 4.2.0
 * Don't initialize filters on iOS unless a filter is set. This was causing a startup performance regression [#1360](https://github.com/react-native-community/react-native-video/pull/1360)
 * Support setting the maxBitRate [#1310](https://github.com/react-native-community/react-native-video/pull/1310)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### Version 4.2.1
+* Fix cache being bypassed when no text tracks are passed.
+
 ### Version 4.2.0
 * Don't initialize filters on iOS unless a filter is set. This was causing a startup performance regression [#1360](https://github.com/react-native-community/react-native-video/pull/1360)
 * Support setting the maxBitRate [#1310](https://github.com/react-native-community/react-native-video/pull/1310)

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -480,7 +480,7 @@ static int const RCTVideoUnset = -1;
     [assetOptions setObject:cookies forKey:AVURLAssetHTTPCookiesKey];
 
 #if __has_include(<react-native-video/RCTVideoCache.h>)
-    if (!_textTracks) {
+    if (_textTracks) {
       /* The DVURLAsset created by cache doesn't have a tracksWithMediaType property, so trying
        *  to bring in the text track code will crash. I suspect this is because the asset hasn't fully loaded.
        * Until this is fixed, we need to bypass caching when text tracks are specified.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "4.2.0",
+    "version": "4.2.1",
     "description": "A <Video /> element for react-native",
     "main": "Video.js",
     "license": "MIT",
@@ -36,7 +36,7 @@
     "dependencies": {
         "keymirror": "0.1.1",
         "prop-types": "^15.5.10",
-	"shaka-player": "2.4.4"
+        "shaka-player": "2.4.4"
     },
     "scripts": {
         "test": "node_modules/.bin/eslint *.js"
@@ -46,7 +46,7 @@
             "sourceDir": "./android-exoplayer"
         }
     },
-    "files":[
+    "files": [
         "android-exoplayer",
         "android",
         "dom",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "4.2.1",
+    "version": "4.2.2",
     "description": "A <Video /> element for react-native",
     "main": "Video.js",
     "license": "MIT",


### PR DESCRIPTION
The documentation and code logs both say that caching should be bypassed if there are text tracks, however the code says the opposite. This PR fixes such that caching works as expected when there are no text tracks.

In the code the if statement checks that there are NO text tracks:
https://github.com/react-native-community/react-native-video/blob/master/ios/Video/RCTVideo.m#L483

However the debug log inside the if statement says there ARE text tracks:
https://github.com/react-native-community/react-native-video/blob/master/ios/Video/RCTVideo.m#L488
