### PR TITLE
Feature/android media session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Changelog
 
 #### next
-* Added media session for Android ExoPlayer allowing user to pause/play playback with headset HW buttons, or for example display player controls in PIP window.
+* Added media session for Android ExoPlayer allowing user to pause/play playback with headset HW buttons, or for example display player controls in PIP window. [#1780](https://github.com/react-native-community/react-native-video/pull/1780)
 
 ### Version 5.0.2
 * Fix crash when RCTVideo's superclass doesn't observe the keyPath 'frame' (iOS) [#1720](https://github.com/react-native-community/react-native-video/pull/1720)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+#### next
+* Added media session for Android ExoPlayer allowing user to pause/play playback with headset HW buttons, or for example display player controls in PIP window.
+
 ### Version 5.0.2
 * Fix crash when RCTVideo's superclass doesn't observe the keyPath 'frame' (iOS) [#1720](https://github.com/react-native-community/react-native-video/pull/1720)
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ var styles = StyleSheet.create({
 * [onAudioBecomingNoisy](#onaudiobecomingnoisy)
 * [onBandwidthUpdate](#onbandwidthupdate)
 * [onEnd](#onend)
+* [onExternalPauseToggled](#onexternalpausetoggled)
 * [onExternalPlaybackChange](#onexternalplaybackchange)
 * [onFullscreenPlayerWillPresent](#onfullscreenplayerwillpresent)
 * [onFullscreenPlayerDidPresent](#onfullscreenplayerdidpresent)
@@ -885,6 +886,24 @@ Callback function that is called when the player reaches the end of the media.
 Payload: none
 
 Platforms: all
+
+#### onExternalPauseToggled
+Callback function that is called when external playback pause/play mode is toggled. This can happen when using headset HW buttons for example. Or PIP window buttons. Can be used to toggle paused state to change play/pause button for example.
+
+Payload:
+
+Property | Type | Description
+--- | --- | ---
+isPlaying | boolean | Boolean indicating whether player is playing.
+
+Example:
+```
+{
+  isPlaying: true
+}
+```
+
+Platforms: Android ExoPlayer
 
 #### onExternalPlaybackChange
 Callback function that is called when external playback mode for current playing video has changed. Mostly useful when connecting/disconnecting to Apple TV – it's called on connection/disconnection.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Video only:
 
 ```diff
   pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
-+  `pod 'react-native-video', :path => '../node_modules/react-native-video/react-native-video.podspec'`
++  `pod 'react-native-video', :podspec => '../node_modules/react-native-video/react-native-video.podspec'`
 end
 ```
 
@@ -85,7 +85,7 @@ Video with caching ([more info](docs/caching.md)):
 
 ```diff
   pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
-+  `pod 'react-native-video/VideoCaching', :path => '../node_modules/react-native-video/react-native-video.podspec'`
++  `pod 'react-native-video/VideoCaching', :podspec => '../node_modules/react-native-video/react-native-video.podspec'`
 end
 ```
 

--- a/Video.js
+++ b/Video.js
@@ -229,9 +229,9 @@ export default class Video extends Component {
     }
   };
 
-  _onExternalPauseTriggered = (event) => {
-    if (this.props.onExternalPauseTriggered) {
-      this.props.onExternalPauseTriggered(event.nativeEvent)
+  _onExternalPauseToggled = (event) => {
+    if (this.props.onExternalPauseToggled) {
+      this.props.onExternalPauseToggled(event.nativeEvent)
     }
   }
 
@@ -309,7 +309,7 @@ export default class Video extends Component {
       onAudioBecomingNoisy: this._onAudioBecomingNoisy,
       onPictureInPictureStatusChanged: this._onPictureInPictureStatusChanged,
       onRestoreUserInterfaceForPictureInPictureStop: this._onRestoreUserInterfaceForPictureInPictureStop,
-      onExternalPauseTriggered: this._onExternalPauseTriggered
+      onExternalPauseToggled: this._onExternalPauseToggled
     });
 
     const posterStyle = {
@@ -469,7 +469,7 @@ Video.propTypes = {
   onPictureInPictureStatusChanged: PropTypes.func,
   needsToRestoreUserInterfaceForPictureInPictureStop: PropTypes.func,
   onExternalPlaybackChange: PropTypes.func,
-  onExternalPauseTriggered: PropTypes.func,
+  onExternalPauseToggled: PropTypes.func,
 
   /* Required by react-native */
   scaleX: PropTypes.number,

--- a/Video.js
+++ b/Video.js
@@ -229,6 +229,12 @@ export default class Video extends Component {
     }
   };
 
+  _onExternalPauseTriggered = (event) => {
+    if (this.props.onExternalPauseTriggered) {
+      this.props.onExternalPauseTriggered(event.nativeEvent)
+    }
+  }
+
   getViewManagerConfig = viewManagerName => {
     if (!NativeModules.UIManager.getViewManagerConfig) {
       return NativeModules.UIManager[viewManagerName];
@@ -303,6 +309,7 @@ export default class Video extends Component {
       onAudioBecomingNoisy: this._onAudioBecomingNoisy,
       onPictureInPictureStatusChanged: this._onPictureInPictureStatusChanged,
       onRestoreUserInterfaceForPictureInPictureStop: this._onRestoreUserInterfaceForPictureInPictureStop,
+      onExternalPauseTriggered: this._onExternalPauseTriggered
     });
 
     const posterStyle = {
@@ -462,6 +469,7 @@ Video.propTypes = {
   onPictureInPictureStatusChanged: PropTypes.func,
   needsToRestoreUserInterfaceForPictureInPictureStop: PropTypes.func,
   onExternalPlaybackChange: PropTypes.func,
+  onExternalPauseTriggered: PropTypes.func,
 
   /* Required by react-native */
   scaleX: PropTypes.number,

--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -37,4 +37,6 @@ dependencies {
     }
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'
 
+    // MediaSession extension
+    implementation 'com.google.android.exoplayer:extension-mediasession:2.8.1'
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -63,7 +63,6 @@ import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultAllocator;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.util.Util;
-import com.google.android.exoplayer2.ui.PlayerControlView;
 import com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector;
 
 import java.net.CookieHandler;
@@ -658,7 +657,7 @@ class ReactExoplayerView extends FrameLayout implements
                  * external play/pause state change.
                  */
                 if (playWhenReady == isPaused) {
-                   eventEmitter.externalPauseTriggered(playWhenReady);
+                   eventEmitter.externalPauseToggled(playWhenReady);
                 }
                 break;
             case Player.STATE_ENDED:

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -13,6 +13,7 @@ import android.view.View;
 import android.view.Window;
 import android.view.accessibility.CaptioningManager;
 import android.widget.FrameLayout;
+import android.support.v4.media.session.MediaSessionCompat;
 
 import com.brentvatne.react.R;
 import com.brentvatne.receiver.AudioBecomingNoisyReceiver;
@@ -65,6 +66,7 @@ import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.util.MimeTypes;
 import com.google.android.exoplayer2.util.Util;
 import com.google.android.exoplayer2.ui.PlayerControlView;
+import com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector;
 
 import java.net.CookieHandler;
 import java.net.CookieManager;
@@ -96,6 +98,7 @@ class ReactExoplayerView extends FrameLayout implements
         DEFAULT_COOKIE_MANAGER.setCookiePolicy(CookiePolicy.ACCEPT_ORIGINAL_SERVER);
     }
 
+    private final MediaSessionCompat mediaSession = new MediaSessionCompat(getContext(), "tag");
     private final VideoEventEmitter eventEmitter;
     private PlayerControlView playerControlView;
     private View playPauseControlContainer;
@@ -394,6 +397,11 @@ class ReactExoplayerView extends FrameLayout implements
                 initializePlayerControl();
                 setControls(controls);
                 applyModifiers();
+
+                //Use Media Session Connector from the ExoPlayer library to enable MediaSession Controls in PIP.
+                MediaSessionConnector mediaSessionConnector = new MediaSessionConnector(mediaSession);
+                mediaSessionConnector.setPlayer(player, null);
+                mediaSession.setActive(true);
             }
         }, 1);
     }
@@ -462,6 +470,7 @@ class ReactExoplayerView extends FrameLayout implements
         themedReactContext.removeLifecycleEventListener(this);
         audioBecomingNoisyReceiver.removeListener();
         BANDWIDTH_METER.removeEventListener(this);
+        mediaSession.release();
     }
 
     private boolean requestAudioFocus() {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -620,6 +620,14 @@ class ReactExoplayerView extends FrameLayout implements
                 if(playerControlView != null) {
                     playerControlView.show();
                 }
+
+                /*
+                 * If play is in playing state, but PAUSED prop is TRUE, report
+                 * external play/pause state change.
+                 */
+                if (playWhenReady == isPaused) {
+                   eventEmitter.externalPauseTriggered(playWhenReady);
+                }
                 break;
             case ExoPlayer.STATE_ENDED:
                 text += "ended";

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -197,7 +197,7 @@ class VideoEventEmitter {
         receiveEvent(EVENT_READY, null);
     }
 
-    void externalPauseTriggered(boolean isPlaying) {
+    void externalPauseToggled(boolean isPlaying) {
         WritableMap map = Arguments.createMap();
         map.putBoolean(EVENT_PROP_IS_PLAYING, isPlaying);
         receiveEvent(EVENT_EXTERNAL_PAUSE_TOGGLED, map);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -46,6 +46,7 @@ class VideoEventEmitter {
     private static final String EVENT_AUDIO_BECOMING_NOISY = "onVideoAudioBecomingNoisy";
     private static final String EVENT_AUDIO_FOCUS_CHANGE = "onAudioFocusChanged";
     private static final String EVENT_PLAYBACK_RATE_CHANGE = "onPlaybackRateChange";
+    private static final String EVENT_EXTERNAL_PAUSE_TRIGGERED = "onExternalPauseTriggered";
 
     static final String[] Events = {
             EVENT_LOAD_START,
@@ -68,6 +69,7 @@ class VideoEventEmitter {
             EVENT_AUDIO_FOCUS_CHANGE,
             EVENT_PLAYBACK_RATE_CHANGE,
             EVENT_BANDWIDTH,
+            EVENT_EXTERNAL_PAUSE_TRIGGERED
     };
 
     @Retention(RetentionPolicy.SOURCE)
@@ -92,6 +94,7 @@ class VideoEventEmitter {
             EVENT_AUDIO_FOCUS_CHANGE,
             EVENT_PLAYBACK_RATE_CHANGE,
             EVENT_BANDWIDTH,
+            EVENT_EXTERNAL_PAUSE_TRIGGERED
     })
     @interface VideoEvents {
     }
@@ -118,6 +121,7 @@ class VideoEventEmitter {
     private static final String EVENT_PROP_HAS_AUDIO_FOCUS = "hasAudioFocus";
     private static final String EVENT_PROP_IS_BUFFERING = "isBuffering";
     private static final String EVENT_PROP_PLAYBACK_RATE = "playbackRate";
+    private static final String EVENT_PROP_IS_PLAYING = "isPlaying";
 
     private static final String EVENT_PROP_ERROR = "error";
     private static final String EVENT_PROP_ERROR_STRING = "errorString";
@@ -191,6 +195,12 @@ class VideoEventEmitter {
 
     void ready() {
         receiveEvent(EVENT_READY, null);
+    }
+
+    void externalPauseTriggered(boolean isPlaying) {
+        WritableMap map = Arguments.createMap();
+        map.putBoolean(EVENT_PROP_IS_PLAYING, isPlaying);
+        receiveEvent(EVENT_EXTERNAL_PAUSE_TRIGGERED, map);
     }
 
     void buffering(boolean isBuffering) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -46,7 +46,7 @@ class VideoEventEmitter {
     private static final String EVENT_AUDIO_BECOMING_NOISY = "onVideoAudioBecomingNoisy";
     private static final String EVENT_AUDIO_FOCUS_CHANGE = "onAudioFocusChanged";
     private static final String EVENT_PLAYBACK_RATE_CHANGE = "onPlaybackRateChange";
-    private static final String EVENT_EXTERNAL_PAUSE_TRIGGERED = "onExternalPauseTriggered";
+    private static final String EVENT_EXTERNAL_PAUSE_TOGGLED = "onExternalPauseToggled";
 
     static final String[] Events = {
             EVENT_LOAD_START,
@@ -69,7 +69,7 @@ class VideoEventEmitter {
             EVENT_AUDIO_FOCUS_CHANGE,
             EVENT_PLAYBACK_RATE_CHANGE,
             EVENT_BANDWIDTH,
-            EVENT_EXTERNAL_PAUSE_TRIGGERED
+            EVENT_EXTERNAL_PAUSE_TOGGLED
     };
 
     @Retention(RetentionPolicy.SOURCE)
@@ -94,7 +94,7 @@ class VideoEventEmitter {
             EVENT_AUDIO_FOCUS_CHANGE,
             EVENT_PLAYBACK_RATE_CHANGE,
             EVENT_BANDWIDTH,
-            EVENT_EXTERNAL_PAUSE_TRIGGERED
+            EVENT_EXTERNAL_PAUSE_TOGGLED
     })
     @interface VideoEvents {
     }
@@ -200,7 +200,7 @@ class VideoEventEmitter {
     void externalPauseTriggered(boolean isPlaying) {
         WritableMap map = Arguments.createMap();
         map.putBoolean(EVENT_PROP_IS_PLAYING, isPlaying);
-        receiveEvent(EVENT_EXTERNAL_PAUSE_TRIGGERED, map);
+        receiveEvent(EVENT_EXTERNAL_PAUSE_TOGGLED, map);
     }
 
     void buffering(boolean isBuffering) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.0.1",
+    "version": "5.0.2",
     "description": "A <Video /> element for react-native",
     "main": "Video.js",
     "license": "MIT",


### PR DESCRIPTION
#### Describe the changes
Added mediaSession for Android ExoPlayer to let device know about currently used player. With this in place you can use some native features like pause/play using HW buttons on any compatible headset connected to the device, displaying playback buttons in PIP window (previous, play/pause, next), etc.. 

Currently using the simplest solution with usage of external ExoPlayer mediaSession extension library, which takes care of all needed mediaSession callback, and the session it self. To support more advanced features, full implementation may be needed. 

Since I'm not an Android expert, it's possible that some things, or additional metadata are missing. Please consider this as MVP which is currently implemented mainly to support PIP player controls. Feel free to suggest any change or pick deeper implementation if needed.

Also added `onExternalPauseToggled ` event prop, which notifies client about new play/pause state, so JS can perform needed actions based on this information. For example change UI state.