### PR TITLE
Fix: Can't disable subtitle on iOS when using type: disabled

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -641,6 +641,13 @@ static int const RCTVideoUnset = -1;
           }
         }
         
+        NSMutableArray *availableTextTracks = [[NSMutableArray alloc] initWithArray:[self getTextTrackInfo]];
+          
+        // Remove the empty subtitle file from the results (since it should be selected using {type: "disabled"})
+        if (availableTextTracks.count > 0 && [[availableTextTracks objectAtIndex:availableTextTracks.count - 1][@"language"] isEqual: @"disabled"]) {
+          [availableTextTracks removeObjectAtIndex:availableTextTracks.count - 1];
+        }
+        
         if (self.onVideoLoad && _videoLoadStarted) {
           self.onVideoLoad(@{@"duration": [NSNumber numberWithFloat:duration],
                              @"currentTime": [NSNumber numberWithFloat:CMTimeGetSeconds(_playerItem.currentTime)],
@@ -656,7 +663,7 @@ static int const RCTVideoUnset = -1;
                                  @"orientation": orientation
                                  },
                              @"audioTracks": [self getAudioTrackInfo],
-                             @"textTracks": [self getTextTrackInfo],
+                             @"textTracks": availableTextTracks,
                              @"target": self.reactTag});
         }
         _videoLoadStarted = NO;


### PR DESCRIPTION
This is a PR to fix #1144. 

### The original issue
When you select a textTrack it starts playing the video with subtitles. To disable these subtitle you can give the `setSelectedTextTrack={{type:'disabled'}}` to the Video component. This works correctly on Android, but on iOS it "freezes" the last known subtitle until the end of the video.

### How does this PR fix this?
There's been a discussion about how to fix this problem. A solution was to generate an empty VTT file with a package like RNFetchBlob. I think however that it's a better solution to generate this file in the Video component itself (since that's where the issue comes from). 

This PR adds an VTT file to the array of TextTracks. When the selectedTextTrack gets `type: disabled` it will select this track which makes the "old" track disappear.

Nothing changes in how you use texttracks. Something to note is that you can't load a completely empty VTT file. So there is a dot at the 98 hour timemark (basically never). 

Edit: I only load this empty VTT file when you actually have other texttracks as well. So you don't have the issue where it breaks Airplay.