### PR TITLE
Adding compileOptions Java 1.8 to build.gradle

### DIFF
--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -7,6 +7,11 @@ def safeExtGet(prop, fallback) {
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 27)
     buildToolsVersion safeExtGet('buildToolsVersion', '27.0.3')
+ 
+    compileOptions {
+        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_1_8
+    }
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)


### PR DESCRIPTION
#### Issue description
Android build for Detox E2E tests does not work (see #1464). This PR should fix that.

#### Versions for reproducing
react-native 0.57.8 
detox 10.0.10

Fixes #1464
