### PR TITLE
fix(ios): message sent to deallocated instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### next
 
 * Fix loading package resolved videos when using video-caching [#1438](https://github.com/react-native-community/react-native-video/pull/1438)
+* Fix "message sent to deallocated instance" crash on ios [#1482](https://github.com/react-native-community/react-native-video/pull/1482)
 
 ### Version 4.3.0
 * Fix iOS video not displaying after switching source [#1395](https://github.com/react-native-community/react-native-video/pull/1395)

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -197,6 +197,7 @@ static int const RCTVideoUnset = -1;
   [self removePlayerLayer];
   [self removePlayerItemObservers];
   [_player removeObserver:self forKeyPath:playbackRate context:nil];
+  [_player removeObserver:self forKeyPath:externalPlaybackActive context: nil];
 }
 
 #pragma mark - App lifecycle handlers


### PR DESCRIPTION
#### Provide an example of how to test the change
I had some `EXC_BAD_ACCESS` crashes in my app without an useful stack trace. After enabling zombie mode I was able to get the following log:

```
[RCTVideo retain]: message sent to deallocated instance 0x10c530890
```

I checked the code and eventually figured out that `[_player removeObserver:self forKeyPath:externalPlaybackActive context: nil];` is not called upon dealloc.

I am not 100% sure this results in the crash. However after adding that line to dealloc I was not able to reproduce this issue with the simulator or my testing device. I will also send out a new testflight in order to verify that this is the case.

The crash seems to occur when you are quickly mounting and unmount video components e.g. through quick navigation.