### PR TITLE
remove _onProgress wrapper function to relax js bridge

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -114,12 +114,6 @@ export default class Video extends Component {
     }
   };
 
-  _onProgress = (event) => {
-    if (this.props.onProgress) {
-      this.props.onProgress(event.nativeEvent);
-    }
-  };
-
   _onBandwidthUpdate = (event) => {
     if (this.props.onBandwidthUpdate) {
       this.props.onBandwidthUpdate(event.nativeEvent);
@@ -286,7 +280,7 @@ export default class Video extends Component {
       onVideoLoadStart: this._onLoadStart,
       onVideoLoad: this._onLoad,
       onVideoError: this._onError,
-      onVideoProgress: this._onProgress,
+      onVideoProgress: this.props.onProgress,
       onVideoSeek: this._onSeek,
       onVideoEnd: this._onEnd,
       onVideoBuffer: this._onBuffer,


### PR DESCRIPTION
#### Describe the changes

I found out that even when the public component property `onProgress` is undefined the progress object is still transfered via bridge every 250ms which could lead to potential performance issues on low end devices.

[There is some code around the native event](https://github.com/react-native-community/react-native-video/blob/master/ios/Video/RCTVideo.m#L271) which checks if `onVideoProgress` is defined. But since `props.onProgress` is wrapped with `_onProgress` this check is kind of useless because the wrapping function will always exist.

I tested this change successfully on ios and testing it on android is also on my list. 
