### PR TITLE
Add troubleshooting from text tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,7 +725,7 @@ Add onLoad callback and dump the info:
 />
 ```
 
-You will see some something like this in the log:
+You will see something like this in the log:
 ```
 textTracks:
        [ { language: 'en',
@@ -741,7 +741,7 @@ selectedTextTrack={{
       value: "sub1:English",
     }}
 ```
-Pay attention to the value maching the title from the received textTracks.
+Pay attention to the value matching the title from the received textTracks.
 
 Platforms: Android ExoPlayer, iOS
 

--- a/README.md
+++ b/README.md
@@ -712,6 +712,37 @@ Both iOS & Android (only 4.4 and higher) offer Settings to enable Captions for h
 
 If a track matching the specified Type (and Value if appropriate) is unavailable, no text track will be displayed. If multiple tracks match the criteria, the first match will be used.
 
+If the track is not showing(especially on Android) the following might help:
+
+Add onLoad callback and dump the info: 
+
+```
+<Video
+    onLoad={(event) => {
+      console.log('video loaded', event);
+    }}
+    ...
+/>
+```
+
+You will see some something like this in the log:
+```
+textTracks:
+       [ { language: 'en',
+           type: 'text/vtt',
+           title: 'sub1:English',
+           index: 0 } ]
+```           
+Then add the following to the <Video> tag: 
+ 
+```
+selectedTextTrack={{
+      type: "title",
+      value: "sub1:English",
+    }}
+```
+Pay attention to the value maching the title from the received textTracks.
+
 Platforms: Android ExoPlayer, iOS
 
 #### selectedVideoTrack


### PR DESCRIPTION

This is the documentation update for text track. I faced an issue react-native-video not showing a text track on Android, but showing on iOS. In the README.MD I added a receipt how to trouble shout and overcome this situation.  
