### PR TITLE
#2045-Fix-ReactVideoView-does-not-clean-up-correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Version 4.4.4
 * Handle racing conditions when props are setted on exoplayer
+* Fix UWP ReactVideoView cleanup on dispose [#2045](https://github.com/react-native-community/react-native-video/issues/2045)
 
 ### Version 4.4.3
 * Fix mute/unmute when controls are present (iOS) [#1654](https://github.com/react-native-community/react-native-video/pull/1654)

--- a/windows/ReactNativeVideo/ReactVideoView.cs
+++ b/windows/ReactNativeVideo/ReactVideoView.cs
@@ -171,6 +171,7 @@ namespace ReactNativeVideo
                 mediaPlayer.PlaybackSession.BufferingStarted -= OnBufferingStarted;
                 mediaPlayer.PlaybackSession.BufferingEnded -= OnBufferingEnded;
                 MediaPlayer.PlaybackSession.SeekCompleted -= OnSeekCompleted;
+                mediaPlayer.Dispose();
             }
 
             _timer.Stop();


### PR DESCRIPTION
Fixed a bug where the `MediaPlayer` kept streaming audio even after dispose.
The issue can be reproduced in previous versions by starting a video stream an then move to another view.

Here is a link to the original issue: [#2045](https://github.com/react-native-community/react-native-video/issues/2045)