### PR TITLE
Fix tvOS picture-in-picture compilation regression.

### DIFF
--- a/ios/Video/RCTVideo.h
+++ b/ios/Video/RCTVideo.h
@@ -14,7 +14,7 @@
 
 @class RCTEventDispatcher;
 #if __has_include(<react-native-video/RCTVideoCache.h>)
-@interface RCTVideo : UIView <RCTVideoPlayerViewControllerDelegate, DVAssetLoaderDelegatesDelegate, AVAssetResourceLoaderDelegate>
+@interface RCTVideo : UIView <RCTVideoPlayerViewControllerDelegate, DVAssetLoaderDelegatesDelegate>
 #elif TARGET_OS_TV
 @interface RCTVideo : UIView <RCTVideoPlayerViewControllerDelegate>
 #else

--- a/ios/Video/RCTVideo.h
+++ b/ios/Video/RCTVideo.h
@@ -14,7 +14,9 @@
 
 @class RCTEventDispatcher;
 #if __has_include(<react-native-video/RCTVideoCache.h>)
-@interface RCTVideo : UIView <RCTVideoPlayerViewControllerDelegate, DVAssetLoaderDelegatesDelegate>
+@interface RCTVideo : UIView <RCTVideoPlayerViewControllerDelegate, DVAssetLoaderDelegatesDelegate, AVAssetResourceLoaderDelegate>
+#elif TARGET_OS_TV
+@interface RCTVideo : UIView <RCTVideoPlayerViewControllerDelegate>
 #else
 @interface RCTVideo : UIView <RCTVideoPlayerViewControllerDelegate, AVPictureInPictureControllerDelegate>
 #endif


### PR DESCRIPTION
A recent PR that introduced Picture-in-Picture via iOS APIs failed to test for tvOS regressions.
https://github.com/react-native-community/react-native-video/pull/1325

There has been discussion after the code was merged and pulled by the community that discusses wrapping the offending APIs in directives. This PR does exactly that and has been tested with a tvOS 12.1 simulator.

Here is a related issue that I created because I wasn't sure if that was protocol for this repo (maybe it will help others that come across this issue before and after it is merged).
https://github.com/react-native-community/react-native-video/issues/1517

Tested this fix with the following code snippet and plays videos on iOS and tvOS.
```
export default class VideoPlayer extends React.PureComponent {
    render() {
        return (
            <View style={styles.container}>
                <Video
                    style={styles.video}
                    ref={this._getRef}
                    pictureInPicture={true} 
                    source={{
                        uri: 'https://bitdash-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
                    }}
                />
            </View>
        );
    }
}
```