### PR TITLE
Revert "[ios] Adaptive fullscreen in landscape by device orientation"

### DIFF
--- a/ios/Video/RCTVideoPlayerViewController.m
+++ b/ios/Video/RCTVideoPlayerViewController.m
@@ -28,7 +28,7 @@
 
 - (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation {
   if ([self.preferredOrientation.lowercaseString isEqualToString:@"landscape"]) {
-    return UIInterfaceOrientationLandscapeLeft | UIInterfaceOrientationLandscapeRight;
+    return UIInterfaceOrientationLandscapeRight;
   }
   else if ([self.preferredOrientation.lowercaseString isEqualToString:@"portrait"]) {
     return UIInterfaceOrientationPortrait;


### PR DESCRIPTION
Not allowed to send mask as `preferredInterfaceOrientationForPresentation`. In waiting for a proper solution I'm reverting this change.

Reverts react-native-community/react-native-video#1862