### PR TITLE
Fix video height and width is undefined when playing HLS in ios

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -638,6 +638,10 @@ static int const RCTVideoUnset = -1;
           } else {
             orientation = @"portrait";
           }
+        } else {
+          // As HLS items would not have video track, we need another way to get the video size
+          width = [NSNumber numberWithFloat:_playerItem.presentationSize.width];
+          height = [NSNumber numberWithFloat:_playerItem.presentationSize.height];
         }
         
         if (self.onVideoLoad && _videoLoadStarted) {


### PR DESCRIPTION
#### Provide an example of how to test the change
Test with HLS, example: https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8

#### Describe the changes
As the number of video asset in player item is zero when playing HLS, we need to get the video size by _playerItem.presentationSize

####Related Issues
#1194
