### PR TITLE
Fix Android example dev builds not working on Android 9+

### DIFF
--- a/examples/basic/android/app/src/debug/AndroidManifest.xml
+++ b/examples/basic/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+
+  <application
+      tools:targetApi="28"
+      tools:ignore="GoogleAppIndexingWarning"
+      android:debuggable="true"
+      android:usesCleartextTraffic="true">
+
+      <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+
+  </application>
+
+</manifest>

--- a/examples/basic/android/app/src/main/AndroidManifest.xml
+++ b/examples/basic/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
     android:versionName="1.0">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
   <application
       android:name=".MainApplication"
@@ -21,7 +20,6 @@
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
       </activity>
-      <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>
 
 </manifest>

--- a/examples/video-caching/android/app/src/debug/AndroidManifest.xml
+++ b/examples/video-caching/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+
+  <application
+      tools:targetApi="28"
+      tools:ignore="GoogleAppIndexingWarning"
+      android:debuggable="true"
+      android:usesCleartextTraffic="true">
+
+      <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+
+  </application>
+
+</manifest>

--- a/examples/video-caching/android/app/src/main/AndroidManifest.xml
+++ b/examples/video-caching/android/app/src/main/AndroidManifest.xml
@@ -4,11 +4,10 @@
     android:versionName="1.0">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
     <uses-sdk
         android:minSdkVersion="16"
-        android:targetSdkVersion="22" />
+        android:targetSdkVersion="28" />
 
     <application
       android:name=".MainApplication"
@@ -26,7 +25,6 @@
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
       </activity>
-      <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>
 
 </manifest>


### PR DESCRIPTION
Android devices running Android 9+ don't allow HTTP traffic by default, only HTTPS. This causes issues when running dev builds as the Metro bundler hosts the app over HTTP so dev builds can't access the app content and therefore throw an error on boot.

This PR updates the examples to add debug AndroidManifest files that enable HTTP traffic in debug builds so that the examples can actually run.

To test, attach an Android device or emulator running Android 9+ and try the following before and after these changes:

Terminal 1:
```
cd ./examples/basic
yarn
yarn start
```

Terminal 2:
```
cd ./examples/basic
npx react-native run-android 
```