### PR TITLE
Fix the code that causes unnecessary re-rendering

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {StyleSheet, requireNativeComponent, NativeModules, View, ViewPropTypes, Image, Platform, findNodeHandle} from 'react-native';
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
@@ -14,30 +14,30 @@ const styles = StyleSheet.create({
 
 export { TextTrackType, FilterType };
 
-export default class Video extends Component {
+export default class Video extends PureComponent {
 
   constructor(props) {
     super(props);
 
     this.state = {
-      showPoster: true,
+      showPoster: !!this.props.poster,
     };
   }
 
   setNativeProps(nativeProps) {
     this._root.setNativeProps(nativeProps);
   }
-  
+
   toTypeString(x) {
     switch (typeof x) {
       case "object":
-        return x instanceof Date 
-          ? x.toISOString() 
+        return x instanceof Date
+          ? x.toISOString()
           : JSON.stringify(x); // object, null
       case "undefined":
         return "";
       default: // boolean, number, string
-        return x.toString();      
+        return x.toString();
     }
   }
 
@@ -53,7 +53,7 @@ export default class Video extends Component {
 
   seek = (time, tolerance = 100) => {
     if (isNaN(time)) throw new Error('Specified time is not a number');
-    
+
     if (Platform.OS === 'ios') {
       this.setNativeProps({
         seek: {
@@ -114,7 +114,7 @@ export default class Video extends Component {
     if (this.props.onBandwidthUpdate) {
       this.props.onBandwidthUpdate(event.nativeEvent);
     }
-  };  
+  };
 
   _onSeek = (event) => {
     if (this.state.showPoster && !this.props.audioOnly) {
@@ -189,7 +189,7 @@ export default class Video extends Component {
       this.props.onPlaybackRateChange(event.nativeEvent);
     }
   };
-  
+
   _onExternalPlaybackChange = (event) => {
     if (this.props.onExternalPlaybackChange) {
       this.props.onExternalPlaybackChange(event.nativeEvent);
@@ -242,7 +242,7 @@ export default class Video extends Component {
     if (uri && uri.match(/^\//)) {
       uri = `file://${uri}`;
     }
-    
+
     if (!uri) {
       console.warn('Trying to load empty source.');
     }
@@ -310,12 +310,11 @@ export default class Video extends Component {
     return (
       <React.Fragment>
         <RCTVideo ref={this._assignRoot} {...nativeProps} />
-        {this.props.poster &&
-          this.state.showPoster && (
-            <View style={nativeProps.style}>
-              <Image style={posterStyle} source={{ uri: this.props.poster }} />
-            </View>
-          )}
+        {this.state.showPoster && (
+          <View style={nativeProps.style}>
+            <Image style={posterStyle} source={{ uri: this.props.poster }} />
+          </View>
+        )}
       </React.Fragment>
     );
   }
@@ -392,7 +391,7 @@ Video.propTypes = {
       PropTypes.string,
       PropTypes.number
     ])
-  }),  
+  }),
   selectedTextTrack: PropTypes.shape({
     type: PropTypes.string.isRequired,
     value: PropTypes.oneOfType([


### PR DESCRIPTION
As you all know, unnecessary re-rendering can cause performance issues.

- Using `PureComponent`
It's generally more efficient than not.

- Changed the logic
Rendering occurs multiple times even if we don't use a `poster`.

Please consider it positively. I hope this helps.
