### PR TITLE
fix(ios): <DRM issues> URL strings of skd:// schema changes.

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -1764,7 +1764,7 @@ didCancelLoadingRequest:(AVAssetResourceLoadingRequest *)loadingRequest {
   }
   _loadingRequest = loadingRequest;
   NSURL *url = loadingRequest.request.URL;
-  NSString *contentId = url.host;
+  NSString *contentId = [url.absoluteString stringByReplacingOccurrencesOfString:@"skd://" withString:@""];
   if (self->_drm != nil) {
     NSString *contentIdOverride = (NSString *)[self->_drm objectForKey:@"contentId"];
     if (contentIdOverride != nil) {
@@ -1782,7 +1782,7 @@ didCancelLoadingRequest:(AVAssetResourceLoadingRequest *)loadingRequest {
           }
           
           if (certificateData != nil) {
-            NSData *contentIdData = [contentId dataUsingEncoding:NSUTF8StringEncoding];
+            NSData *contentIdData = [NSData dataWithBytes: [contentId cStringUsingEncoding:NSUTF8StringEncoding] length:[contentId lengthOfBytesUsingEncoding:NSUTF8StringEncoding]];
             AVAssetResourceLoadingDataRequest *dataRequest = [loadingRequest dataRequest];
             if (dataRequest != nil) {
               NSError *spcError = nil;


### PR DESCRIPTION
Recently, On DRM project using of AVFoundation, there was an error on controlling FairPlay keys in iOS. 
And I noticed that the URL host can be chopped because of a base64 strings.
For example, If you got a URL string like "skd://[lenght of key 3][/ ( just a slash string)][lenght of key 61]"
it would be cropped only [lenght of key 3] string.
