### PR TITLE
Clear progress messages on STATE_IDLE and STATE_BUFFERING

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -625,10 +625,12 @@ class ReactExoplayerView extends FrameLayout implements
             case Player.STATE_IDLE:
                 text += "idle";
                 eventEmitter.idle();
+                clearProgressMessageHandler();
                 break;
             case Player.STATE_BUFFERING:
                 text += "buffering";
                 onBuffering(true);
+                clearProgressMessageHandler();
                 break;
             case Player.STATE_READY:
                 text += "ready";
@@ -636,7 +638,7 @@ class ReactExoplayerView extends FrameLayout implements
                 onBuffering(false);
                 startProgressHandler();
                 videoLoaded();
-                //Setting the visibility for the playerControlView
+                // Setting the visibility for the playerControlView
                 if (playerControlView != null) {
                     playerControlView.show();
                 }
@@ -655,6 +657,15 @@ class ReactExoplayerView extends FrameLayout implements
 
     private void startProgressHandler() {
         progressHandler.sendEmptyMessage(SHOW_PROGRESS);
+    }
+
+    /*
+        The progress message handler will duplicate recursions of the onProgressMessage handler
+        on change of player state from any state to STATE_READY with playWhenReady is true (when
+        the video is not paused). This clears all existing messages.
+     */
+    private void clearProgressMessageHandler() {
+         progressHandler.removeMessages(SHOW_PROGRESS);
     }
 
     private void videoLoaded() {


### PR DESCRIPTION
The progress message handler will duplicate recursions of the `onProgressMessage` handler on change of player state from any state to STATE_READY with `playWhenReady` is true (when video is not paused). This clears the messages on STATE_IDLE and STATE_BUFFERING to break the recursion.

Fixes #1556, #1320