### PR TITLE
Fixes bug where poster and video was displayed simultaneously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### next
 * Added `onPlaybackRateChange` to README [#1578](https://github.com/react-native-community/react-native-video/pull/1578)
+* Added `onReadyForDisplay` to README [#1627](https://github.com/react-native-community/react-native-video/pull/1627)
+* Improved handling of poster image. Fixes bug with displaying video and poster simultaneously. [#1627](https://github.com/react-native-community/react-native-video/pull/1627)
 
 ### Version 4.4.1
 * Fix tvOS picture-in-picture compilation regression [#1518](https://github.com/react-native-community/react-native-video/pull/1518)

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ var styles = StyleSheet.create({
 * [onFullscreenPlayerDidDismiss](#onfullscreenplayerdiddismiss)
 * [onLoad](#onload)
 * [onLoadStart](#onloadstart)
+* [onReadyForDisplay](#onreadyfordisplay)
 * [onPictureInPictureStatusChanged](#onpictureinpicturestatuschanged)
 * [onPlaybackRateChange](#onplaybackratechange)
 * [onProgress](#onprogress)
@@ -951,6 +952,16 @@ Example:
   uri: 'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8'
 }
 ```
+
+Platforms: all
+
+#### onReadyForDisplay
+Callback function that is called when the first video frame is ready for display. This is when the poster is removed.
+
+Payload: none
+
+* iOS: [readyForDisplay](https://developer.apple.com/documentation/avkit/avplayerviewcontroller/1615830-readyfordisplay?language=objc)
+* Android: [MEDIA_INFO_VIDEO_RENDERING_START](https://developer.android.com/reference/android/media/MediaPlayer#MEDIA_INFO_VIDEO_RENDERING_START)
 
 Platforms: all
 

--- a/README.md
+++ b/README.md
@@ -962,8 +962,9 @@ Payload: none
 
 * iOS: [readyForDisplay](https://developer.apple.com/documentation/avkit/avplayerviewcontroller/1615830-readyfordisplay?language=objc)
 * Android: [MEDIA_INFO_VIDEO_RENDERING_START](https://developer.android.com/reference/android/media/MediaPlayer#MEDIA_INFO_VIDEO_RENDERING_START)
+* Android ExoPlayer [STATE_READY](https://exoplayer.dev/doc/reference/com/google/android/exoplayer2/Player.html#STATE_READY)
 
-Platforms: all
+Platforms: Android ExoPlayer, Android MediaPlayer, iOS, Web
 
 #### onPictureInPictureStatusChanged
 Callback function that is called when picture in picture becomes active or inactive.

--- a/Video.js
+++ b/Video.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {StyleSheet, requireNativeComponent, NativeModules, View, ViewPropTypes, Image, Platform, findNodeHandle,Animated} from 'react-native';
+import {StyleSheet, requireNativeComponent, NativeModules, View, ViewPropTypes, Image, Platform, findNodeHandle} from 'react-native';
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 import TextTrackType from './TextTrackType';
 import FilterType from './FilterType';
@@ -20,8 +20,7 @@ export default class Video extends Component {
     super(props);
 
     this.state = {
-      showPoster: !!props.poster,
-      posterFadeAnim: new Animated.Value(1),
+      showPoster: !!props.poster
     };
   }
 
@@ -88,15 +87,7 @@ export default class Video extends Component {
   };
 
   _hidePoster = () => {
-    Animated.timing(
-      this.state.posterFadeAnim,
-      {
-        toValue: 0,
-        delay: 200, // Not ideal but need to wait for the first frame to be rendered
-        duration: 100,
-        useNativeDriver: true
-      }
-    ).start(() => this.setState({showPoster: false}));
+    this.setState({showPoster: false});
   }
 
   _onLoadStart = (event) => {
@@ -106,9 +97,6 @@ export default class Video extends Component {
   };
 
   _onLoad = (event) => {
-    if (this.state.showPoster) {
-      this._hidePoster();
-    }
     if (this.props.onLoad) {
       this.props.onLoad(event.nativeEvent);
     }
@@ -175,6 +163,9 @@ export default class Video extends Component {
   };
 
   _onReadyForDisplay = (event) => {
+    if (this.state.showPoster) {
+      this._hidePoster();
+    }
     if (this.props.onReadyForDisplay) {
       this.props.onReadyForDisplay(event.nativeEvent);
     }
@@ -323,7 +314,7 @@ export default class Video extends Component {
           style={StyleSheet.absoluteFill}
         />
         {this.state.showPoster && (
-          <Animated.Image style={[posterStyle, {opacity: this.state.posterFadeAnim}]} source={{ uri: this.props.poster }} />
+          <Image style={posterStyle} source={{ uri: this.props.poster }} />
         )}
       </View>
     );

--- a/Video.js
+++ b/Video.js
@@ -308,15 +308,16 @@ export default class Video extends Component {
     };
 
     return (
-      <React.Fragment>
-        <RCTVideo ref={this._assignRoot} {...nativeProps} />
-        {this.props.poster &&
-          this.state.showPoster && (
-            <View style={nativeProps.style}>
-              <Image style={posterStyle} source={{ uri: this.props.poster }} />
-            </View>
-          )}
-      </React.Fragment>
+      <View style={nativeProps.style}>
+        <RCTVideo
+          ref={this._assignRoot}
+          {...nativeProps}
+          style={StyleSheet.absoluteFill}
+        />
+        {this.props.poster && this.state.showPoster && (
+          <Image style={posterStyle} source={{ uri: this.props.poster }} />
+        )}
+      </View>
     );
   }
 }

--- a/Video.js
+++ b/Video.js
@@ -87,7 +87,9 @@ export default class Video extends Component {
   };
 
   _hidePoster = () => {
-    this.setState({showPoster: false});
+    if (this.state.showPoster) {
+      this.setState({showPoster: false});
+    }
   }
 
   _onLoadStart = (event) => {
@@ -97,6 +99,10 @@ export default class Video extends Component {
   };
 
   _onLoad = (event) => {
+    // Need to hide poster here for windows as onReadyForDisplay is not implemented
+    if (Platform.OS === 'windows') {
+      this._hidePoster();
+    }
     if (this.props.onLoad) {
       this.props.onLoad(event.nativeEvent);
     }
@@ -163,9 +169,7 @@ export default class Video extends Component {
   };
 
   _onReadyForDisplay = (event) => {
-    if (this.state.showPoster) {
-      this._hidePoster();
-    }
+    this._hidePoster();
     if (this.props.onReadyForDisplay) {
       this.props.onReadyForDisplay(event.nativeEvent);
     }

--- a/dom/RCTVideo.js
+++ b/dom/RCTVideo.js
@@ -37,6 +37,7 @@ class RCTVideo extends RCTView {
     this.videoElement = this.initializeVideoElement();
     this.videoElement.addEventListener("ended", this.onEnd);
     this.videoElement.addEventListener("loadeddata", this.onLoad);
+    this.videoElement.addEventListener("canplay", this.onReadyForDisplay);
     this.videoElement.addEventListener("loadstart", this.onLoadStart);
     this.videoElement.addEventListener("pause", this.onPause);
     this.videoElement.addEventListener("play", this.onPlay);
@@ -51,6 +52,7 @@ class RCTVideo extends RCTView {
   detachFromView(view: UIView) {
     this.videoElement.removeEventListener("ended", this.onEnd);
     this.videoElement.removeEventListener("loadeddata", this.onLoad);
+    this.videoElement.removeEventListener("canplay", this.onReadyForDisplay);
     this.videoElement.removeEventListener("loadstart", this.onLoadStart);
     this.videoElement.removeEventListener("pause", this.onPause);
     this.videoElement.removeEventListener("play", this.onPlay);
@@ -201,6 +203,10 @@ class RCTVideo extends RCTView {
       }
     };
     this.sendEvent("topVideoLoad", payload);
+  }
+
+  onReadyForDisplay = () => {
+    this.sendEvent("onReadyForDisplay");
   }
 
   onLoadStart = () => {

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -354,8 +354,6 @@ static int const RCTVideoUnset = -1;
       [self setMaxBitRate:_maxBitRate];
       
       [_player pause];
-      [_playerViewController.view removeFromSuperview];
-      _playerViewController = nil;
         
       if (_playbackRateObserverRegistered) {
         [_player removeObserver:self forKeyPath:playbackRate context:nil];
@@ -598,7 +596,10 @@ static int const RCTVideoUnset = -1;
     } else
       return [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
   }
-  
+  if([keyPath isEqualToString:readyForDisplayKeyPath] && [change objectForKey:NSKeyValueChangeNewKey] && self.onReadyForDisplay) {
+    self.onReadyForDisplay(@{@"target": self.reactTag});
+    return;
+  }
   if (object == _playerItem) {
     // When timeMetadata is read the event onTimedMetadata is triggered
     if ([keyPath isEqualToString:timedMetadata]) {
@@ -689,12 +690,6 @@ static int const RCTVideoUnset = -1;
       }
       _playerBufferEmpty = NO;
       self.onVideoBuffer(@{@"isBuffering": @(NO), @"target": self.reactTag});
-    }
-  } else if (object == _playerLayer) {
-    if([keyPath isEqualToString:readyForDisplayKeyPath] && [change objectForKey:NSKeyValueChangeNewKey]) {
-      if([change objectForKey:NSKeyValueChangeNewKey] && self.onReadyForDisplay) {
-        self.onReadyForDisplay(@{@"target": self.reactTag});
-      }
     }
   } else if (object == _player) {
     if([keyPath isEqualToString:playbackRate]) {
@@ -1283,7 +1278,9 @@ static int const RCTVideoUnset = -1;
 {
   if( _player )
   {
-    _playerViewController = [self createPlayerViewController:_player withPlayerItem:_playerItem];
+    if (!_playerViewController) {
+      _playerViewController = [self createPlayerViewController:_player withPlayerItem:_playerItem];
+    }
     // to prevent video from being animated when resizeMode is 'cover'
     // resize mode must be set before subview is added
     [self setResizeMode:_resizeMode];
@@ -1293,6 +1290,8 @@ static int const RCTVideoUnset = -1;
       [viewController addChildViewController:_playerViewController];
       [self addSubview:_playerViewController.view];
     }
+      
+    [_playerViewController addObserver:self forKeyPath:readyForDisplayKeyPath options:NSKeyValueObservingOptionNew context:nil];
     
     [_playerViewController.contentOverlayView addObserver:self forKeyPath:@"frame" options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:NULL];
   }
@@ -1488,6 +1487,7 @@ static int const RCTVideoUnset = -1;
   [self removePlayerLayer];
   
   [_playerViewController.contentOverlayView removeObserver:self forKeyPath:@"frame"];
+  [_playerViewController removeObserver:self forKeyPath:readyForDisplayKeyPath];
   [_playerViewController.view removeFromSuperview];
   _playerViewController = nil;
   


### PR DESCRIPTION
When using poster image and not using absolute positioning of the Video element you end up with both video and poster elements. This was introduced in #1167. My fix to revert some changes but keep the benefits of no flashing.

This fix relies on `onReadyForDisplay` callback to hide the poster. It's been tested on iOS and ExoPlayer. I added it to DOM as well but haven't been able to test...

Fixes [1509](https://github.com/react-native-community/react-native-video/issues/1509)