### PR TITLE
Removing the call to observeValueForKeyPath:ofObject:change:context: …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 ## Changelog
 
+### Version 5.0.1
+* Fix crash when RCTVideo's superclass doesn't observe the keyPath 'frame' (iOS) [#1720](https://github.com/react-native-community/react-native-video/pull/1720)
+
 ### Version 5.0.0
 * AndroidX Support
 
 ### Version 4.4.4
 * Handle racing conditions when props are setted on exoplayer
-
 ### Version 4.4.3
 * Fix mute/unmute when controls are present (iOS) [#1654](https://github.com/react-native-community/react-native-video/pull/1654)
 * Fix Android videos being able to play with background music/audio from other apps.

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -712,8 +712,6 @@ static int const RCTVideoUnset = -1;
 
         return;
       }
-  } else if ([super respondsToSelector:@selector(observeValueForKeyPath:ofObject:change:context:)]) {
-    [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
   }
 }
 


### PR DESCRIPTION
 Removing the call to observeValueForKeyPath:ofObject:change:context: on super from RCTVideo.

If the super class is not actually observing the key, the app will crash. Checking to see if
the super class responds to this selector doesn't solve this issue.

react-native-video GitHub issue: https://github.com/react-native-community/react-native-video/issues/1515

Discussion about this particular problem: https://stackoverflow.com/questions/6574714/whats-wrong-with-this-observevalueforkeypathofobjectchangecontext-implement
