### PR TITLE
requestaudiofocus deprecated

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -151,6 +151,7 @@ class ReactExoplayerView extends FrameLayout implements
                         long bufferedDuration = player.getBufferedPercentage() * player.getDuration() / 100;
                         eventEmitter.progressChanged(pos, bufferedDuration, player.getDuration());
                         msg = obtainMessage(SHOW_PROGRESS);
+                        removeMessages(SHOW_PROGRESS);
                         sendMessageDelayed(msg, Math.round(mProgressUpdateInterval));
                     }
                     break;


### PR DESCRIPTION


#### Provide an example of how to test the change
use `react-native-video` to play video/audio, and then try to play music in another music app(google music),  this sound was covered.

#### Focus the PR on only one area
This because `requestaudiofocus` API was deprecated

#### Describe the changes
add Android 8.0 and later request audio focus support
