### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ end
 ### tvOS installation
   <details>
   <summary>tvOS details</summary>
-  
+
 `react-native link react-native-video` doesn’t work properly with the tvOS target so we need to add the library manually.
 
 First select your project in Xcode.
@@ -1168,7 +1168,7 @@ Save video to your Photos with current filter prop. Returns promise.
 
 Example:
 ```
-let response = await this.save();
+let response = await this.player.save();
 let path = response.uri;
 ```
 
@@ -1180,12 +1180,12 @@ Notes:
  - Works with cached videos as well. (Checkout video-caching example)
  - If the video is has not began buffering (e.g. there is no internet connection) then the save function will throw an error.
  - If the video is buffering then the save function promise will return after the video has finished buffering and processing.
- 
+
 Future: 
  - Will support multiple qualities through options
  - Will support more formats in the future through options
  - Will support custom directory and file name through options
- 
+
 Platforms: iOS
 
 #### restoreUserInterfaceForPictureInPictureStopCompleted


### PR DESCRIPTION
This may seem silly but for an absent-minded person like me, I copied the save example without double-checking and was stuck. This PR fixes just one typo in the README in wich the save function needs the video player reference.