### PR TITLE
README.md improvement: warning about duplicate seeks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1249,6 +1249,8 @@ Seek to the specified position represented by seconds. seconds is a float value.
 
 `seek()` can only be called after the `onLoad` event has fired. Once completed, the [onSeek](#onseek) event will be called.
 
+Calling `seek(seconds)` will not result in an [onSeek](#onseek) event if the video's current time was already equal to `seconds`. This may have surprising results if you are keeping track of the video's seek state: not every call to `seek()` will result in an `onSeek` event.
+
 Example:
 ```
 this.player.seek(200); // Seek to 3 minutes, 20 seconds


### PR DESCRIPTION
## What was changed
This is a small documentation addition that explains an edge case I ran into: not every call to `seek()` will result in an `onSeek` event.

I initially considered filing this behavior as a bug, but I understand the logic behind ignoring what appear to be redundant `seek()` calls.  I ran into this because of a specific use case:
  - The component Video is `paused`.
  - I'm keeping track whether a seek in is progress with an `isSeeking` state.
  - When a user interacts with my custom controls, I check `isSeeking`:
     - true =>  disregard the user action.
     - false => call `seek()` and set `isSeeking` to true
 - When `onSeek` is called, set `isSeeking` to false.

This implementation has a bug: the user can request a seek to the same time twice (or more) in a row. The video is paused, so seeking is the only thing that will update the current video time. This means the first call to `seek` will result in an `onSeek` which sets `isSeeking` to false. But the _second_  call will set `isSeeking` to true and leave it there forever, disregarding all future user actions.

The solution was to keep track of the last seek time to avoid redundant calls on my side the same way the library is avoiding redundant calls.