### PR TITLE
Add support for setting audio attributes in ExoPlayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### next
+* Add support for setting audio attributes in ExoPlayer [#1475](https://github.com/react-native-community/react-native-video/pull/1475)
+
 ### Version 4.4.0
 * Fix runtime warning by replacing `UIManager.RCTVideo` with `UIManager.getViewManagerConfig('RCTVideo')` (and ensuring backwards compat) [#1487](https://github.com/react-native-community/react-native-video/pull/1487)
 * Fix loading package resolved videos when using video-caching [#1438](https://github.com/react-native-community/react-native-video/pull/1438)

--- a/Video.js
+++ b/Video.js
@@ -458,6 +458,9 @@ Video.propTypes = {
   onPictureInPictureStatusChanged: PropTypes.func,
   needsToRestoreUserInterfaceForPictureInPictureStop: PropTypes.func,
   onExternalPlaybackChange: PropTypes.func,
+  audioUsage: PropTypes.string,
+  audioFlags: PropTypes.string,
+  audioContentType: PropTypes.string,
 
   /* Required by react-native */
   scaleX: PropTypes.number,

--- a/android-exoplayer/README.md
+++ b/android-exoplayer/README.md
@@ -25,6 +25,9 @@ https://github.com/google/ExoPlayer
         disableFocus={true} // disables audio focus and wake lock (default false)
         onAudioBecomingNoisy={this.onAudioBecomingNoisy} // Callback when audio is becoming noisy - should pause video
         onAudioFocusChanged={this.onAudioFocusChanged} // Callback when audio focus has been lost - pause if focus has been lost
+        audioUsage={'alarm'} //Sets audio attribute usage to "USAGE_ALARM" (default is USAGE_MEDIA)
+        audioFlags={'audibility_enforced'} //Sets audio attribute flag to "FLAG_AUDIBILITY_ENFORCED" (default is none)
+        audioContentType={'speech'} //Sets audio attribute content type to "CONTENT_TYPE_SPEECH" (default is CONTENT_TYPE_UNKNOWN)
       />
     )
   }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -35,6 +35,7 @@ import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.Timeline;
+import com.google.android.exoplayer2.audio.AudioAttributes;
 import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
 import com.google.android.exoplayer2.mediacodec.MediaCodecRenderer;
 import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
@@ -107,6 +108,7 @@ class ReactExoplayerView extends FrameLayout implements
     private DataSource.Factory mediaDataSourceFactory;
     private SimpleExoPlayer player;
     private DefaultTrackSelector trackSelector;
+    private AudioAttributes.Builder audioAttributesBuilder = AudioAttributes.Builder();
     private boolean playerNeedsSource;
 
     private int resumeWindow;
@@ -344,6 +346,7 @@ class ReactExoplayerView extends FrameLayout implements
             player = ExoPlayerFactory.newSimpleInstance(getContext(), trackSelector, defaultLoadControl);
             player.addListener(this);
             player.setMetadataOutput(this);
+            player.setAudioAttributes(audioAttributesBuilder.build());
             exoPlayerView.setPlayer(player);
             audioBecomingNoisyReceiver.setListener(this);
             BANDWIDTH_METER.addEventListener(new Handler(), this);
@@ -1053,7 +1056,6 @@ class ReactExoplayerView extends FrameLayout implements
         }
     }
 
-
     public void setVolumeModifier(float volume) {
         audioVolume = volume;
         if (player != null) {
@@ -1160,5 +1162,17 @@ class ReactExoplayerView extends FrameLayout implements
         } else if (getChildAt(1) instanceof PlayerControlView && exoPlayerView != null) {
             removeViewAt(1);
         }
+    }
+
+    public void setAudioUsage(int audioUsage) {
+        audioAttributesBuilder.setUsage(audioUsage)
+    }
+
+    public void setAudioFlags(int audioFlags) {
+        audioAttributesBuilder.setFlags(audioFlags)
+    }
+
+    public void setAudioContentType(int audioContentType) {
+        audioAttributesBuilder.setContentType(audioContentType)
     }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -11,6 +11,7 @@ import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.DefaultLoadControl;
 import com.google.android.exoplayer2.upstream.RawResourceDataSource;
 
@@ -59,6 +60,9 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SELECTED_VIDEO_TRACK_VALUE = "value";
     private static final String PROP_HIDE_SHUTTER_VIEW = "hideShutterView";
     private static final String PROP_CONTROLS = "controls";
