### PR TITLE
[fix] dont set reactViewController view frame to whole screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Version 5.1.0-alpha6
+
+- Fix iOS bug which would break size of views when video is displayed with controls on a non full-screen React view. [#1931](https://github.com/react-native-community/react-native-video/pull/1931)
+
 ### Version 5.1.0-alpha5
 
 - Add support for react-native Windows Cpp/WinRT [#1893]((https://github.com/react-native-community/react-native-video/pull/1893))

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -708,10 +708,10 @@ static int const RCTVideoUnset = -1;
         if (!CGRectEqualToRect(oldRect, newRect)) {
           if (CGRectEqualToRect(newRect, [UIScreen mainScreen].bounds)) {
             NSLog(@"in fullscreen");
-          } else NSLog(@"not fullscreen");
 
-          [self.reactViewController.view setFrame:[UIScreen mainScreen].bounds];
-          [self.reactViewController.view setNeedsLayout];
+            [self.reactViewController.view setFrame:[UIScreen mainScreen].bounds];
+            [self.reactViewController.view setNeedsLayout];
+          } else NSLog(@"not fullscreen");
         }
 
         return;


### PR DESCRIPTION
Only set the view frame when video is being presented as fullScreen.

The component, when not displayed fullScreen, shouldn't assume the parent React View is on the whole screen.

This fixes the case on any time you have a react view that displays the video, but its being rendered with controls but not as a full screen (ie. easily reproducible when you have a tabbar for instance - the reactViewController.view frame shouldn't be the whole screen bounds).

#### Update the documentation
🆗  No changes needed.

#### Update the changelog
✅ Done

#### Provide an example of how to test the change
Notice the bottom of the contentSize on the scroll view.

| Before | After |
| -- | -- |
| ![before](https://user-images.githubusercontent.com/428364/75365579-ad6ebb80-58bd-11ea-84bc-70cc83bc4c12.gif) | ![after](https://user-images.githubusercontent.com/428364/75365606-b52e6000-58bd-11ea-94e4-a62c0c96336d.gif) |

#### Focus the PR on only one area
🆗 

#### Describe the changes
✅ Done