### PR TITLE
Fix playerviewcontroller keypath leak of observers

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -1381,8 +1381,11 @@ static int const RCTVideoUnset = -1;
 {
   if (_playerViewController == playerViewController && _fullscreenPlayerPresented && self.onVideoFullscreenPlayerWillDismiss)
   {
-    [_playerViewController.contentOverlayView removeObserver:self forKeyPath:@"frame"];
-    [_playerViewController removeObserver:self forKeyPath:readyForDisplayKeyPath];
+    @try{
+      [_playerViewController.contentOverlayView removeObserver:self forKeyPath:@"frame"];
+      [_playerViewController removeObserver:self forKeyPath:readyForDisplayKeyPath];
+    }@catch(id anException){
+    }
     self.onVideoFullscreenPlayerWillDismiss(@{@"target": self.reactTag});
   }
 }

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -1381,6 +1381,8 @@ static int const RCTVideoUnset = -1;
 {
   if (_playerViewController == playerViewController && _fullscreenPlayerPresented && self.onVideoFullscreenPlayerWillDismiss)
   {
+    [_playerViewController.contentOverlayView removeObserver:self forKeyPath:@"frame"];
+    [_playerViewController removeObserver:self forKeyPath:readyForDisplayKeyPath];
     self.onVideoFullscreenPlayerWillDismiss(@{@"target": self.reactTag});
   }
 }


### PR DESCRIPTION
Bug fix for autorotation and dismissal from 

#### Provide an example of how to test the change
Dismissal of fullscreen player on iOS 10.3.1 was resulting in a fatal crash because keypath observers had not yet been removed from _playerViewController

#### Describe the changes
Add try catch block to remove keypath observers in the dismissal of the playerviewController. Fixes crash from exiting fullscreen.