### PR TITLE
Fix audio focus

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -581,6 +581,10 @@ class ReactExoplayerView extends FrameLayout implements
         switch (focusChange) {
             case AudioManager.AUDIOFOCUS_LOSS:
                 eventEmitter.audioFocusChanged(false);
+                audioManager.abandonAudioFocus(this);
+                break;
+            case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
+                eventEmitter.audioFocusChanged(false);
                 break;
             case AudioManager.AUDIOFOCUS_GAIN:
                 eventEmitter.audioFocusChanged(true);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -581,6 +581,7 @@ class ReactExoplayerView extends FrameLayout implements
         switch (focusChange) {
             case AudioManager.AUDIOFOCUS_LOSS:
                 eventEmitter.audioFocusChanged(false);
+                pausePlayback();
                 audioManager.abandonAudioFocus(this);
                 break;
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:


### PR DESCRIPTION
Implement audio focus as per android docs:
https://developer.android.com/guide/topics/media-apps/audio-focus
https://medium.com/androiddevelopers/audio-focus-3-cdc09da9c122

`AUDIOFOCUS_LOSS` should abandon focus and not try resuming audio, this is done with `AUDIOFOCUS_LOSS_TRANSIENT`

This fixes at least:
- Audio not being paused after focus being taken by some voip applications
- Content resuming and pausing instantly sporadically (some race condition perhaps) when activity was resumed from background.

Since this is triggering events, my proposal is to trigger the same event as for `AUDIO_FOCUS_LOSS` and let the developer choose to either use stop or pause, yet we explicitly abandon focus as per the docs.