### PR TITLE
Replace RCTBubblingEventBlock  by RCTDirectEventBlock to avoid event name collision with Expo AV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### next
+* Replaced RCTBubblingEventBlock events by RCTDirectEventBlock to avoid event name collisions [#1625](https://github.com/react-native-community/react-native-video/pull/1625)
 * Added `onPlaybackRateChange` to README [#1578](https://github.com/react-native-community/react-native-video/pull/1578)
 
 ### Version 4.4.1

--- a/ios/Video/RCTVideo.h
+++ b/ios/Video/RCTVideo.h
@@ -21,27 +21,27 @@
 @interface RCTVideo : UIView <RCTVideoPlayerViewControllerDelegate, AVPictureInPictureControllerDelegate>
 #endif
 
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoLoadStart;
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoLoad;
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoBuffer;
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoError;
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoProgress;
-@property (nonatomic, copy) RCTBubblingEventBlock onBandwidthUpdate;
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoSeek;
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoEnd;
-@property (nonatomic, copy) RCTBubblingEventBlock onTimedMetadata;
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoAudioBecomingNoisy;
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoFullscreenPlayerWillPresent;
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoFullscreenPlayerDidPresent;
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoFullscreenPlayerWillDismiss;
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoFullscreenPlayerDidDismiss;
-@property (nonatomic, copy) RCTBubblingEventBlock onReadyForDisplay;
-@property (nonatomic, copy) RCTBubblingEventBlock onPlaybackStalled;
-@property (nonatomic, copy) RCTBubblingEventBlock onPlaybackResume;
-@property (nonatomic, copy) RCTBubblingEventBlock onPlaybackRateChange;
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoExternalPlaybackChange;
-@property (nonatomic, copy) RCTBubblingEventBlock onPictureInPictureStatusChanged;
-@property (nonatomic, copy) RCTBubblingEventBlock onRestoreUserInterfaceForPictureInPictureStop;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoLoadStart;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoLoad;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoBuffer;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoError;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoProgress;
+@property (nonatomic, copy) RCTDirectEventBlock onBandwidthUpdate;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoSeek;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoEnd;
+@property (nonatomic, copy) RCTDirectEventBlock onTimedMetadata;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoAudioBecomingNoisy;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoFullscreenPlayerWillPresent;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoFullscreenPlayerDidPresent;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoFullscreenPlayerWillDismiss;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoFullscreenPlayerDidDismiss;
+@property (nonatomic, copy) RCTDirectEventBlock onReadyForDisplay;
+@property (nonatomic, copy) RCTDirectEventBlock onPlaybackStalled;
+@property (nonatomic, copy) RCTDirectEventBlock onPlaybackResume;
+@property (nonatomic, copy) RCTDirectEventBlock onPlaybackRateChange;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoExternalPlaybackChange;
+@property (nonatomic, copy) RCTDirectEventBlock onPictureInPictureStatusChanged;
+@property (nonatomic, copy) RCTDirectEventBlock onRestoreUserInterfaceForPictureInPictureStop;
 
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher NS_DESIGNATED_INITIALIZER;
 


### PR DESCRIPTION
#### Update the changelog
Pending, will do tomorrow.

#### Provide an example of how to test the change
Test case with expo is reported here: https://github.com/react-native-community/react-native-video/issues/1618

#### Describe the changes
Replaces RCTBubblingEventBlock for RCTDirectEventBlock.
As bubbling events are recommended for DOM-like events (scroll, focus, ...) that need to propagate.
This avoids collision on event names with the expo av library. As `DeviceEventEmitter` is shared among all libraries.

Ref: https://gist.github.com/chourobin/f83f3b3a6fd2053fad29fff69524f91c#ios
```Notes: Bubbling events are like DOM events so that a parent component can capture an event fired by its child. Generally these are UI-related, like "the user touched this box". Direct events are not bubbled and are intended for more abstract events like "this image failed to load".```

Closes https://github.com/react-native-community/react-native-video/issues/1618

Tomorrow I will test that events are firing correctly, but I open the PR so people can test it easily.