+    private static final String PROP_AUDIO_USAGE = "audioUsage";
+    private static final String PROP_AUDIO_FLAGS = "audioFlags";
+    private static final String PROP_AUDIO_CONTENT_TYPE = "audioContentType";
 
     @Override
     public String getName() {
@@ -284,6 +288,96 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
                     ? bufferConfig.getInt(PROP_BUFFER_CONFIG_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS) : bufferForPlaybackAfterRebufferMs;
             videoView.setBufferConfig(minBufferMs, maxBufferMs, bufferForPlaybackMs, bufferForPlaybackAfterRebufferMs);
         }
+    }
+
+    @ReactProp(name = PROP_AUDIO_USAGE)
+    public void setAudioUsage(final ReactExoplayerView videoView, final String audioUsageStr) {
+        int audioUsage;
+        switch(audioUsageStr) {
+            case "alarm":
+                audioUsage = C.USAGE_ALARM;
+                break;
+            case "assistance_accessibility":
+                audioUsage = C.USAGE_ASSISTANCE_ACCESSIBILITY;
+                break;
+            case "assistance_navigation_guidance":
+                audioUsage = C.USAGE_ASSISTANCE_NAVIGATION_GUIDANCE;
+                break;
+            case "assistance_sonification":
+                audioUsage = C.USAGE_ASSISTANCE_SONIFICATION;
+                break;
+            case "assistant":
+                audioUsage = C.USAGE_ASSISTANT;
+                break;
+            case "game":
+                audioUsage = C.USAGE_GAME;
+                break;
+            case "notification":
+                audioUsage = C.USAGE_NOTIFICATION;
+                break;
+            case "notification_communication_delayed":
+                audioUsage = C.USAGE_NOTIFICATION_COMMUNICATION_DELAYED;
+                break;
+            case "notification_communication_instant":
+                audioUsage = C.USAGE_NOTIFICATION_COMMUNICATION_INSTANT;
+                break;
+            case "notification_communication_request":
+                audioUsage = C.USAGE_NOTIFICATION_COMMUNICATION_REQUEST;
+                break;
+            case "notification_event":
+                audioUsage = C.USAGE_NOTIFICATION_EVENT;
+                break;
+            case "notification_ringtone":
+                audioUsage = C.USAGE_NOTIFICATION_RINGTONE;
+                break;
+            case "unknown":
+                audioUsage = C.USAGE_UNKNOWN;
+                break;
+            case "voice_communication":
+                audioUsage = C.USAGE_VOICE_COMMUNICATION;
+                break;
+            case "voice_communication_signalling":
+                audioUsage = C.USAGE_VOICE_COMMUNICATION_SIGNALLING;
+                break;
+            case "media":
+            default:
+                audioUsage = C.USAGE_MEDIA;
+                break;
+        }
+        videoView.setAudioUsage(audioUsage);
+    }
+
+    @ReactProp(name = PROP_AUDIO_FLAGS)
+    public void setAudioFlags(final ReactExoplayerView videoView, final String audioFlagsStr) {
+        switch(audioFlagsStr) {
+            case "audibility_enforced":
+                videoView.setAudioFlags(C.FLAG_AUDIBILITY_ENFORCED);
+                break;
+        }
+    }
+
+    @ReactProp(name = PROP_AUDIO_CONTENT_TYPE)
+    public void setAudioContentType(final ReactExoplayerView videoView, final String audioContentTypeStr) {
+        int audioContentType;
+        switch(audioContentTypeStr) {
+            case "movie":
+                audioContentType = C.CONTENT_TYPE_MOVIE;
+                break;
+            case "music":
+                audioContentType = C.CONTENT_TYPE_MUSIC;
+                break;
+            case "sonification":
+                audioContentType = C.CONTENT_TYPE_SONIFICATION;
+                break;
+            case "speech":
+                audioContentType = C.CONTENT_TYPE_SPEECH;
+                break;
+            case "unknown":
+            default:
+                audioContentType = C.CONTENT_TYPE_UNKNOWN:
+                break;
+        }
+        videoView.setAudioContentType(audioContentType);
     }
 
     private boolean startsWithValidScheme(String uriString) {


### PR DESCRIPTION
<Video
  audioUsage={'alarm'} //Sets audio attribute usage to "USAGE_ALARM" (default is USAGE_MEDIA)
  audioFlags={'audibility_enforced'} //Sets audio attribute flag to "FLAG_AUDIBILITY_ENFORCED" (default is none)
  audioContentType={'speech'} //Sets audio attribute content type to "CONTENT_TYPE_SPEECH" (default is CONTENT_TYPE_UNKNOWN)
/>

#### Provide an example of how to test the change
Set the "audioUsage" to "alarm", mute the main "music" audio stream on Android, and watch as you're able to hear the audio from the video via a different stream.

#### Describe the changes
This PR allows you to set the various audio attributes on an ExoPlayer instance via the <Video> element.  Currently, this library lacks the ability to do so.