### PR TITLE
Fix audioVolume value when muted is false

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1160,7 +1160,7 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setMutedModifier(boolean muted) {
         this.muted = muted;
-        audioVolume = muted ? 0.f : 1.f;
+        audioVolume = muted ? 0.f : audioVolume;
         if (player != null) {
             player.setVolume(audioVolume);
         }


### PR DESCRIPTION
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

#### Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

#### Update the changelog
After you open the PR, update the CHANGELOG.md file with an entry pointing to your PR.

#### Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

#### Focus the PR on only one area
Testing multiple features takes longer than isolated changes and if there is a bug in one feature, prevents the other parts of your PR from getting merged until it gets fixed.
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

#### Describe the changes

when I set volume = 0.1 or other less than 1 value, it doesn't work, because muted be set `1.f` when setMutedModifier(false),
so we need to use `audioVolume` instead of `1.f`
```js
         <Video
              source={{ uri: videoPlayUrl }}
              muted={false}
              volume={0.1}
              resizeMode="contain"
            />
```
```java    
//old
audioVolume = muted ? 0.f : 1.f;
//new
audioVolume = muted ? 0.f : audioVolume;
```
