### PR TITLE
Fix video dimensions for HLS streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Version 5.1.0-alpha6
 
 - Fix iOS bug which would break size of views when video is displayed with controls on a non full-screen React view. [#1931](https://github.com/react-native-community/react-native-video/pull/1931)
+- Fix video dimensions were undefined when playing HLS in ios
 
 ### Version 5.1.0-alpha5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Version 5.1.0-alpha6
 
 - Fix iOS bug which would break size of views when video is displayed with controls on a non full-screen React view. [#1931](https://github.com/react-native-community/react-native-video/pull/1931)
-- Fix video dimensions were undefined when playing HLS in ios
+- Fix video dimensions being undefined when playing HLS in ios. [#1992](https://github.com/react-native-community/react-native-video/pull/1992)
 
 ### Version 5.1.0-alpha5
 

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -641,7 +641,7 @@ static int const RCTVideoUnset = -1;
         } else if (_playerItem.presentationSize.height) {
           width = [NSNumber numberWithFloat:_playerItem.presentationSize.width];
           height = [NSNumber numberWithFloat:_playerItem.presentationSize.height];
-          orientation = width > height ? @"landscape" : @"portrait";
+          orientation = _playerItem.presentationSize.width > _playerItem.presentationSize.height ? @"landscape" : @"portrait";
         }
         
         if (self.onVideoLoad && _videoLoadStarted) {

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -638,6 +638,10 @@ static int const RCTVideoUnset = -1;
           } else {
             orientation = @"portrait";
           }
+        } else if (_playerItem.presentationSize.height) {
+          width = [NSNumber numberWithFloat:_playerItem.presentationSize.width];
+          height = [NSNumber numberWithFloat:_playerItem.presentationSize.height];
+          orientation = width > height ? @"landscape" : @"portrait";
         }
         
         if (self.onVideoLoad && _videoLoadStarted) {


### PR DESCRIPTION
For HLS streams we need to get the video dimensions from `playerItem.presentationSize`. I've been using this code for months in a live app and works fine.

Resolves #1933 #1194 