### PR TITLE
fix README about reportBandwidth

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,8 +628,8 @@ Platforms: all
 #### reportBandwidth
 Determine whether to generate onBandwidthUpdate events. This is needed due to the high frequency of these events on ExoPlayer.
 
-* **false (default)** - Generate onBandwidthUpdate events
-* **true** - Don't generate onBandwidthUpdate events
+* **false (default)** - Don't generate onBandwidthUpdate events
+* **true** - Generate onBandwidthUpdate events
 
 Platforms: Android ExoPlayer
 


### PR DESCRIPTION
In the README, the description of the reportBandwidth prop's value (true or false) is reversed.
Actually, events are generated when reportBandwidth is true.