### PR TITLE
Added support for automaticallyWaitsToMinimizeStalling property on iOS 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### Version 5.0.1
+* Added support for automaticallyWaitsToMinimizeStalling property (iOS) [#1723](https://github.com/react-native-community/react-native-video/pull/1723)
+
 ### Version 5.0.0
 * AndroidX Support
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,9 @@ Indicates whether the player should only play the audio track and instead of dis
 
 For this to work, the poster prop must be set.
 
+#### automaticallyWaitsToMinimizeStalling
+A Boolean value that indicates whether the player should automatically delay playback in order to minimize stalling. For clients linked against iOS 10.0 and later
+
 Platforms: all
 
 #### bufferConfig

--- a/README.md
+++ b/README.md
@@ -356,6 +356,8 @@ Platforms: all
 
 #### automaticallyWaitsToMinimizeStalling
 A Boolean value that indicates whether the player should automatically delay playback in order to minimize stalling. For clients linked against iOS 10.0 and later
+* **false** - Immediately starts playback
+* **true (default)** - Delays playback in order to minimize stalling
 
 Platforms: iOS
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ var styles = StyleSheet.create({
 ### Configurable props
 * [allowsExternalPlayback](#allowsexternalplayback)
 * [audioOnly](#audioonly)
+* [automaticallyWaitsToMinimizeStalling](#automaticallyWaitsToMinimizeStalling)
 * [bufferConfig](#bufferconfig)
 * [controls](#controls)
 * [filter](#filter)
@@ -351,10 +352,12 @@ Indicates whether the player should only play the audio track and instead of dis
 
 For this to work, the poster prop must be set.
 
+Platforms: all
+
 #### automaticallyWaitsToMinimizeStalling
 A Boolean value that indicates whether the player should automatically delay playback in order to minimize stalling. For clients linked against iOS 10.0 and later
 
-Platforms: all
+Platforms: iOS
 
 #### bufferConfig
 Adjust the buffer settings. This prop takes an object with one or more of the properties listed below.

--- a/Video.js
+++ b/Video.js
@@ -382,6 +382,7 @@ Video.propTypes = {
   poster: PropTypes.string,
   posterResizeMode: Image.propTypes.resizeMode,
   repeat: PropTypes.bool,
+  automaticallyWaitsToMinimizeStalling: PropTypes.bool,
   allowsExternalPlayback: PropTypes.bool,
   selectedAudioTrack: PropTypes.shape({
     type: PropTypes.string.isRequired,

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -54,6 +54,7 @@ static int const RCTVideoUnset = -1;
   float _rate;
   float _maxBitRate;
 
+  BOOL _automaticallyWaitsToMinimizeStalling;
   BOOL _muted;
   BOOL _paused;
   BOOL _repeat;
@@ -376,6 +377,7 @@ static int const RCTVideoUnset = -1;
       _isExternalPlaybackActiveObserverRegistered = YES;
         
       [self addPlayerTimeObserver];
+	  [self setAutomaticallyWaitsToMinimizeStalling:_automaticallyWaitsToMinimizeStalling];
 
       //Perform on next run loop, otherwise onVideoLoadStart is nil
       if (self.onVideoLoadStart) {
@@ -866,7 +868,13 @@ static int const RCTVideoUnset = -1;
     } else if([_ignoreSilentSwitch isEqualToString:@"obey"]) {
       [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:nil];
     }
-    [_player play];
+    
+	if (@available(iOS 10.0, *) && _automaticallyWaitsToMinimizeStalling) {
+		[_player playImmediatelyAtRate:1.0];
+	} else {
+		[_player play];
+		[_player setRate:_rate];
+	}
     [_player setRate:_rate];
   }
   
@@ -951,6 +959,12 @@ static int const RCTVideoUnset = -1;
 - (void)setMaxBitRate:(float) maxBitRate {
   _maxBitRate = maxBitRate;
   _playerItem.preferredPeakBitRate = maxBitRate;
+}
+
+- (void)setAutomaticallyWaitsToMinimizeStalling:(BOOL)waits
+{
+	_automaticallyWaitsToMinimizeStalling = waits;
+	_player.automaticallyWaitsToMinimizeStalling = waits;
 }
 
 

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -89,6 +89,7 @@ static int const RCTVideoUnset = -1;
   if ((self = [super init])) {
     _eventDispatcher = eventDispatcher;
     
+	_automaticallyWaitsToMinimizeStalling = YES;
     _playbackRateObserverRegistered = NO;
     _isExternalPlaybackActiveObserverRegistered = NO;
     _playbackStalled = NO;
@@ -869,7 +870,7 @@ static int const RCTVideoUnset = -1;
       [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:nil];
     }
     
-	if (@available(iOS 10.0, *) && _automaticallyWaitsToMinimizeStalling) {
+	if (@available(iOS 10.0, *) && !_automaticallyWaitsToMinimizeStalling) {
 		[_player playImmediatelyAtRate:1.0];
 	} else {
 		[_player play];

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -88,8 +88,7 @@ static int const RCTVideoUnset = -1;
 {
   if ((self = [super init])) {
     _eventDispatcher = eventDispatcher;
-    
-	_automaticallyWaitsToMinimizeStalling = YES;
+	  _automaticallyWaitsToMinimizeStalling = YES;
     _playbackRateObserverRegistered = NO;
     _isExternalPlaybackActiveObserverRegistered = NO;
     _playbackStalled = NO;
@@ -378,7 +377,9 @@ static int const RCTVideoUnset = -1;
       _isExternalPlaybackActiveObserverRegistered = YES;
         
       [self addPlayerTimeObserver];
-	  [self setAutomaticallyWaitsToMinimizeStalling:_automaticallyWaitsToMinimizeStalling];
+      if (@available(iOS 10.0, *)) {
+        [self setAutomaticallyWaitsToMinimizeStalling:_automaticallyWaitsToMinimizeStalling];
+      }
 
       //Perform on next run loop, otherwise onVideoLoadStart is nil
       if (self.onVideoLoadStart) {

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -22,6 +22,7 @@ RCT_EXPORT_VIEW_PROPERTY(src, NSDictionary);
 RCT_EXPORT_VIEW_PROPERTY(maxBitRate, float);
 RCT_EXPORT_VIEW_PROPERTY(resizeMode, NSString);
 RCT_EXPORT_VIEW_PROPERTY(repeat, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(automaticallyWaitsToMinimizeStalling, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(allowsExternalPlayback, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(textTracks, NSArray);
 RCT_EXPORT_VIEW_PROPERTY(selectedTextTrack, NSDictionary);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "description": "A <Video /> element for react-native",
     "main": "Video.js",
     "license": "MIT",


### PR DESCRIPTION
#### Describe the changes
This pull request adds the `automaticallyWaitsToMinimizeStalling` property which is available on iOS only starting from iOS 10. The property is set to `true` by default.

From the official Apple documentation (https://developer.apple.com/documentation/avfoundation/avplayer/1643482-automaticallywaitstominimizestal?language=objc)
A Boolean value that indicates whether the player should automatically delay playback in order to minimize stalling.

#### Update the documentation
The property has been added to the documentation

#### Update the changelog
The changelog is updated mentioning the current pull request

#### Provide an example of how to test the change
The changes can be tested with any video by implementing the `automaticallyWaitsToMinimizeStalling` prop on `Video` and setting it to `false`.
