### PR TITLE
Fix exoplayer aspect ratio update on source changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added preventsDisplaySleepDuringVideoPlayback (#2019)
 - Reverted the JS fullscreening for Android. [#2013](https://github.com/react-native-community/react-native-video/pull/2013)
 - Set iOS request headers without needing to edit RCTVideo.m. [#2014](https://github.com/react-native-community/react-native-video/pull/2014)
+- Fix exoplayer aspect ratio update on source changes [#2053](https://github.com/react-native-community/react-native-video/pull/2053)
 
 ### Version 5.1.0-alpha5
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/AspectRatioFrameLayout.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/AspectRatioFrameLayout.java
@@ -67,6 +67,10 @@ public final class AspectRatioFrameLayout extends FrameLayout {
         return videoAspectRatio;
     }
 
+    public void invalidateAspectRatio() {
+        videoAspectRatio = 0;
+    }
+
     /**
      * Sets the resize mode which can be of value {@link ResizeMode.Mode}
      *

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -200,6 +200,11 @@ public final class ExoPlayerView extends FrameLayout {
         shutterView.setVisibility(VISIBLE);
     }
 
+    public void invalidateAspectRatio() {
+        // Resetting aspect ratio will force layout refresh on next video size changed
+        layout.invalidateAspectRatio();
+    }
+
     private final class ComponentListener implements SimpleExoPlayer.VideoListener,
             TextOutput, ExoPlayer.EventListener {
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -410,6 +410,8 @@ class ReactExoplayerView extends FrameLayout implements
                     player.setPlaybackParameters(params);
                 }
                 if (playerNeedsSource && srcUri != null) {
+                    exoPlayerView.invalidateAspectRatio();
+
                     ArrayList<MediaSource> mediaSourceList = buildTextSources();
                     MediaSource videoSource = buildMediaSource(srcUri, extension);
                     MediaSource mediaSource;


### PR DESCRIPTION
When using same player for reproducing videos with different sizes and aspect ratios, exoplayer will not update aspect ratio layout upon source change

This changes fix this by invalidating the aspect ration on every source change so the layout will be recalculated on next ``onVideoSizeChanged`` event.

Fixes #1225