### PR TITLE
Get onBandwidthUpdate working on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 
+* Get onBandwidthUpdate working on iOS (iOS) [#1720](https://github.com/react-native-community/react-native-video/pull/1745)
+
 ### Version 5.0.2
 * Fix crash when RCTVideo's superclass doesn't observe the keyPath 'frame' (iOS) [#1720](https://github.com/react-native-community/react-native-video/pull/1720)
 

--- a/README.md
+++ b/README.md
@@ -877,7 +877,7 @@ Example:
 
 Note: On Android ExoPlayer, you must set the [reportBandwidth](#reportbandwidth) prop to enable this event. This is due to the high volume of events generated.
 
-Platforms: Android ExoPlayer
+Platforms: all
 
 #### onEnd
 Callback function that is called when the player reaches the end of the media.

--- a/ios/Video/RCTVideo.h
+++ b/ios/Video/RCTVideo.h
@@ -26,7 +26,7 @@
 @property (nonatomic, copy) RCTDirectEventBlock onVideoBuffer;
 @property (nonatomic, copy) RCTDirectEventBlock onVideoError;
 @property (nonatomic, copy) RCTDirectEventBlock onVideoProgress;
-@property (nonatomic, copy) RCTDirectEventBlock onBandwidthUpdate;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoBandwidthUpdate;
 @property (nonatomic, copy) RCTDirectEventBlock onVideoSeek;
 @property (nonatomic, copy) RCTDirectEventBlock onVideoEnd;
 @property (nonatomic, copy) RCTDirectEventBlock onTimedMetadata;

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -747,12 +747,10 @@ static int const RCTVideoUnset = -1;
 - (void)handleAVPlayerAccess:(NSNotification *)notification {
     AVPlayerItemAccessLog *accessLog = [((AVPlayerItem *)notification.object) accessLog];
     AVPlayerItemAccessLogEvent *lastEvent = accessLog.events.lastObject;
-    
-    /* TODO: get this working
-    if (self.onBandwidthUpdate) {
-        self.onBandwidthUpdate(@{@"bitrate": [NSNumber numberWithFloat:lastEvent.observedBitrate]});
+
+    if (self.onVideoBandwidthUpdate) {
+        self.onVideoBandwidthUpdate(@{@"bitrate": [NSNumber numberWithFloat:lastEvent.observedBitrate]});
     }
-    */
 }
 
 - (void)playbackStalled:(NSNotification *)notification

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -50,7 +50,7 @@ RCT_EXPORT_VIEW_PROPERTY(onVideoLoad, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoBuffer, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoError, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoProgress, RCTDirectEventBlock);
-RCT_EXPORT_VIEW_PROPERTY(onBandwidthUpdate, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onVideoBandwidthUpdate, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoSeek, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoEnd, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onTimedMetadata, RCTDirectEventBlock);


### PR DESCRIPTION
`onBandwidthUpdate` was only supported on Android platforms. This PR adds support for iOS as well.

#### Provide an example of how to test the change
```
onBandwidthUpdate = ({ bitrate }) => console.log('>>>', bitrate);
...
<Video
  onBandwidthUpdate={this.onBandwidthUpdate}
/>
```

#### Describe the changes
![image](https://user-images.githubusercontent.com/4654784/64793042-128a5b00-d583-11e9-8107-cd6e19a51057.png)
Uncommented code above, and fixed callback naming.
The issue was caused by wrong naming on iOS native side.