### PR TITLE
fix: use AVPlayerLooper to repeat videos on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Changelog
 
 ### next
-* Fix AVPlayer release
+* Fix - Release AVPlayer instance[#1787](https://github.com/react-native-community/react-native-video/pull/1787)
 
 ### Version 5.1.0-alpha1
 * Fixed Exoplayer doesn't work with mute=true (Android). [#1696](https://github.com/react-native-community/react-native-video/pull/1696)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### next
+* Fix AVPlayer release
+
 ### Version 5.1.0-alpha1
 * Fixed Exoplayer doesn't work with mute=true (Android). [#1696](https://github.com/react-native-community/react-native-video/pull/1696)
 * Added support for automaticallyWaitsToMinimizeStalling property (iOS) [#1723](https://github.com/react-native-community/react-native-video/pull/1723)

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -203,10 +203,11 @@ static int const RCTVideoUnset = -1;
 - (void)dealloc
 {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
-  [self removePlayerLayer];
   [self removePlayerItemObservers];
   [_player removeObserver:self forKeyPath:playbackRate context:nil];
   [_player removeObserver:self forKeyPath:externalPlaybackActive context: nil];
+  [self removePlayerLayer];
+  _player = nil;
 }
 
 #pragma mark - App lifecycle handlers
@@ -343,9 +344,10 @@ static int const RCTVideoUnset = -1;
 - (void)setSrc:(NSDictionary *)source
 {
   _source = source;
-  [self removePlayerLayer];
   [self removePlayerTimeObserver];
   [self removePlayerItemObservers];
+  [self removePlayerLayer];
+  _player = nil;
 
   dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) 0), dispatch_get_main_queue(), ^{
 
@@ -1499,9 +1501,6 @@ static int const RCTVideoUnset = -1;
     [_player removeObserver:self forKeyPath:externalPlaybackActive context:nil];
     _isExternalPlaybackActiveObserverRegistered = NO;
   }
-  _player = nil;
-  
-  [self removePlayerLayer];
   
   [_playerViewController.contentOverlayView removeObserver:self forKeyPath:@"frame"];
   [_playerViewController removeObserver:self forKeyPath:readyForDisplayKeyPath];
@@ -1515,6 +1514,9 @@ static int const RCTVideoUnset = -1;
   
   _eventDispatcher = nil;
   [[NSNotificationCenter defaultCenter] removeObserver:self];
+
+  [self removePlayerLayer];
+  _player = nil;
   
   [super removeFromSuperview];
 }


### PR DESCRIPTION
The original `repeat` implementation on iOS leaks memory for some reason and it will cause app to become slower and slower each time it loops. This PR replace the implementation with [AVPlayerLooper](https://developer.apple.com/documentation/avfoundation/avplayerlooper) which would solve the issue.

This PR is based on #1787.