### PR TITLE
Fix for isssue #1463

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {StyleSheet, requireNativeComponent, NativeModules, View, ViewPropTypes, Image, Platform, findNodeHandle} from 'react-native';
+import {StyleSheet, requireNativeComponent, NativeModules, View, ViewPropTypes, Image, Platform, findNodeHandle, UIManager} from 'react-native';
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 import TextTrackType from './TextTrackType';
 import FilterType from './FilterType';
@@ -225,13 +225,13 @@ export default class Video extends Component {
 
     let nativeResizeMode;
     if (resizeMode === VideoResizeMode.stretch) {
-      nativeResizeMode = NativeModules.UIManager.RCTVideo.Constants.ScaleToFill;
+      nativeResizeMode = UIManager.getViewManagerConfig('RCTVideo').Constants.ScaleToFill;
     } else if (resizeMode === VideoResizeMode.contain) {
-      nativeResizeMode = NativeModules.UIManager.RCTVideo.Constants.ScaleAspectFit;
+      nativeResizeMode = UIManager.getViewManagerConfig('RCTVideo').Constants.ScaleAspectFit;
     } else if (resizeMode === VideoResizeMode.cover) {
-      nativeResizeMode = NativeModules.UIManager.RCTVideo.Constants.ScaleAspectFill;
+      nativeResizeMode = UIManager.getViewManagerConfig('RCTVideo').Constants.ScaleAspectFill;
     } else {
-      nativeResizeMode = NativeModules.UIManager.RCTVideo.Constants.ScaleNone;
+      nativeResizeMode = UIManager.getViewManagerConfig('RCTVideo').Constants.ScaleNone;
     }
 
     const nativeProps = Object.assign({}, this.props);


### PR DESCRIPTION
Fix for Issue, directly accessing NativeModules.UIManager is no longer supported.
Propose to add import to UIManager directly from 'react-native' module on top and change the code from NativeModules.UIManager.RCTVideo.~~~ to UIManager.getViewManagerConfig('RCTVideo').~~~ as suggested from react-native's warning.
