### PR TITLE
Fix Android audio crash fixes Issue #1417

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -984,7 +984,9 @@ class ReactExoplayerView extends FrameLayout implements
                     tracks[j] = j;
                 }
             }
-        } else if (groupIndex == C.INDEX_UNSET) {
+        } 
+
+        if (groupIndex == C.INDEX_UNSET) {
             trackSelector.setParameters(disableParameters);
             return;
         }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -975,14 +975,13 @@ class ReactExoplayerView extends FrameLayout implements
             groupIndex = getGroupIndexForDefaultLocale(groups);
         }
 
-        if (groupIndex == C.INDEX_UNSET && trackType == C.TRACK_TYPE_VIDEO) { // Video auto
-            if (groups.length != 0) {
-                TrackGroup group = groups.get(0);
-                tracks = new int[group.length];
-                groupIndex = 0;
-                for (int j = 0; j < group.length; j++) {
-                    tracks[j] = j;
-                }
+        if (groupIndex == C.INDEX_UNSET && trackType == C.TRACK_TYPE_VIDEO && groups.length != 0) { // Video auto
+            // Add all tracks as valid options for ABR to choose from
+            TrackGroup group = groups.get(0);
+            tracks = new int[group.length];
+            groupIndex = 0;
+            for (int j = 0; j < group.length; j++) {
+                tracks[j] = j;
             }
         } 
 


### PR DESCRIPTION
Fix Issue #1417

Why:

It appears that in [this commit](https://github.com/react-native-community/react-native-video/commit/2d016e7e6ab0bbe4b4ac765093ce607668c991bd) the check added to ensure group lengths are greater than 0 still allows for a case in which the groupIndex is -1 but the group.length == 0 so we are never breaking for the invalid groupIndex.

This change addresses the need by:

* Don't chain check for INDEX_UNSET to previous conditional
