### PR TITLE
Make player ready when user starts playback for new video after error

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -511,16 +511,12 @@ class ReactExoplayerView extends FrameLayout implements
                 case Player.STATE_ENDED:
                     initializePlayer();
                     break;
-                case Player.STATE_BUFFERING:
-                case Player.STATE_READY:
-                    if (!player.getPlayWhenReady()) {
-                        setPlayWhenReady(true);
-                    }
-                    break;
                 default:
                     break;
             }
-
+            if (!player.getPlayWhenReady()) {
+                setPlayWhenReady(true);
+            }
         } else {
             initializePlayer();
         }


### PR DESCRIPTION
### Scenario
- Set phone to airplane mode
- Try to play video *a* from URL
- Disable airplane mode
- Try to play video *b*

#### Expected
App should start playing video *b*

#### Current
App loads video *b* but it doesn't start playing because method `startPlayback` didn't set `setPlayWhenReady` because player `paused` property was set before new source.

### Solution
When method `startPlayback` is invoked and `player` is instantiated enable `playWhenReady` regardless of `playbackState` 
