### PR TITLE
Fix Array Out of Bounds crash if no video tracks present

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -889,11 +889,13 @@ class ReactExoplayerView extends FrameLayout implements
         }
 
         if (groupIndex == C.INDEX_UNSET && trackType == C.TRACK_TYPE_VIDEO) { // Video auto
-            TrackGroup group = groups.get(0);
-            tracks = new int[group.length];
-            groupIndex = 0;
-            for (int j = 0; j < group.length; j++) {
-                tracks[j] = j;
+            if (groups.length != 0) {
+                TrackGroup group = groups.get(0);
+                tracks = new int[group.length];
+                groupIndex = 0;
+                for (int j = 0; j < group.length; j++) {
+                    tracks[j] = j;
+                }
             }
         } else if (groupIndex == C.INDEX_UNSET) {
             trackSelector.setParameters(disableParameters);


### PR DESCRIPTION
This was caused by the video track auto selection code assuming there was always a video track group. On audio only files, there is no video group so we get an out of bounds. The code now checks to ensure that group 0 actually exists.

In the multi-track videos I tested, auto-track selection works properly, but I'm not sure if there are any situations where you might have multiple video track groups. I believe this would only happen with an MP4 that has multiple embedded video streams.

Fixes #1408 
