### PR TITLE
Fixing ID3 Frame Error When Receiving EventMessage in TimedMetadata

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -229,25 +229,38 @@ class VideoEventEmitter {
         WritableArray metadataArray = Arguments.createArray();
 
         for (int i = 0; i < metadata.length(); i++) {
+            
+            Metadata.Entry entry = metadata.get(i);
 
+            if (entry instanceof Id3Frame) {
 
-            Id3Frame frame = (Id3Frame) metadata.get(i);
+                Id3Frame frame = (Id3Frame) entry;
 
-            String value = "";
+                String value = "";
 
-            if (frame instanceof TextInformationFrame) {
-                TextInformationFrame txxxFrame = (TextInformationFrame) frame;
-                value = txxxFrame.value;
+                if (frame instanceof TextInformationFrame) {
+                    TextInformationFrame txxxFrame = (TextInformationFrame) frame;
+                    value = txxxFrame.value;
+                }
+
+                String identifier = frame.id;
+
+                WritableMap map = Arguments.createMap();
+                map.putString("identifier", identifier);
+                map.putString("value", value);
+
+                metadataArray.pushMap(map);
+                
+            } else if (entry instanceof EventMessage) {
+                
+                EventMessage eventMessage = (EventMessage) entry;
+                
+                WritableMap map = Arguments.createMap();
+                map.putString("identifier", eventMessage.schemeIdUri);
+                map.putString("value", eventMessage.value);
+                metadataArray.pushMap(map);
+                
             }
-
-            String identifier = frame.id;
-
-            WritableMap map = Arguments.createMap();
-            map.putString("identifier", identifier);
-            map.putString("value", value);
-
-            metadataArray.pushMap(map);
-
         }
 
         WritableMap event = Arguments.createMap();

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -9,6 +9,7 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.google.android.exoplayer2.metadata.Metadata;
+import com.google.android.exoplayer2.metadata.emsg.EventMessage;
 import com.google.android.exoplayer2.metadata.id3.Id3Frame;
 import com.google.android.exoplayer2.metadata.id3.TextInformationFrame;
 


### PR DESCRIPTION
#### Describe the changes
On certain video streams, it is possible to receive an EventMessage instead of an ID3Frame. Thus the line `Id3Frame frame = (Id3Frame) metadata.get(i);` would cause a fatal Java Error. We are now funneling the logic into two branches when receiving an ID3 Frame or an EventMessage.

#### Update the changelog
After you open the PR, update the CHANGELOG.md file with an entry pointing to your PR.

#### Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.


