### PR TITLE
#836 Probable fix for stopping the repeat on iOS

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -918,7 +918,7 @@ static int const RCTVideoUnset = -1;
         if (!_timeObserver) {
           [self addPlayerTimeObserver];
         }
-        if (!wasPaused) {
+        if (!wasPaused && _paused) {
           [self setPaused:false];
         }
         if(self.onVideoSeek) {


### PR DESCRIPTION
When using seek(0) and in the same time trying to pause (stop) video player it seems that seek takes longer than pause, but it stores initial pause value and then onSeek end it restore initial pause state regardless the current pause value.
