### PR TITLE
Fix iOS Volume not returning to normal volumes when using ducking

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -963,7 +963,6 @@ static int const RCTVideoUnset = -1;
       [_player play];
       [_player setRate:_rate];
     }
-    [session setActive:TRUE error:nil];
     [_player setRate:_rate];
   }
 

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -928,12 +928,18 @@ static int const RCTVideoUnset = -1;
 {
   if (paused) {
     [_player pause];
-    [_player setRate:0.0];
+    [_player setRate:0.0]; 
+   
+    AVAudioSession *session = [AVAudioSession sharedInstance];
+    [session setActive:FALSE error:nil];
+    // // [session setActive:NO]
+    // [session setActive:NO];
+    // // [session setActive:false]
   } else {
     AVAudioSession *session = [AVAudioSession sharedInstance];
     AVAudioSessionCategory category = nil;
     AVAudioSessionCategoryOptions options = nil;
-
+    
     if([_ignoreSilentSwitch isEqualToString:@"ignore"]) {
       category = AVAudioSessionCategoryPlayback;
     } else if([_ignoreSilentSwitch isEqualToString:@"obey"]) {
@@ -960,9 +966,10 @@ static int const RCTVideoUnset = -1;
       [_player play];
       [_player setRate:_rate];
     }
+    [session setActive:TRUE error:nil];
     [_player setRate:_rate];
   }
-  
+
   _paused = paused;
 }
 

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -932,9 +932,6 @@ static int const RCTVideoUnset = -1;
    
     AVAudioSession *session = [AVAudioSession sharedInstance];
     [session setActive:FALSE error:nil];
-    // // [session setActive:NO]
-    // [session setActive:NO];
-    // // [session setActive:false]
   } else {
     AVAudioSession *session = [AVAudioSession sharedInstance];
     AVAudioSessionCategory category = nil;


### PR DESCRIPTION
Activates and Deactivates the audio session based on paused being set to true/false.  This is needed to restore ducking volume to normal normal level.