### PR TITLE
[Windows] Renaming Boolean etc to AsBoolean

### DIFF
--- a/windows/ReactNativeVideoCPP/ReactVideoViewManager.cpp
+++ b/windows/ReactNativeVideoCPP/ReactVideoViewManager.cpp
@@ -64,28 +64,28 @@ void ReactVideoViewManager::UpdateProperties(
       auto const &propertyValue = pair.second;
       if (!propertyValue.IsNull()) {
         if (propertyName == "src") {
-            auto const &srcMap = propertyValue.Object();
+            auto const &srcMap = propertyValue.AsObject();
             auto const &uri = srcMap.at("uri");
-            reactVideoView.Set_UriString(to_hstring(uri.String()));
+            reactVideoView.Set_UriString(to_hstring(uri.AsString()));
         } else if (propertyName == "resizeMode") {
-            reactVideoView.Stretch(static_cast<Stretch>(std::stoul(propertyValue.String())));
+            reactVideoView.Stretch(static_cast<Stretch>(std::stoul(propertyValue.AsString())));
         } else if (propertyName == "repeat") {
-            reactVideoView.Set_IsLoopingEnabled(propertyValue.Boolean());
+            reactVideoView.Set_IsLoopingEnabled(propertyValue.AsBoolean());
         } else if (propertyName == "paused") {
-            m_paused = propertyValue.Boolean();
+            m_paused = propertyValue.AsBoolean();
             reactVideoView.Set_Paused(m_paused);
         } else if (propertyName == "muted") {
-            reactVideoView.Set_Muted(propertyValue.Boolean());
+            reactVideoView.Set_Muted(propertyValue.AsBoolean());
         } else if (propertyName == "volume") {
-            reactVideoView.Set_Volume(propertyValue.Double());
+            reactVideoView.Set_Volume(propertyValue.AsDouble());
         } else if (propertyName == "seek") {
-            reactVideoView.Set_Position(propertyValue.Double());
+            reactVideoView.Set_Position(propertyValue.AsDouble());
         } else if (propertyName == "controls") {
-            reactVideoView.Set_Controls(propertyValue.Boolean());
+            reactVideoView.Set_Controls(propertyValue.AsBoolean());
         } else if (propertyName == "fullscreen") {
-            reactVideoView.Set_FullScreen(propertyValue.Boolean());
+            reactVideoView.Set_FullScreen(propertyValue.AsBoolean());
         } else if (propertyName == "progressUpdateInterval") {
-            reactVideoView.Set_ProgressUpdateInterval(propertyValue.Int64());
+            reactVideoView.Set_ProgressUpdateInterval(propertyValue.AsInt64());
         }
       }
     }


### PR DESCRIPTION
Uses `NSValue.AsObject(`) instead of `Object()` that might be worked sometimes. There is also other `AsSomething()` changes

Tested with:
"react": "16.13.1",
"react-native": "0.62.2",
"react-native-windows": "0.62.5",
