### PR TITLE
Ability to set FontSize for textTrack in Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ var styles = StyleSheet.create({
 * [fullscreen](#fullscreen)
 * [fullscreenAutorotate](#fullscreenautorotate)
 * [fullscreenOrientation](#fullscreenorientation)
+* [fontSizeTrack](#fontSizeTrack)
 * [headers](#headers)
 * [hideShutterView](#hideshutterview)
 * [id](#id)
@@ -475,6 +476,11 @@ Platforms: iOS
 * **portrait**
 
 Platforms: iOS
+
+#### fontSizeTrack
+prop for setting fontSize of textTracks in Android 
+
+Platforms: Android
 
 #### headers
 Pass headers to the HTTP client. Can be used for authorization. Headers must be a part of the source object.

--- a/Video.js
+++ b/Video.js
@@ -53,7 +53,7 @@ export default class Video extends Component {
   }
 
   seek = (time, tolerance = 100) => {
-    if (isNaN(time)) {throw new Error('Specified time is not a number');}
+    if (isNaN(time)) { throw new Error('Specified time is not a number'); }
 
     if (Platform.OS === 'ios') {
       this.setNativeProps({
@@ -476,6 +476,7 @@ Video.propTypes = {
   fullscreenAutorotate: PropTypes.bool,
   fullscreenOrientation: PropTypes.oneOf(['all', 'landscape', 'portrait']),
   progressUpdateInterval: PropTypes.number,
+  fontSizeTrack: PropTypes.number,
   useTextureView: PropTypes.bool,
   hideShutterView: PropTypes.bool,
   onLoadStart: PropTypes.func,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -86,7 +86,7 @@ public final class ExoPlayerView extends FrameLayout {
     }
 
     public void setFontSizeTrack(int fontSizeTrack) {
-        subtitleLayout.setFixedTextSize(TypedValue.COMPLEX_UNIT_SP, fontSizeTrack );
+        subtitleLayout.setFixedTextSize(2, fontSizeTrack );
     }
 
     private void setVideoView() {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -85,6 +85,10 @@ public final class ExoPlayerView extends FrameLayout {
         addViewInLayout(layout, 0, aspectRatioParams);
     }
 
+    public void setFontSizeTrack(int fontSizeTrack) {
+        subtitleLayout.setFixedTextSize(TypedValue.COMPLEX_UNIT_SP, fontSizeTrack );
+    }
+
     private void setVideoView() {
         if (surfaceView instanceof TextureView) {
             player.setVideoTextureView((TextureView) surfaceView);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1169,6 +1169,10 @@ class ReactExoplayerView extends FrameLayout implements
         trackSelector.setParameters(selectionParameters);
     }
 
+     public void setFontSizeTrack(int fontSizeTrack) {
+        exoPlayerView.setFontSizeTrack(fontSizeTrack);
+    }
+
     private int getGroupIndexForDefaultLocale(TrackGroupArray groups) {
         if (groups.length == 0){
             return C.INDEX_UNSET;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -70,7 +70,8 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SELECTED_VIDEO_TRACK_VALUE = "value";
     private static final String PROP_HIDE_SHUTTER_VIEW = "hideShutterView";
     private static final String PROP_CONTROLS = "controls";
-
+    private static final String PROP_FRONT_SIZE_TRACK = "fontSizeTrack";
+    
     private ReactExoplayerConfig config;
 
     public ReactExoplayerViewManager(ReactExoplayerConfig config) {
@@ -271,6 +272,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_RATE)
     public void setRate(final ReactExoplayerView videoView, final float rate) {
         videoView.setRateModifier(rate);
+    }
+    
+    @ReactProp(name = PROP_FRONT_SIZE_TRACK, defaultInt = 30)
+    public void setFontSizeTrack(final ReactExoplayerView videoView, final int fontSizeTrack) {
+        videoView.setFontSizeTrack(fontSizeTrack);
     }
 
     @ReactProp(name = PROP_MAXIMUM_BIT_RATE)


### PR DESCRIPTION
Pass `fontSizeTrack` prop for setting fontSize of textTracks in Android.

```
<Video
            selectedTextTrack={{ type: 'language', value: 'en' }}
            textTracks={textTracks}
            source={{
              uri: this.props.route.params.file,
              type: 'mp4',
            }}
            controls={true}
            fullscreen={true}
            fontSizeTrack={16}
          />
```