### PR TITLE
Support for displaying controls in Android Exoplayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ Note on iOS, controls are always shown when in fullscreen mode.
 
 Controls are not available Android because the system does not provide a stock set of controls. You will need to build your own or use a package like [react-native-video-controls](https://github.com/itsnubix/react-native-video-controls) or [react-native-video-player](https://github.com/cornedor/react-native-video-player).
 
-Platforms: iOS, Android, react-native-dom
+Platforms: iOS, Android ExoPlayer, react-native-dom
 
 #### filter
 Add video filter

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ Note on iOS, controls are always shown when in fullscreen mode.
 
 Controls are not available Android because the system does not provide a stock set of controls. You will need to build your own or use a package like [react-native-video-controls](https://github.com/itsnubix/react-native-video-controls) or [react-native-video-player](https://github.com/cornedor/react-native-video-player).
 
-Platforms: iOS, react-native-dom
+Platforms: iOS, Android, react-native-dom
 
 #### filter
 Add video filter

--- a/README.md
+++ b/README.md
@@ -359,9 +359,9 @@ Determines whether to show player controls.
 
 Note on iOS, controls are always shown when in fullscreen mode.
 
-Controls are not available Android because the system does not provide a stock set of controls. You will need to build your own or use a package like [react-native-video-controls](https://github.com/itsnubix/react-native-video-controls) or [react-native-video-player](https://github.com/cornedor/react-native-video-player).
+For Android MediaPlayer, you will need to build your own controls or use a package like [react-native-video-controls](https://github.com/itsnubix/react-native-video-controls) or [react-native-video-player](https://github.com/cornedor/react-native-video-player).
 
-Platforms: iOS, Android ExoPlayer, react-native-dom
+Platforms: Android ExoPlayer, iOS, react-native-dom
 
 #### filter
 Add video filter

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -265,9 +265,9 @@ class ReactExoplayerView extends FrameLayout implements
      */
     private void togglePlayerControlVisibility() {
         if(playerControlView.isVisible()) {
-            playerControlView.setVisibility(INVISIBLE);
+            playerControlView.hide();
         } else {
-            playerControlView.setVisibility(VISIBLE);
+            playerControlView.show();
         }
     }
 
@@ -286,7 +286,7 @@ class ReactExoplayerView extends FrameLayout implements
 
         //Setting the player for the playerControlView
         playerControlView.setPlayer(player);
-        playerControlView.setVisibility(VISIBLE);
+        playerControlView.show();
 
         //Invoking onClick event for exoplayerView
         exoPlayerView.setOnClickListener(new OnClickListener() {
@@ -559,7 +559,7 @@ class ReactExoplayerView extends FrameLayout implements
                 videoLoaded();
                 //Setting the visibility for the playerControlView
                 if(playerControlView != null) {
-                    playerControlView.setVisibility(VISIBLE);
+                    playerControlView.show();
                 }
                 break;
             case ExoPlayer.STATE_ENDED:

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -64,7 +64,6 @@ import com.google.android.exoplayer2.upstream.BandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.util.MimeTypes;
 import com.google.android.exoplayer2.util.Util;
-//Import PlayerControlView
 import com.google.android.exoplayer2.ui.PlayerControlView;
 
 import java.net.CookieHandler;
@@ -98,7 +97,6 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private final VideoEventEmitter eventEmitter;
-    //Create playerControlView instance
     private PlayerControlView playerControlView;
     
     private Handler mainHandler;
@@ -274,9 +272,9 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     /**
-     * Initialising Player control
+     * Initializing Player control
      */
-    private void initialisePlayerControl() {
+    private void initializePlayerControl() {
         playerControlView = new PlayerControlView(getContext());
         LayoutParams layoutParams = new LayoutParams(
                 LayoutParams.MATCH_PARENT,
@@ -1107,8 +1105,8 @@ class ReactExoplayerView extends FrameLayout implements
      */
     public void setControls(boolean controls) {
         if(controls && (exoPlayerView != null)) {
-            //Initialise playerControlView
-            initialisePlayerControl();
+            //Initialize playerControlView
+            initializePlayerControl();
         }
     }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -98,6 +98,8 @@ class ReactExoplayerView extends FrameLayout implements
 
     private final VideoEventEmitter eventEmitter;
     private PlayerControlView playerControlView;
+    private View playPauseControlContainer;
+    private Player.EventListener eventListener;
     
     private Handler mainHandler;
     private ExoPlayerView exoPlayerView;
@@ -264,6 +266,7 @@ class ReactExoplayerView extends FrameLayout implements
      * Toggling the visibility of the player control view 
      */
     private void togglePlayerControlVisibility() {
+        reLayout(playerControlView);
         if(playerControlView.isVisible()) {
             playerControlView.hide();
         } else {
@@ -287,6 +290,7 @@ class ReactExoplayerView extends FrameLayout implements
         //Setting the player for the playerControlView
         playerControlView.setPlayer(player);
         playerControlView.show();
+        playPauseControlContainer = playerControlView.findViewById(R.id.exo_play_pause_container);
 
         //Invoking onClick event for exoplayerView
         exoPlayerView.setOnClickListener(new OnClickListener() {
@@ -295,6 +299,29 @@ class ReactExoplayerView extends FrameLayout implements
                 togglePlayerControlVisibility();
             }
         });
+
+        //Invoking onPlayerStateChanged event for Player
+        eventListener = new Player.EventListener() {
+            @Override
+            public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
+                reLayout(playPauseControlContainer);
+                player.removeListener(eventListener);
+            }
+        };
+        player.addListener(eventListener);
+    }
+
+    /**
+     * Update the layout
+     *
+     * This is a workaround for the open bug in react-native: https://github.com/facebook/react-native/issues/17968
+     * @param view  view needs to update layout
+     */
+    private void reLayout(View view) {
+        if(view == null) return;
+        view.measure(MeasureSpec.makeMeasureSpec(getMeasuredWidth(), MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(getMeasuredHeight(), MeasureSpec.EXACTLY));
+        view.layout(view.getLeft(), view.getTop(), view.getMeasuredWidth(), view.getMeasuredHeight());
     }
 
     private void initializePlayer() {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -281,11 +281,6 @@ class ReactExoplayerView extends FrameLayout implements
         if(playerControlView == null) {
             playerControlView = new PlayerControlView(getContext());
         }
-        LayoutParams layoutParams = new LayoutParams(
-                LayoutParams.MATCH_PARENT,
-                LayoutParams.MATCH_PARENT);
-        playerControlView.setLayoutParams(layoutParams);
-        addView(playerControlView, 1, layoutParams);
 
         //Setting the player for the playerControlView
         playerControlView.setPlayer(player);
@@ -305,10 +300,22 @@ class ReactExoplayerView extends FrameLayout implements
             @Override
             public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
                 reLayout(playPauseControlContainer);
+                //Remove this eventListener once its executed. since UI will work fine once after the reLayout is done
                 player.removeListener(eventListener);
             }
         };
         player.addListener(eventListener);
+    }
+
+    /**
+     * Adding Player control to the frame layout
+     */
+    private void addPlayerControl() {
+        LayoutParams layoutParams = new LayoutParams(
+                LayoutParams.MATCH_PARENT,
+                LayoutParams.MATCH_PARENT);
+        playerControlView.setLayoutParams(layoutParams);
+        addView(playerControlView, 1, layoutParams);
     }
 
     /**
@@ -369,6 +376,9 @@ class ReactExoplayerView extends FrameLayout implements
             eventEmitter.loadStart();
             loadVideoStarted = true;
         }
+
+        //Initializing the playerControlView
+        initializePlayerControl();
     }
 
     private MediaSource buildMediaSource(Uri uri, String overrideExtension) {
@@ -1135,8 +1145,8 @@ class ReactExoplayerView extends FrameLayout implements
      */
     public void setControls(boolean controls) {
          if(controls && (exoPlayerView != null)) {
-            //Initialize playerControlView
-            initializePlayerControl();
+             //adding the playerControlView
+             addPlayerControl();
         } else {
             if(getChildAt(1) instanceof PlayerControlView && (exoPlayerView != null)){
                 removeViewAt(1);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -275,7 +275,9 @@ class ReactExoplayerView extends FrameLayout implements
      * Initializing Player control
      */
     private void initializePlayerControl() {
-        playerControlView = new PlayerControlView(getContext());
+        if(playerControlView == null) {
+            playerControlView = new PlayerControlView(getContext());
+        }
         LayoutParams layoutParams = new LayoutParams(
                 LayoutParams.MATCH_PARENT,
                 LayoutParams.MATCH_PARENT);
@@ -284,6 +286,7 @@ class ReactExoplayerView extends FrameLayout implements
 
         //Setting the player for the playerControlView
         playerControlView.setPlayer(player);
+        playerControlView.setVisibility(VISIBLE);
 
         //Invoking onClick event for exoplayerView
         exoPlayerView.setOnClickListener(new OnClickListener() {
@@ -1104,9 +1107,13 @@ class ReactExoplayerView extends FrameLayout implements
      * @param controls  value of the controls prop passed from react-native
      */
     public void setControls(boolean controls) {
-        if(controls && (exoPlayerView != null)) {
+         if(controls && (exoPlayerView != null)) {
             //Initialize playerControlView
             initializePlayerControl();
+        } else {
+            if(getChildAt(1) instanceof PlayerControlView && (exoPlayerView != null)){
+                removeViewAt(1);
+            }
         }
     }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -64,6 +64,8 @@ import com.google.android.exoplayer2.upstream.BandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.util.MimeTypes;
 import com.google.android.exoplayer2.util.Util;
+//Import PlayerControlView
+import com.google.android.exoplayer2.ui.PlayerControlView;
 
 import java.net.CookieHandler;
 import java.net.CookieManager;
@@ -96,6 +98,8 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private final VideoEventEmitter eventEmitter;
+    //Create playerControlView instance
+    private PlayerControlView playerControlView;
     
     private Handler mainHandler;
     private ExoPlayerView exoPlayerView;
@@ -257,6 +261,41 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     // Internal methods
+
+    /**
+     * Toggling the visibility of the player control view 
+     */
+    private void togglePlayerControlVisibility() {
+        if(playerControlView.isVisible()) {
+            playerControlView.setVisibility(INVISIBLE);
+        } else {
+            playerControlView.setVisibility(VISIBLE);
+        }
+    }
+
+    /**
+     * Initialising Player control
+     */
+    private void initialisePlayerControl() {
+        playerControlView = new PlayerControlView(getContext());
+        LayoutParams layoutParams = new LayoutParams(
+                LayoutParams.MATCH_PARENT,
+                LayoutParams.MATCH_PARENT);
+        playerControlView.setLayoutParams(layoutParams);
+        addView(playerControlView, 1, layoutParams);
+
+        //Setting the player for the playerControlView
+        playerControlView.setPlayer(player);
+
+        //Invoking onClick event for exoplayerView
+        exoPlayerView.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                togglePlayerControlVisibility();
+            }
+        });
+    }
+
     private void initializePlayer() {
         if (player == null) {
             TrackSelection.Factory videoTrackSelectionFactory = new AdaptiveTrackSelection.Factory(BANDWIDTH_METER);
@@ -517,6 +556,10 @@ class ReactExoplayerView extends FrameLayout implements
                 onBuffering(false);
                 startProgressHandler();
                 videoLoaded();
+                //Setting the visibility for the playerControlView
+                if(playerControlView != null) {
+                    playerControlView.setVisibility(VISIBLE);
+                }
                 break;
             case ExoPlayer.STATE_ENDED:
                 text += "ended";
@@ -1055,5 +1098,17 @@ class ReactExoplayerView extends FrameLayout implements
         bufferForPlaybackAfterRebufferMs = newBufferForPlaybackAfterRebufferMs;
         releasePlayer();
         initializePlayer();
+    }
+
+    /**
+     * Handling controls prop
+     * 
+     * @param controls  value of the controls prop passed from react-native
+     */
+    public void setControls(boolean controls) {
+        if(controls && (exoPlayerView != null)) {
+            //Initialise playerControlView
+            initialisePlayerControl();
+        }
     }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -267,7 +267,7 @@ class ReactExoplayerView extends FrameLayout implements
      */
     private void togglePlayerControlVisibility() {
         reLayout(playerControlView);
-        if(playerControlView.isVisible()) {
+        if (playerControlView.isVisible()) {
             playerControlView.hide();
         } else {
             playerControlView.show();
@@ -278,16 +278,16 @@ class ReactExoplayerView extends FrameLayout implements
      * Initializing Player control
      */
     private void initializePlayerControl() {
-        if(playerControlView == null) {
+        if (playerControlView == null) {
             playerControlView = new PlayerControlView(getContext());
         }
 
-        //Setting the player for the playerControlView
+        // Setting the player for the playerControlView
         playerControlView.setPlayer(player);
         playerControlView.show();
         playPauseControlContainer = playerControlView.findViewById(R.id.exo_play_pause_container);
 
-        //Invoking onClick event for exoplayerView
+        // Invoking onClick event for exoplayerView
         exoPlayerView.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -295,7 +295,7 @@ class ReactExoplayerView extends FrameLayout implements
             }
         });
 
-        //Invoking onPlayerStateChanged event for Player
+        // Invoking onPlayerStateChanged event for Player
         eventListener = new Player.EventListener() {
             @Override
             public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
@@ -320,12 +320,12 @@ class ReactExoplayerView extends FrameLayout implements
 
     /**
      * Update the layout
+     * @param view  view needs to update layout
      *
      * This is a workaround for the open bug in react-native: https://github.com/facebook/react-native/issues/17968
-     * @param view  view needs to update layout
      */
     private void reLayout(View view) {
-        if(view == null) return;
+        if (view == null) return;
         view.measure(MeasureSpec.makeMeasureSpec(getMeasuredWidth(), MeasureSpec.EXACTLY),
                 MeasureSpec.makeMeasureSpec(getMeasuredHeight(), MeasureSpec.EXACTLY));
         view.layout(view.getLeft(), view.getTop(), view.getMeasuredWidth(), view.getMeasuredHeight());
@@ -377,7 +377,7 @@ class ReactExoplayerView extends FrameLayout implements
             loadVideoStarted = true;
         }
 
-        //Initializing the playerControlView
+        // Initializing the playerControlView
         initializePlayerControl();
     }
 
@@ -1141,16 +1141,13 @@ class ReactExoplayerView extends FrameLayout implements
     /**
      * Handling controls prop
      * 
-     * @param controls  value of the controls prop passed from react-native
+     * @param controls  Controls prop, if true enable controls, if false disable them
      */
     public void setControls(boolean controls) {
-         if(controls && (exoPlayerView != null)) {
-             //adding the playerControlView
-             addPlayerControl();
-        } else {
-            if(getChildAt(1) instanceof PlayerControlView && (exoPlayerView != null)){
-                removeViewAt(1);
-            }
+        if (controls && exoPlayerView != null) {
+            addPlayerControl();
+        } else if (getChildAt(1) instanceof PlayerControlView && exoPlayerView != null) {
+            removeViewAt(1);
         }
     }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -57,6 +57,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SELECTED_VIDEO_TRACK_TYPE = "type";
     private static final String PROP_SELECTED_VIDEO_TRACK_VALUE = "value";
     private static final String PROP_HIDE_SHUTTER_VIEW = "hideShutterView";
+    private static final String PROP_CONTROLS = "controls";
 
     @Override
     public String getName() {
@@ -253,6 +254,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_HIDE_SHUTTER_VIEW, defaultBoolean = false)
     public void setHideShutterView(final ReactExoplayerView videoView, final boolean hideShutterView) {
         videoView.setHideShutterView(hideShutterView);
+    }
+
+    @ReactProp(name = PROP_CONTROLS, defaultBoolean = false)
+    public void setControls(final ReactExoplayerView videoView, final boolean controls) {
+        videoView.setControls(controls);
     }
 
     @ReactProp(name = PROP_BUFFER_CONFIG)

--- a/android-exoplayer/src/main/res/layout/exo_player_control_view.xml
+++ b/android-exoplayer/src/main/res/layout/exo_player_control_view.xml
@@ -20,6 +20,7 @@
         <ImageButton android:id="@id/exo_rew"
             style="@style/ExoMediaButton.Rewind"/>
         <FrameLayout
+            android:id="@+id/exo_play_pause_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center">

--- a/android-exoplayer/src/main/res/layout/exo_player_control_view.xml
+++ b/android-exoplayer/src/main/res/layout/exo_player_control_view.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom"
+    android:layoutDirection="ltr"
+    android:background="#CC000000"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingTop="4dp"
+        android:orientation="horizontal">
+
+        <ImageButton android:id="@id/exo_prev"
+            style="@style/ExoMediaButton.Previous"/>
+
+        <ImageButton android:id="@id/exo_rew"
+            style="@style/ExoMediaButton.Rewind"/>
+        <FrameLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center">
+            <ImageButton android:id="@id/exo_play"
+                style="@style/ExoMediaButton.Play"/>
+
+            <ImageButton android:id="@id/exo_pause"
+                style="@style/ExoMediaButton.Pause"/>
+        </FrameLayout>
+
+        <ImageButton android:id="@id/exo_ffwd"
+            style="@style/ExoMediaButton.FastForward"/>
+
+        <ImageButton android:id="@id/exo_next"
+            style="@style/ExoMediaButton.Next"/>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView android:id="@id/exo_position"
+            android:layout_width="50dp"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:paddingLeft="4dp"
+            android:paddingRight="4dp"
+            android:includeFontPadding="false"
+            android:textColor="#FFBEBEBE"/>
+
+        <com.google.android.exoplayer2.ui.DefaultTimeBar
+            android:id="@id/exo_progress"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="26dp"/>
+
+        <TextView android:id="@id/exo_duration"
+            android:layout_width="50dp"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:paddingLeft="4dp"
+            android:paddingRight="4dp"
+            android:includeFontPadding="false"
+            android:textColor="#FFBEBEBE"/>
+    </LinearLayout>
+
+</LinearLayout>


### PR DESCRIPTION
Added support for displaying player controls in Android Exoplayer component using [PlayerControlView](https://google.github.io/ExoPlayer/doc/reference/com/google/android/exoplayer2/ui/PlayerControlView.html)
Utilised the existing boolean prop 'controls' to show/hide the native controls for the player.

**Sample Usage**
```
<Video
  source={
    {uri: 'https://www.w3schools.com/html/mov_bbb.mp4'}
  }
  controls={true}
/>
```

