### PR TITLE
Fix: iOS rate is reset to 1.0 after play/pause #1930

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -718,7 +718,10 @@ static int const RCTVideoUnset = -1;
     }
   } else if (object == _player) {
     if([keyPath isEqualToString:playbackRate]) {
-      if(self.onPlaybackRateChange) {
+      if (_player.rate > 0 && _rate > 0 && _player.rate != _rate) {
+        // Playback is resuming, apply rate modifer.
+        [_player setRate:_rate];
+      } else if(self.onPlaybackRateChange) {
         self.onPlaybackRateChange(@{@"playbackRate": [NSNumber numberWithFloat:_player.rate],
                                     @"target": self.reactTag});
       }


### PR DESCRIPTION
#### Update the documentation
No changes to documentation needed.

#### Update the changelog
Will do.

#### Provide an example of how to test the change
If the rate prop is set it will apply as expected. However, when the video is paused & played the rate will be set to 1.0 - the custom rate is not re-applied. This bug is present on any fresh build.

#### Describe the changes
When playback resumes we check the new playbackRate against the props rate. If they're different we set the playbackRate to match the props rate.
