### PR TITLE
added alternativeAudioSource prop to replace audio track if needed (i…

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ var styles = StyleSheet.create({
 * [selectedTextTrack](#selectedtexttrack)
 * [selectedVideoTrack](#selectedvideotrack)
 * [source](#source)
+* [alternativeAudioSource](#alternativeAudioSource)
 * [stereoPan](#stereopan)
 * [textTracks](#texttracks)
 * [useTextureView](#usetextureview)
@@ -738,6 +739,10 @@ Sets the media source. You can pass an asset loaded via require or an object wit
 
 The docs for this prop are incomplete and will be updated as each option is investigated and tested.
 
+#### alternativeAudioSource
+Sets the audio to be played with the video, as an alternative. Use this if you have trouble selecting another audio track on iOS. You can pass an asset loaded via require or an object with a uri, as in `source`.
+
+Platforms: iOS
 
 ##### Asset loaded via require
 

--- a/Video.js
+++ b/Video.js
@@ -239,8 +239,10 @@ export default class Video extends Component {
   render() {
     const resizeMode = this.props.resizeMode;
     const source = resolveAssetSource(this.props.source) || {};
+    const alternativeAudioSource = resolveAssetSource(this.props.alternativeAudioSource) || {};
     const shouldCache = !Boolean(source.__packager_asset)
 
+    let alternativeAudioURI = alternativeAudioSource.uri || '';
     let uri = source.uri || '';
     if (uri && uri.match(/^\//)) {
       uri = `file://${uri}`;
@@ -271,6 +273,7 @@ export default class Video extends Component {
       style: [styles.base, nativeProps.style],
       resizeMode: nativeResizeMode,
       src: {
+        alternativeAudioURI,
         uri,
         isNetwork,
         isAsset,

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -418,7 +418,7 @@ static int const RCTVideoUnset = -1;
   return nil;
 }
 
-- (void)playerItemPrepareText:(AVAsset *)asset assetOptions:(NSDictionary * __nullable)assetOptions withCallback:(void(^)(AVPlayerItem *))handler
+- (void)playerItemPrepareText:(AVAsset *)asset assetOptions:(NSDictionary * __nullable)assetOptions withCallback:(void(^)(AVPlayerItem *))handler withAudio:(AVAsset *)audio
 {
   // AVPlayer can't airplay AVMutableCompositions
   _allowsExternalPlayback = NO;


### PR DESCRIPTION
I've added the possibility to use an alternative audio, like using a german audio track for a video with an english (or none) sound. 

The prop `selectedAudioTrack` and `audioTracks` only worked on Android, but not iOS. So I've implemented the alternative only for iOS. It's actually pretty simple and works like the `source` property.

Let me know what you think.