### PR TITLE
[ios] Adaptive fullscreen in landscape by device orientation

### DIFF
--- a/ios/Video/RCTVideoPlayerViewController.m
+++ b/ios/Video/RCTVideoPlayerViewController.m
@@ -28,8 +28,7 @@
 
 - (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation {
   if ([self.preferredOrientation.lowercaseString isEqualToString:@"landscape"]) {
-    UIDeviceOrientation currentOrientation = [[UIDevice currentDevice] orientation];
-    return currentOrientation == UIDeviceOrientationLandscapeRight ? UIInterfaceOrientationLandscapeLeft : UIInterfaceOrientationLandscapeRight;
+    return UIInterfaceOrientationLandscapeLeft | UIInterfaceOrientationLandscapeRight;
   }
   else if ([self.preferredOrientation.lowercaseString isEqualToString:@"portrait"]) {
     return UIInterfaceOrientationPortrait;

--- a/ios/Video/RCTVideoPlayerViewController.m
+++ b/ios/Video/RCTVideoPlayerViewController.m
@@ -28,7 +28,8 @@
 
 - (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation {
   if ([self.preferredOrientation.lowercaseString isEqualToString:@"landscape"]) {
-    return UIInterfaceOrientationLandscapeRight;
+    UIDeviceOrientation currentOrientation = [[UIDevice currentDevice] orientation];
+    return currentOrientation == UIDeviceOrientationLandscapeRight ? UIInterfaceOrientationLandscapeLeft : UIInterfaceOrientationLandscapeRight;
   }
   else if ([self.preferredOrientation.lowercaseString isEqualToString:@"portrait"]) {
     return UIInterfaceOrientationPortrait;


### PR DESCRIPTION
Currently, when setting `fullscreenOrientation` to `landscape`, the video will always display in `landscape right`.
This PR allows checking the device's orientation then set the right `UIInterfaceOrientation`.