### PR TITLE
Add ARM64 support for windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Version 5.1.0-alpha9
+
+- Add arm64 support (TODO: update after PR is created)
+
 ### Version 5.1.0-alpha8
 
 - Fixing ID3 Frame Error When Receiving EventMessage in TimedMetadata [#2116](https://github.com/react-native-community/react-native-video/pull/2116)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Version 5.1.0-alpha9
 
-- Add arm64 support [#2137](https://github.com/react-native-community/react-native-video/pull/2137)
+- Add ARM64 support for windows [#2137](https://github.com/react-native-community/react-native-video/pull/2137)
 
 ### Version 5.1.0-alpha8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Version 5.1.0-alpha9
 
-- Add arm64 support (TODO: update after PR is created)
+- Add arm64 support [#2137](https://github.com/react-native-community/react-native-video/pull/2137)
 
 ### Version 5.1.0-alpha8
 

--- a/windows/ReactNativeVideoCPP/ReactNativeVideoCPP.vcxproj
+++ b/windows/ReactNativeVideoCPP/ReactNativeVideoCPP.vcxproj
@@ -22,6 +22,10 @@
       <Configuration>Debug</Configuration>
       <Platform>ARM</Platform>
     </ProjectConfiguration>
+	<ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
@@ -33,6 +37,10 @@
     <ProjectConfiguration Include="Release|ARM">
       <Configuration>Release</Configuration>
       <Platform>ARM</Platform>
+    </ProjectConfiguration>
+	<ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>

--- a/windows/ReactNativeVideoCPP/ReactNativeVideoCPP.vcxproj
+++ b/windows/ReactNativeVideoCPP/ReactNativeVideoCPP.vcxproj
@@ -22,7 +22,7 @@
       <Configuration>Debug</Configuration>
       <Platform>ARM</Platform>
     </ProjectConfiguration>
-	<ProjectConfiguration Include="Debug|ARM64">
+    <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>
       <Platform>ARM64</Platform>
     </ProjectConfiguration>
@@ -38,7 +38,7 @@
       <Configuration>Release</Configuration>
       <Platform>ARM</Platform>
     </ProjectConfiguration>
-	<ProjectConfiguration Include="Release|ARM64">
+    <ProjectConfiguration Include="Release|ARM64">
       <Configuration>Release</Configuration>
       <Platform>ARM64</Platform>
     </ProjectConfiguration>


### PR DESCRIPTION
Adding arm64 support for RNW builds.

Nothing in this project is using anything that isn't already supported in arm64 windows libs. It was simply overlooked when RNW was originally added.


We have been using RNW and RNV in our project for 6+ months and just been using a patch-package to apply this change. Figured it was overdue to upstream this change.

You can see this similar code in the RNW repo.
https://github.com/microsoft/react-native-windows/blob/95935e008621778dbcec01363602c19abc060632/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleLibraryCPP.vcxproj#L28
and
https://github.com/microsoft/react-native-windows/blob/master/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleLibraryCPP.vcxproj#L44

