### PR TITLE
Throw an error instead of crashing app when video source is empty

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -219,6 +219,8 @@ export default class Video extends Component {
     if (uri && uri.match(/^\//)) {
       uri = `file://${uri}`;
     }
+    
+    if (!uri) throw new Error('Trying to load empty source.');
 
     const isNetwork = !!(uri && uri.match(/^https?:/));
     const isAsset = !!(uri && uri.match(/^(assets-library|ipod-library|file|content|ms-appx|ms-appdata):/));


### PR DESCRIPTION
If an undefined source is accidentally loaded in react-native-video a fatal error SIGABRT will happen and crash the application. This is very difficult to debug since there's apparently no relation between this crash and react-native-video. So this change checks if the URI is empty and, if it is, it throws an error, allowing the user to find out early about the issue.

![](https://cloud.githubusercontent.com/assets/5795227/20283860/08223ba6-aabb-11e6-9fdc-d12d32b3aa9a.png)