### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/react-native-video.podspec
+++ b/react-native-video.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
     s.static_framework = true
   end
 
-  s.dependency "React"
+  s.dependency "React-Core"
 
   s.default_subspec = "Video"
 


### PR DESCRIPTION
#### Provide an example of how to test the change
Use this branch to install with an app running on Xcode 12 (and 11).

#### Describe the changes
Latest Xcode 12 fails to build while without a module to depend on `React-Core` directly hence this change is necessary for native modules on iOS. This change requires to React Native 0.60.2 or newer. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116
