### PR TITLE
Feature Implementation: Recovery from transient internet failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix text not appearing in release builds of Android apps [#1373](https://github.com/react-native-community/react-native-video/pull/1373)
 * Update to ExoPlayer 2.9.3 [#1406](https://github.com/react-native-community/react-native-video/pull/1406)
 * Add video track selection & onBandwidthUpdate [#1199](https://github.com/react-native-community/react-native-video/pull/1199)
+* Recovery from transient internet failures and props to configure the custom retry count [#1448](https://github.com/react-native-community/react-native-video/pull/1448)
 
 ### Version 4.2.0
 * Don't initialize filters on iOS unless a filter is set. This was causing a startup performance regression [#1360](https://github.com/react-native-community/react-native-video/pull/1360)

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ var styles = StyleSheet.create({
 * [audioOnly](#audioonly)
 * [bufferConfig](#bufferconfig)
 * [controls](#controls)
+* [failureRetryCount](#failureRetryCount)
 * [filter](#filter)
 * [filterEnabled](#filterEnabled)
 * [fullscreen](#fullscreen)
@@ -269,7 +270,6 @@ var styles = StyleSheet.create({
 * [id](#id)
 * [ignoreSilentSwitch](#ignoresilentswitch)
 * [maxBitRate](#maxbitrate)
-* [failureRetryCount](#failureRetryCount)
 * [muted](#muted)
 * [paused](#paused)
 * [playInBackground](#playinbackground)
@@ -363,6 +363,18 @@ Note on iOS, controls are always shown when in fullscreen mode.
 Controls are not available Android because the system does not provide a stock set of controls. You will need to build your own or use a package like [react-native-video-controls](https://github.com/itsnubix/react-native-video-controls) or [react-native-video-player](https://github.com/cornedor/react-native-video-player).
 
 Platforms: iOS, react-native-dom
+
+#### failureRetryCount
+Sets the number of times the media play failures to be retried. Useful to recover from transient internet faiures. Recoverable failures are retried before reporting the error to the application.
+
+Default: 3. Retry 3 times.
+
+Example:
+```
+failureRetryCount={5} // retry 5 times
+```
+
+Platforms: Android ExoPlayer
 
 #### filter
 Add video filter
@@ -475,18 +487,6 @@ maxBitRate={2000000} // 2 megabits
 ```
 
 Platforms: Android ExoPlayer, iOS
-
-#### failureRetryCount
-Sets the number of times the media play failures to be retried. Useful to recover from transient internet faiures. Recoverable failures are retried before reporting the error to the application.
-
-Default: 3. Retry 3 times.
-
-Example:
-```
-failureRetryCount={5} // retry 5 times
-```
-
-Platforms: Android ExoPlayer
 
 #### muted
 Controls whether the audio is muted

--- a/README.md
+++ b/README.md
@@ -259,7 +259,6 @@ var styles = StyleSheet.create({
 * [audioOnly](#audioonly)
 * [bufferConfig](#bufferconfig)
 * [controls](#controls)
-* [failureRetryCount](#failureRetryCount)
 * [filter](#filter)
 * [filterEnabled](#filterEnabled)
 * [fullscreen](#fullscreen)
@@ -270,6 +269,7 @@ var styles = StyleSheet.create({
 * [id](#id)
 * [ignoreSilentSwitch](#ignoresilentswitch)
 * [maxBitRate](#maxbitrate)
+* [minLoadRetryCount](#minLoadRetryCount)
 * [muted](#muted)
 * [paused](#paused)
 * [playInBackground](#playinbackground)
@@ -363,18 +363,6 @@ Note on iOS, controls are always shown when in fullscreen mode.
 Controls are not available Android because the system does not provide a stock set of controls. You will need to build your own or use a package like [react-native-video-controls](https://github.com/itsnubix/react-native-video-controls) or [react-native-video-player](https://github.com/cornedor/react-native-video-player).
 
 Platforms: iOS, react-native-dom
-
-#### failureRetryCount
-Sets the number of times the media play failures to be retried. Useful to recover from transient internet faiures. Recoverable failures are retried before reporting the error to the application.
-
-Default: 3. Retry 3 times.
-
-Example:
-```
-failureRetryCount={5} // retry 5 times
-```
-
-Platforms: Android ExoPlayer
 
 #### filter
 Add video filter
@@ -487,6 +475,18 @@ maxBitRate={2000000} // 2 megabits
 ```
 
 Platforms: Android ExoPlayer, iOS
+
+#### minLoadRetryCount
+Sets the minimum number of times to retry loading data before failing and reporting an error to the application. Useful to recover from transient internet failures.
+
+Default: 3. Retry 3 times.
+
+Example:
+```
+minLoadRetryCount={5} // retry 5 times
+```
+
+Platforms: Android ExoPlayer
 
 #### muted
 Controls whether the audio is muted

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ var styles = StyleSheet.create({
 * [id](#id)
 * [ignoreSilentSwitch](#ignoresilentswitch)
 * [maxBitRate](#maxbitrate)
+* [failureRetryCount](#failureRetryCount)
 * [muted](#muted)
 * [paused](#paused)
 * [playInBackground](#playinbackground)
@@ -474,6 +475,18 @@ maxBitRate={2000000} // 2 megabits
 ```
 
 Platforms: Android ExoPlayer, iOS
+
+#### failureRetryCount
+Sets the number of times the media play failures to be retried. Useful to recover from transient internet faiures. Recoverable failures are retried before reporting the error to the application.
+
+Default: 3. Retry 3 times.
+
+Example:
+```
+failureRetryCount={5} // retry 5 times
+```
+
+Platforms: Android ExoPlayer
 
 #### muted
 Controls whether the audio is muted

--- a/Video.js
+++ b/Video.js
@@ -339,7 +339,7 @@ Video.propTypes = {
     // Opaque type returned by require('./video.mp4')
     PropTypes.number
   ]),
-  failureRetryCount: PropTypes.number,
+  minLoadRetryCount: PropTypes.number,
   maxBitRate: PropTypes.number,
   resizeMode: PropTypes.string,
   poster: PropTypes.string,

--- a/Video.js
+++ b/Video.js
@@ -339,6 +339,7 @@ Video.propTypes = {
     // Opaque type returned by require('./video.mp4')
     PropTypes.number
   ]),
+  failureRetryCount: PropTypes.number,
   maxBitRate: PropTypes.number,
   resizeMode: PropTypes.string,
   poster: PropTypes.string,

--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -18,18 +18,26 @@ android {
 
 dependencies {
     compileOnly "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation('com.google.android.exoplayer:exoplayer:2.9.3') {
-        exclude group: 'com.android.support'
-    }
+    // implementation('com.google.android.exoplayer:exoplayer:2.9.3') {
+    //     exclude group: 'com.android.support'
+    // }
+
+    implementation project(':exoplayer-library-core')
+    implementation project(':exoplayer-library-dash')
+    implementation project(':exoplayer-library-ui')
+    implementation project(':exoplayer-library-smoothstreaming')
+    implementation project(':exoplayer-library-hls')
+    implementation project(':exoplayer-extension-okhttp')
 
     // All support libs must use the same version
     implementation "com.android.support:support-annotations:${safeExtGet('supportLibVersion', '+')}"
     implementation "com.android.support:support-compat:${safeExtGet('supportLibVersion', '+')}"
     implementation "com.android.support:support-media-compat:${safeExtGet('supportLibVersion', '+')}"
 
-    implementation('com.google.android.exoplayer:extension-okhttp:2.9.3') {
-        exclude group: 'com.squareup.okhttp3', module: 'okhttp'
-    }
+    // implementation('com.google.android.exoplayer:extension-okhttp:2.9.3') {
+    //     exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+    // }
+    
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'
 
 }

--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -18,26 +18,18 @@ android {
 
 dependencies {
     compileOnly "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    // implementation('com.google.android.exoplayer:exoplayer:2.9.3') {
-    //     exclude group: 'com.android.support'
-    // }
-
-    implementation project(':exoplayer-library-core')
-    implementation project(':exoplayer-library-dash')
-    implementation project(':exoplayer-library-ui')
-    implementation project(':exoplayer-library-smoothstreaming')
-    implementation project(':exoplayer-library-hls')
-    implementation project(':exoplayer-extension-okhttp')
+    implementation('com.google.android.exoplayer:exoplayer:2.9.3') {
+        exclude group: 'com.android.support'
+    }
 
     // All support libs must use the same version
     implementation "com.android.support:support-annotations:${safeExtGet('supportLibVersion', '+')}"
     implementation "com.android.support:support-compat:${safeExtGet('supportLibVersion', '+')}"
     implementation "com.android.support:support-media-compat:${safeExtGet('supportLibVersion', '+')}"
 
-    // implementation('com.google.android.exoplayer:extension-okhttp:2.9.3') {
-    //     exclude group: 'com.squareup.okhttp3', module: 'okhttp'
-    // }
-    
+    implementation('com.google.android.exoplayer:extension-okhttp:2.9.3') {
+        exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+    }
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'
 
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -876,7 +876,7 @@ class ReactExoplayerView extends FrameLayout implements
                 TrackGroup group = groups.get(i);
                 for (int j = 0; j < group.length; j++) {
                     Format format = group.getFormat(j);
-                    if (format.height == value.asInt()) {
+                    if (format.height == height) {
                         groupIndex = i;
                         tracks[0] = j;
                         break;
@@ -894,14 +894,12 @@ class ReactExoplayerView extends FrameLayout implements
             groupIndex = getGroupIndexForDefaultLocale(groups);
         }
 
-        if (groupIndex == C.INDEX_UNSET && trackType == C.TRACK_TYPE_VIDEO) { // Video auto
-            if (groups.length != 0) {
-                TrackGroup group = groups.get(0);
-                tracks = new int[group.length];
-                groupIndex = 0;
-                for (int j = 0; j < group.length; j++) {
-                    tracks[j] = j;
-                }
+        if (groupIndex == C.INDEX_UNSET && trackType == C.TRACK_TYPE_VIDEO && groups.length > 0) { // Video auto
+            TrackGroup group = groups.get(0);
+            tracks = new int[group.length];
+            groupIndex = 0;
+            for (int j = 0; j < group.length; j++) {
+                tracks[j] = j;
             }
         } else if (groupIndex == C.INDEX_UNSET) {
             trackSelector.setParameters(disableParameters);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -114,6 +114,7 @@ class ReactExoplayerView extends FrameLayout implements
     private boolean isBuffering;
     private float rate = 1f;
     private float audioVolume = 1f;
+    private int failureRetryCount = 3;
     private int maxBitRate = 0;
     private long seekTime = C.TIME_UNSET;
 
@@ -310,12 +311,17 @@ class ReactExoplayerView extends FrameLayout implements
         switch (type) {
             case C.TYPE_SS:
                 return new SsMediaSource(uri, buildDataSourceFactory(false),
-                        new DefaultSsChunkSource.Factory(mediaDataSourceFactory), mainHandler, null);
+                        new DefaultSsChunkSource.Factory(mediaDataSourceFactory), 
+                        failureRetryCount, SsMediaSource.DEFAULT_LIVE_PRESENTATION_DELAY_MS, 
+                        mainHandler, null);
             case C.TYPE_DASH:
                 return new DashMediaSource(uri, buildDataSourceFactory(false),
-                        new DefaultDashChunkSource.Factory(mediaDataSourceFactory), mainHandler, null);
+                        new DefaultDashChunkSource.Factory(mediaDataSourceFactory), 
+                        failureRetryCount, DashMediaSource.DEFAULT_LIVE_PRESENTATION_DELAY_MS,
+                        mainHandler, null);
             case C.TYPE_HLS:
-                return new HlsMediaSource(uri, mediaDataSourceFactory, mainHandler, null);
+                return new HlsMediaSource(uri, mediaDataSourceFactory, 
+                        failureRetryCount, mainHandler, null);
             case C.TYPE_OTHER:
                 return new ExtractorMediaSource(uri, mediaDataSourceFactory, new DefaultExtractorsFactory(),
                         mainHandler, null);
@@ -998,6 +1004,11 @@ class ReactExoplayerView extends FrameLayout implements
         }
     }
 
+    public void setfailureRetryCountModifier(int newFailureRetryCount) {
+        failureRetryCount = newFailureRetryCount;
+        releasePlayer();
+        initializePlayer();
+    }
 
     public void setPlayInBackground(boolean playInBackground) {
         this.playInBackground = playInBackground;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -114,7 +114,7 @@ class ReactExoplayerView extends FrameLayout implements
     private boolean isBuffering;
     private float rate = 1f;
     private float audioVolume = 1f;
-    private int failureRetryCount = 3;
+    private int minLoadRetryCount = 3;
     private int maxBitRate = 0;
     private long seekTime = C.TIME_UNSET;
 
@@ -312,16 +312,16 @@ class ReactExoplayerView extends FrameLayout implements
             case C.TYPE_SS:
                 return new SsMediaSource(uri, buildDataSourceFactory(false),
                         new DefaultSsChunkSource.Factory(mediaDataSourceFactory), 
-                        failureRetryCount, SsMediaSource.DEFAULT_LIVE_PRESENTATION_DELAY_MS, 
+                        minLoadRetryCount, SsMediaSource.DEFAULT_LIVE_PRESENTATION_DELAY_MS, 
                         mainHandler, null);
             case C.TYPE_DASH:
                 return new DashMediaSource(uri, buildDataSourceFactory(false),
                         new DefaultDashChunkSource.Factory(mediaDataSourceFactory), 
-                        failureRetryCount, DashMediaSource.DEFAULT_LIVE_PRESENTATION_DELAY_MS,
+                        minLoadRetryCount, DashMediaSource.DEFAULT_LIVE_PRESENTATION_DELAY_MS,
                         mainHandler, null);
             case C.TYPE_HLS:
                 return new HlsMediaSource(uri, mediaDataSourceFactory, 
-                        failureRetryCount, mainHandler, null);
+                        minLoadRetryCount, mainHandler, null);
             case C.TYPE_OTHER:
                 return new ExtractorMediaSource(uri, mediaDataSourceFactory, new DefaultExtractorsFactory(),
                         mainHandler, null);
@@ -1002,8 +1002,8 @@ class ReactExoplayerView extends FrameLayout implements
         }
     }
 
-    public void setfailureRetryCountModifier(int newFailureRetryCount) {
-        failureRetryCount = newFailureRetryCount;
+    public void setMinLoadRetryCountModifier(int newMinLoadRetryCount) {
+        minLoadRetryCount = newMinLoadRetryCount;
         releasePlayer();
         initializePlayer();
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -894,12 +894,14 @@ class ReactExoplayerView extends FrameLayout implements
             groupIndex = getGroupIndexForDefaultLocale(groups);
         }
 
-        if (groupIndex == C.INDEX_UNSET && trackType == C.TRACK_TYPE_VIDEO && groups.length > 0) { // Video auto
-            TrackGroup group = groups.get(0);
-            tracks = new int[group.length];
-            groupIndex = 0;
-            for (int j = 0; j < group.length; j++) {
-                tracks[j] = j;
+        if (groupIndex == C.INDEX_UNSET && trackType == C.TRACK_TYPE_VIDEO) { // Video auto
+            if (groups.length != 0) {
+                TrackGroup group = groups.get(0);
+                tracks = new int[group.length];
+                groupIndex = 0;
+                for (int j = 0; j < group.length; j++) {
+                    tracks[j] = j;
+                }
             }
         } else if (groupIndex == C.INDEX_UNSET) {
             trackSelector.setParameters(disableParameters);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -48,7 +48,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_REPORT_BANDWIDTH = "reportBandwidth";
     private static final String PROP_SEEK = "seek";
     private static final String PROP_RATE = "rate";
-    private static final String PROP_FAILURE_RETRY_COUNT = "failureRetryCount";
+    private static final String PROP_MIN_LOAD_RETRY_COUNT = "minLoadRetryCount";
     private static final String PROP_MAXIMUM_BIT_RATE = "maxBitRate";
     private static final String PROP_PLAY_IN_BACKGROUND = "playInBackground";
     private static final String PROP_DISABLE_FOCUS = "disableFocus";
@@ -231,9 +231,9 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
         videoView.setMaxBitRateModifier(maxBitRate);
     }
 
-    @ReactProp(name = PROP_FAILURE_RETRY_COUNT)
-    public void failureRetryCount(final ReactExoplayerView videoView, final int failureRetryCount) {
-        videoView.setfailureRetryCountModifier(failureRetryCount);
+    @ReactProp(name = PROP_MIN_LOAD_RETRY_COUNT)
+    public void minLoadRetryCount(final ReactExoplayerView videoView, final int minLoadRetryCount) {
+        videoView.setMinLoadRetryCountModifier(minLoadRetryCount);
     }
 
     @ReactProp(name = PROP_PLAY_IN_BACKGROUND, defaultBoolean = false)

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -48,6 +48,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_REPORT_BANDWIDTH = "reportBandwidth";
     private static final String PROP_SEEK = "seek";
     private static final String PROP_RATE = "rate";
+    private static final String PROP_FAILURE_RETRY_COUNT = "failureRetryCount";
     private static final String PROP_MAXIMUM_BIT_RATE = "maxBitRate";
     private static final String PROP_PLAY_IN_BACKGROUND = "playInBackground";
     private static final String PROP_DISABLE_FOCUS = "disableFocus";
@@ -228,6 +229,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_MAXIMUM_BIT_RATE)
     public void setMaxBitRate(final ReactExoplayerView videoView, final int maxBitRate) {
         videoView.setMaxBitRateModifier(maxBitRate);
+    }
+
+    @ReactProp(name = PROP_FAILURE_RETRY_COUNT)
+    public void failureRetryCount(final ReactExoplayerView videoView, final int failureRetryCount) {
+        videoView.setfailureRetryCountModifier(failureRetryCount);
     }
 
     @ReactProp(name = PROP_PLAY_IN_BACKGROUND, defaultBoolean = false)


### PR DESCRIPTION
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

#### Update the documentation
Documentation updated

#### Update the changelog
Will update the changelog

#### Provide an example of how to test the change
Send failureRetryCount={10} in props. When video play is active just turn-off the internet/wifi for 1-2 seconds and  turn-on immediately. Video play should continue after the wifi is turned-on

#### Focus the PR on only one area
ok

#### Describe the changes
This is a new feature to recover from transient internet issues. In mobile network the connection will not be stable and in case of transient internet issues video play should recover and continue to play once the connection is ok. Exoplayer has a feature to configure the retry count. This PR uses the exoplayer feature to recover from transient internet issues.
