### PR TITLE
Normalize language code on track selection on Exoplayer

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1041,9 +1041,10 @@ class ReactExoplayerView extends FrameLayout implements
             trackSelector.setParameters(disableParameters);
             return;
         } else if (type.equals("language")) {
+            String normalizedLanguage = Util.normalizeLanguageCode(value.asString());
             for (int i = 0; i < groups.length; ++i) {
                 Format format = groups.get(i).getFormat(0);
-                if (format.language != null && format.language.equals(value.asString())) {
+                if (format.language != null && format.language.equals(normalizedLanguage)) {
                     groupIndex = i;
                     break;
                 }


### PR DESCRIPTION
On ExoPlayer tracks gets their language normalized, so "spa" becomes "es" and "eng" becomes "en". Ths change normalize the language before comparing the selected track.

Reference:

https://github.com/google/ExoPlayer/blob/r2.11.4/library/core/src/main/java/com/google/android/exoplayer2/Format.java#L980
