### PR TITLE
fix for iOS video hang on changing to higher playback rate

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -869,11 +869,12 @@ static int const RCTVideoUnset = -1;
       [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:nil];
     }
     
-    if (@available(iOS 10.0, *) && !_automaticallyWaitsToMinimizeStalling) {
-      [_player playImmediatelyAtRate:_rate];
-    } else {
-      [_player play];
-      [_player setRate:_rate];
+    if (_paused) {
+      if (@available(iOS 10.0, *) && !_automaticallyWaitsToMinimizeStalling) {
+        [_player playImmediatelyAtRate:_rate];
+      } else {
+        [_player play];
+      }
     }
     [_player setRate:_rate];
   }


### PR DESCRIPTION
changing higher playback rate when the video is playing can cause the video to hang while the audio still playing.

#### Describe the changes
Previously when the video is playing and the rate is changed, it calls setPaused and [_player playImmediatelyAtRate:_rate] or [_player play] which sometimes causes the video to hang.

the change is when setPaused is called with false value then checking if the video is currently paused or not and only if it is paused then calls  [_player playImmediatelyAtRate:_rate] or [_player play].