### PR TITLE
[Android] Font Size and padding Botton Subtitles

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ var styles = StyleSheet.create({
 * [textTracks](#texttracks)
 * [useTextureView](#usetextureview)
 * [volume](#volume)
+* [fontSizeTrack](#fontSizeTrack)
+* [paddingBottonTrack](#paddingBottonTrack)
 
 ### Event props
 * [onAudioBecomingNoisy](#onaudiobecomingnoisy)
@@ -805,6 +807,19 @@ Adjust the volume.
 
 Platforms: all
 
+#### fontSizeTrack
+Adjust the font size of the subtitles in Android.
+* **Default font size of the device** - The default value for this props
+* **Other values (int)** - Change the font size
+
+Platforms: Android ExoPlayer
+
+#### paddingBottonTrack
+Adjust the padding botton of the subtitles in Android.
+* **0.1 (default)** - Give a padding botton of 0.1
+* **Other values (float)** - Change the padding botton
+
+Platforms: Android ExoPlayer
 
 ### Event props
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ var styles = StyleSheet.create({
 * [useTextureView](#usetextureview)
 * [volume](#volume)
 * [fontSizeTrack](#fontSizeTrack)
-* [paddingBottonTrack](#paddingBottonTrack)
+* [paddingBottomTrack](#paddingBottomTrack)
 
 ### Event props
 * [onAudioBecomingNoisy](#onaudiobecomingnoisy)
@@ -814,10 +814,10 @@ Adjust the font size of the subtitles in Android.
 
 Platforms: Android ExoPlayer
 
-#### paddingBottonTrack
-Adjust the padding botton of the subtitles in Android.
-* **0.1 (default)** - Give a padding botton of 0.1
-* **Other values (float)** - Change the padding botton
+#### paddigBottomTrack
+Adjust the padding bottom of the subtitles in Android.
+* **0.1 (default)** - Give a padding bottom of 0.1
+* **Other values (float)** - Change the padding bottom
 
 Platforms: Android ExoPlayer
 

--- a/Video.js
+++ b/Video.js
@@ -435,7 +435,7 @@ Video.propTypes = {
   fullscreenAutorotate: PropTypes.bool,
   fullscreenOrientation: PropTypes.oneOf(['all','landscape','portrait']),
   progressUpdateInterval: PropTypes.number,
-  paddingBottonTrack: PropTypes.number,
+  paddingBottomTrack: PropTypes.number,
   fontSizeTrack: PropTypes.number,
   useTextureView: PropTypes.bool,
   hideShutterView: PropTypes.bool,

--- a/Video.js
+++ b/Video.js
@@ -435,6 +435,8 @@ Video.propTypes = {
   fullscreenAutorotate: PropTypes.bool,
   fullscreenOrientation: PropTypes.oneOf(['all','landscape','portrait']),
   progressUpdateInterval: PropTypes.number,
+  paddingBottonTrack: PropTypes.number,
+  fontSizeTrack: PropTypes.number,
   useTextureView: PropTypes.bool,
   hideShutterView: PropTypes.bool,
   onLoadStart: PropTypes.func,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -84,6 +84,14 @@ public final class ExoPlayerView extends FrameLayout {
         addViewInLayout(layout, 0, aspectRatioParams);
     }
 
+    public void setFontSizeTrack(int fontSizeTrack) {
+        subtitleLayout.setFixedTextSize(TypedValue.COMPLEX_UNIT_SP, fontSizeTrack );
+    }
+
+    public void setPaddingBottonTrack(float paddingBottonTrack) {
+        subtitleLayout.setBottomPaddingFraction(paddingBottonTrack);
+    }
+
     private void setVideoView() {
         if (surfaceView instanceof TextureView) {
             player.setVideoTextureView((TextureView) surfaceView);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -11,6 +11,7 @@ import android.view.TextureView;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
+import android.util.TypedValue;
 
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.ExoPlaybackException;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -89,8 +89,8 @@ public final class ExoPlayerView extends FrameLayout {
         subtitleLayout.setFixedTextSize(TypedValue.COMPLEX_UNIT_SP, fontSizeTrack );
     }
 
-    public void setPaddingBottonTrack(float paddingBottonTrack) {
-        subtitleLayout.setBottomPaddingFraction(paddingBottonTrack);
+    public void setPaddingBottomTrack(float paddingBottomTrack) {
+        subtitleLayout.setBottomPaddingFraction(paddingBottomTrack);
     }
 
     private void setVideoView() {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1167,7 +1167,7 @@ class ReactExoplayerView extends FrameLayout implements
         exoPlayerView.setFontSizeTrack(fontSizeTrack);
     }
 
-    public void setPaddingBottonTrack(float paddingBottonTrack) {
-        exoPlayerView.setPaddingBottonTrack(paddingBottonTrack);
+    public void setPaddingBottomTrack(float paddingBottomTrack) {
+        exoPlayerView.setPaddingBottomTrack(paddingBottomTrack);
     }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1162,4 +1162,12 @@ class ReactExoplayerView extends FrameLayout implements
             removeViewAt(1);
         }
     }
+
+    public void setFontSizeTrack(int fontSizeTrack) {
+        exoPlayerView.setFontSizeTrack(fontSizeTrack);
+    }
+
+    public void setPaddingBottonTrack(float paddingBottonTrack) {
+        exoPlayerView.setPaddingBottonTrack(paddingBottonTrack);
+    }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -59,6 +59,8 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SELECTED_VIDEO_TRACK_VALUE = "value";
     private static final String PROP_HIDE_SHUTTER_VIEW = "hideShutterView";
     private static final String PROP_CONTROLS = "controls";
+    private static final String PROP_FRONT_SIZE_TRACK = "fontSizeTrack";
+    private static final String PROP_PADDIND_BOTTON_TRACK = "paddingBottonTrack";
 
     @Override
     public String getName() {
@@ -265,6 +267,16 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_CONTROLS, defaultBoolean = false)
     public void setControls(final ReactExoplayerView videoView, final boolean controls) {
         videoView.setControls(controls);
+    }
+
+    @ReactProp(name = PROP_FRONT_SIZE_TRACK, defaultInt = 30)
+    public void setFontSizeTrack(final ReactExoplayerView videoView, final int fontSizeTrack) {
+        videoView.setFontSizeTrack(fontSizeTrack);
+    }
+
+    @ReactProp(name = PROP_PADDIND_BOTTON_TRACK, defaultFloat = 0.1f)
+    public void setPaddingBottonTrack(final ReactExoplayerView videoView, final float paddingBottonTrack) {
+        videoView.setPaddingBottonTrack(paddingBottonTrack);
     }
 
     @ReactProp(name = PROP_BUFFER_CONFIG)

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -59,8 +59,8 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SELECTED_VIDEO_TRACK_VALUE = "value";
     private static final String PROP_HIDE_SHUTTER_VIEW = "hideShutterView";
     private static final String PROP_CONTROLS = "controls";
-    private static final String PROP_FRONT_SIZE_TRACK = "fontSizeTrack";
-    private static final String PROP_PADDIND_BOTTON_TRACK = "paddingBottonTrack";
+    private static final String PROP_FONT_SIZE_TRACK = "fontSizeTrack";
+    private static final String PROP_PADDIND_BOTTOM_TRACK = "paddingBottomTrack";
 
     @Override
     public String getName() {
@@ -269,14 +269,14 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
         videoView.setControls(controls);
     }
 
-    @ReactProp(name = PROP_FRONT_SIZE_TRACK)
+    @ReactProp(name = PROP_FONT_SIZE_TRACK)
     public void setFontSizeTrack(final ReactExoplayerView videoView, final int fontSizeTrack) {
         videoView.setFontSizeTrack(fontSizeTrack);
     }
 
-    @ReactProp(name = PROP_PADDIND_BOTTON_TRACK, defaultFloat = 0.1f)
-    public void setPaddingBottonTrack(final ReactExoplayerView videoView, final float paddingBottonTrack) {
-        videoView.setPaddingBottonTrack(paddingBottonTrack);
+    @ReactProp(name = PROP_PADDIND_BOTTOM_TRACK, defaultFloat = 0.1f)
+    public void setPaddingBottomTrack(final ReactExoplayerView videoView, final float paddingBottomTrack) {
+        videoView.setPaddingBottomTrack(paddingBottomTrack);
     }
 
     @ReactProp(name = PROP_BUFFER_CONFIG)

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -269,7 +269,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
         videoView.setControls(controls);
     }
 
-    @ReactProp(name = PROP_FRONT_SIZE_TRACK, defaultInt = 30)
+    @ReactProp(name = PROP_FRONT_SIZE_TRACK)
     public void setFontSizeTrack(final ReactExoplayerView videoView, final int fontSizeTrack) {
         videoView.setFontSizeTrack(fontSizeTrack);
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -60,7 +60,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_HIDE_SHUTTER_VIEW = "hideShutterView";
     private static final String PROP_CONTROLS = "controls";
     private static final String PROP_FONT_SIZE_TRACK = "fontSizeTrack";
-    private static final String PROP_PADDIND_BOTTOM_TRACK = "paddingBottomTrack";
+    private static final String PROP_PADDING_BOTTOM_TRACK = "paddingBottomTrack";
 
     @Override
     public String getName() {
@@ -274,7 +274,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
         videoView.setFontSizeTrack(fontSizeTrack);
     }
 
-    @ReactProp(name = PROP_PADDIND_BOTTOM_TRACK, defaultFloat = 0.1f)
+    @ReactProp(name = PROP_PADDING_BOTTOM_TRACK, defaultFloat = 0.1f)
     public void setPaddingBottomTrack(final ReactExoplayerView videoView, final float paddingBottomTrack) {
         videoView.setPaddingBottomTrack(paddingBottomTrack);
     }


### PR DESCRIPTION
Fix issue [#1335](https://github.com/react-native-community/react-native-video/issues/1335)

**Font size**

Before the font size of the subtitles was set by default for Android and the default size was really large and looks weird in some devices. It was no possible to set the font size via JavaScript or editing the VTT file. Now with this changes it is possible to set a font size via JavaScrip using the props: fontSizeTrack.  

**Padding botton** 

It seems that in some devices the subtitles were hidden, so with the props paddingBottonTrack is possible to set via JavaScript a padding botton to position better the subtitles in the screen.