### PR TITLE
Added textureViewOpaque prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### Version 5.1.0-alpha2
+* Added prop textureViewOpaque for Android ExoPlayer. [#1883](https://github.com/react-native-community/react-native-video/pull/1883)
+
 ### Version 5.1.0-alpha1
 * Fixed Exoplayer doesn't work with mute=true (Android). [#1696](https://github.com/react-native-community/react-native-video/pull/1696)
 * Added support for automaticallyWaitsToMinimizeStalling property (iOS) [#1723](https://github.com/react-native-community/react-native-video/pull/1723)

--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ var styles = StyleSheet.create({
 * [source](#source)
 * [stereoPan](#stereopan)
 * [textTracks](#texttracks)
+* [textureViewOpaque](#textureViewOpaque)
 * [useTextureView](#usetextureview)
 * [volume](#volume)
 
@@ -835,6 +836,16 @@ textTracks={[
 
 
 Platforms: Android ExoPlayer, iOS
+
+#### textureViewOpaque
+Controls whether the content of the TextureView is opaque or not.
+
+Setting this to false is useful if you are performing any opacity style changes to the video component.
+
+* **true (default)** - TextureView content is opaque
+* **false** TextureView content is not opaque
+
+Platforms: Android ExoPlayer
 
 #### useTextureView
 Controls whether to output to a TextureView or SurfaceView.

--- a/Video.js
+++ b/Video.js
@@ -444,6 +444,7 @@ Video.propTypes = {
   fullscreenOrientation: PropTypes.oneOf(['all','landscape','portrait']),
   progressUpdateInterval: PropTypes.number,
   useTextureView: PropTypes.bool,
+  textureViewOpaque: PropTypes.bool,
   hideShutterView: PropTypes.bool,
   onLoadStart: PropTypes.func,
   onLoad: PropTypes.func,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -39,6 +39,7 @@ public final class ExoPlayerView extends FrameLayout {
     private ViewGroup.LayoutParams layoutParams;
 
     private boolean useTextureView = true;
+    private boolean textureViewOpaque = true;
     private boolean hideShutterView = false;
 
     public ExoPlayerView(Context context) {
@@ -94,6 +95,9 @@ public final class ExoPlayerView extends FrameLayout {
 
     private void updateSurfaceView() {
         View view = useTextureView ? new TextureView(context) : new SurfaceView(context);
+        if (useTextureView) {
+            ((TextureView) view).setOpaque(this.textureViewOpaque);
+        }
         view.setLayoutParams(layoutParams);
 
         surfaceView = view;
@@ -164,6 +168,13 @@ public final class ExoPlayerView extends FrameLayout {
     public void setUseTextureView(boolean useTextureView) {
         if (useTextureView != this.useTextureView) {
             this.useTextureView = useTextureView;
+            updateSurfaceView();
+        }
+    }
+
+    public void setTextureViewOpaque(boolean textureViewOpaque) {
+        if (textureViewOpaque != this.textureViewOpaque) {
+            this.textureViewOpaque = textureViewOpaque;
             updateSurfaceView();
         }
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1193,6 +1193,10 @@ class ReactExoplayerView extends FrameLayout implements
         exoPlayerView.setUseTextureView(useTextureView);
     }
 
+    public void setTextureViewOpaque(boolean textureViewOpaque) {
+        exoPlayerView.setTextureViewOpaque(textureViewOpaque);
+    }
+
     public void setHideShutterView(boolean hideShutterView) {
         exoPlayerView.setHideShutterView(hideShutterView);
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -54,6 +54,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_DISABLE_FOCUS = "disableFocus";
     private static final String PROP_FULLSCREEN = "fullscreen";
     private static final String PROP_USE_TEXTURE_VIEW = "useTextureView";
+    private static final String PROP_TEXTURE_VIEW_OPAQUE = "textureViewOpaque";
     private static final String PROP_SELECTED_VIDEO_TRACK = "selectedVideoTrack";
     private static final String PROP_SELECTED_VIDEO_TRACK_TYPE = "type";
     private static final String PROP_SELECTED_VIDEO_TRACK_VALUE = "value";
@@ -261,6 +262,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_USE_TEXTURE_VIEW, defaultBoolean = true)
     public void setUseTextureView(final ReactExoplayerView videoView, final boolean useTextureView) {
         videoView.setUseTextureView(useTextureView);
+    }
+
+    @ReactProp(name = PROP_TEXTURE_VIEW_OPAQUE, defaultBoolean = true)
+    public void setTextureViewOpaque(final ReactExoplayerView videoView, final boolean textureViewOpaque) {
+        videoView.setTextureViewOpaque(textureViewOpaque);
     }
 
     @ReactProp(name = PROP_HIDE_SHUTTER_VIEW, defaultBoolean = false)


### PR DESCRIPTION
This adds a prop for controlling the opaque setting for a TextureView surface view. It defaults to true which maintains current behaviour of the module. Setting the prop to false is very useful for opacity changes on the <Video /> component. If you decrease opacity on a <Video /> component leaving this on true means that you start to see a black background appear. Setting it to false eliminates the black background and the video can be faded out in a much more pleasing way.


