### PR TITLE
docs(video): fix bufferConfig property name

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Property | Type | Description
 minBufferMs | number | The default minimum duration of media that the player will attempt to ensure is buffered at all times, in milliseconds.
 maxBufferMs | number | The default maximum duration of media that the player will attempt to buffer, in milliseconds.
 bufferForPlaybackMs | number | The default duration of media that must be buffered for playback to start or resume following a user action such as a seek, in milliseconds.
-playbackAfterRebufferMs | number | The default duration of media that must be buffered for playback to resume after a rebuffer, in milliseconds. A rebuffer is defined to be caused by buffer depletion rather than a user action.
+bufferForPlaybackAfterRebufferMs | number | The default duration of media that must be buffered for playback to resume after a rebuffer, in milliseconds. A rebuffer is defined to be caused by buffer depletion rather than a user action.
 
 This prop should only be set when you are setting the source, changing it after the media is loaded will cause it to be reloaded.
 


### PR DESCRIPTION
Obvious mistatek with `bufferForPlaybackAfterRebufferMs` property name
documentation.
https://github.com/react-native-community/react-native-video/blob/0df667692baf52fabe35e541379beb90217ea711/Video.js#L430

No changelog required, as this is minor docs fix.

Thanks!

