### PR TITLE
handle racing conditions when props are setted on exoplayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### next
+* Handle racing conditions when props are setted on exoplayer
+
 ### Version 4.4.2
 * Change compileOnly to implementation on gradle (for newer gradle versions and react-native 0.59 support) [#1592](https://github.com/react-native-community/react-native-video/pull/1592)
 * Replaced RCTBubblingEventBlock events by RCTDirectEventBlock to avoid event name collisions [#1625](https://github.com/react-native-community/react-native-video/pull/1625)

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -144,6 +144,7 @@ class ReactExoplayerView extends FrameLayout implements
     private boolean playInBackground = false;
     private Map<String, String> requestHeaders;
     private boolean mReportBandwidth = false;
+    private boolean controls;
     // \ End props
 
     // React
@@ -267,6 +268,7 @@ class ReactExoplayerView extends FrameLayout implements
      * Toggling the visibility of the player control view 
      */
     private void togglePlayerControlVisibility() {
+        if(player == null) return;
         reLayout(playerControlView);
         if (playerControlView.isVisible()) {
             playerControlView.hide();
@@ -312,10 +314,15 @@ class ReactExoplayerView extends FrameLayout implements
      * Adding Player control to the frame layout
      */
     private void addPlayerControl() {
+        if(player == null) return;
         LayoutParams layoutParams = new LayoutParams(
                 LayoutParams.MATCH_PARENT,
                 LayoutParams.MATCH_PARENT);
         playerControlView.setLayoutParams(layoutParams);
+        int indexOfPC = indexOfChild(playerControlView);
+        if (indexOfPC != -1) {
+            removeViewAt(indexOfPC);
+        }
         addView(playerControlView, 1, layoutParams);
     }
 
@@ -385,6 +392,7 @@ class ReactExoplayerView extends FrameLayout implements
 
                 // Initializing the playerControlView
                 initializePlayerControl();
+                setControls(controls);
             }
         }, 1);
     }
@@ -1165,10 +1173,15 @@ class ReactExoplayerView extends FrameLayout implements
      * @param controls  Controls prop, if true enable controls, if false disable them
      */
     public void setControls(boolean controls) {
-        if (controls && exoPlayerView != null) {
+        this.controls = controls;
+        if (player == null || exoPlayerView == null) return;
+        if (controls) {
             addPlayerControl();
-        } else if (getChildAt(1) instanceof PlayerControlView && exoPlayerView != null) {
-            removeViewAt(1);
+        } else {
+            int indexOfPC = indexOfChild(playerControlView);
+            if (indexOfPC != -1) {
+                removeViewAt(indexOfPC);
+            }
         }
     }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -393,6 +393,7 @@ class ReactExoplayerView extends FrameLayout implements
                 // Initializing the playerControlView
                 initializePlayerControl();
                 setControls(controls);
+                applyModifiers();
             }
         }, 1);
     }
@@ -908,6 +909,10 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setResizeModeModifier(@ResizeMode.Mode int resizeMode) {
         exoPlayerView.setResizeMode(resizeMode);
+    }
+
+    private void applyModifiers() {
+        setRepeatModifier(repeat);
     }
 
     public void setRepeatModifier(boolean repeat) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -341,7 +341,7 @@ class ReactExoplayerView extends FrameLayout implements
 
     private void initializePlayer() {
         ReactExoplayerView self = this;
-
+        // This ensures all props have been setted, to avoid async racing conditions.
         new Handler().postDelayed(new Runnable() {
             @Override
             public void run() {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -457,7 +457,6 @@ class ReactExoplayerView extends FrameLayout implements
             player.setMetadataOutput(null);
             trackSelector = null;
             player = null;
-
         }
         progressHandler.removeMessages(SHOW_PROGRESS);
         themedReactContext.removeLifecycleEventListener(this);


### PR DESCRIPTION
As react native sets props one by one and not in batch, it seems it was producing some inconsistent scenarios.

Test this branch carefully, as some prop setting may need adjustment.
I have seen most setters check `if (player != null) {` but I may missed some