### PR TITLE
fix: Only allow Picture in picture if _pictureInPicture is set to true

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -156,7 +156,9 @@ static int const RCTVideoUnset = -1;
   viewController.showsPlaybackControls = YES;
   viewController.rctDelegate = self;
   viewController.preferredOrientation = _fullscreenOrientation;
-  
+  if (@available(iOS 9.0, *)) {
+	viewController.allowsPictureInPicturePlayback = _pictureInPicture;
+  }
   viewController.view.frame = self.bounds;
   viewController.player = player;
   return viewController;


### PR DESCRIPTION
**Provide an example of how to test the change**
Run example project on iOS 14 and picture in picture is not shown by default.

**Describe the changes**
pictureInPicture is default **false** but since iOS 14 picture in picture is shown by default. This change sets `allowsPictureInPicturePlayback` to the same value as pictureInPicture.

Issue: https://github.com/react-native-video/react-native-video/issues/2177