### PR TITLE
Fix iOS video not displaying after switching source

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -858,7 +858,7 @@ static int const RCTVideoUnset = -1;
 
 - (void)setMaxBitRate:(float) maxBitRate {
   _maxBitRate = maxBitRate;
-  [self applyModifiers];
+  _playerItem.preferredPeakBitRate = maxBitRate;
 }
 
 
@@ -872,8 +872,7 @@ static int const RCTVideoUnset = -1;
     [_player setMuted:NO];
   }
   
-  _playerItem.preferredPeakBitRate = _maxBitRate;
-  
+  [self setMaxBitRate:_maxBitRate];
   [self setSelectedAudioTrack:_selectedAudioTrack];
   [self setSelectedTextTrack:_selectedTextTrack];
   [self setResizeMode:_resizeMode];


### PR DESCRIPTION
Fixes #1394 

When switching videos on iOS the video loads but does not display. I tracked this down to:
https://github.com/react-native-community/react-native-video/pull/1310/files#diff-42e8804735be64e84d6dd1fb103210a1R861
where applying modifiers while setting the source causes us to lose the player layer and not display the new video. 

@ashnfb Please do your best to do extensive testing around switching sources & different video types before submitting PRs. We need to do everything we can to avoid regressions creeping into releases as this breaks apps for numerous developers. It ended up taking about an hour and a half to track this down which would be best spent on reviewing PRs & fixing bugs.

@n1ru4l heads up on regression