### PR TITLE
Changed iOS check for video landscape/portrait

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -617,17 +617,26 @@ static int const RCTVideoUnset = -1;
           width = [NSNumber numberWithFloat:videoTrack.naturalSize.width];
           height = [NSNumber numberWithFloat:videoTrack.naturalSize.height];
           CGAffineTransform preferredTransform = [videoTrack preferredTransform];
-          
-          if ((videoTrack.naturalSize.width == preferredTransform.tx
-               && videoTrack.naturalSize.height == preferredTransform.ty)
-              || (preferredTransform.tx == 0 && preferredTransform.ty == 0))
+
+          // Landscape transform is of the shape:
+          // | 1 0 |
+          // | 0 1 |
+          // Portrait transform is of the shape:
+          // | 0 1 |
+          // |-1 0 |
+          // https://en.wikipedia.org/wiki/Matrix_(mathematics)#Linear_transformations
+          if (preferredTransform.a == 1 && preferredTransform.b == 0 && preferredTransform.c == 0 && preferredTransform.d == 1)
           {
             orientation = @"landscape";
-          } else {
+          }
+          else if (preferredTransform.a == 0 && preferredTransform.b == 1 && preferredTransform.c == -1 && preferredTransform.d == 0) {
+            NSObject *temp = width;
+            width = height;
+            height = temp;
             orientation = @"portrait";
           }
         }
-        
+
         if (self.onVideoLoad && _videoLoadStarted) {
           self.onVideoLoad(@{@"duration": [NSNumber numberWithFloat:duration],
                              @"currentTime": [NSNumber numberWithFloat:CMTimeGetSeconds(_playerItem.currentTime)],


### PR DESCRIPTION
#### Provide an example of how to test the change
Any video taken in Portrait should do the trick. Access this video using react-native-video. Hook up an `onLoad` listener. Before the change, naturalSize would be of the shape 
```javascript
naturalSize: {
  orientation: 'landscape',  // Occasionally it would correctly report as 'portrait'
  width: landscapeWidth,  // Typically the large of the two values
  height: landscapeHeight,
}
```
After the change, naturalSize for portrait should be of the shape
```javascript
naturalSize: {
  orientation: 'portrait',
  width: portraitWidth, // Should be the smaller of the two values
  height: portraitHeight, // Should be the larger of the two values
}
```

Landscape videos should still accurately report as landscape with the correct dimensions

#### Describe the changes
iOS returned `natrualSize` differently from Android. This PR seeks to get these two in alignment and to accurately detect if the video is portrait or landscape.
