### PR TITLE
remove unnecessary setRate

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -960,7 +960,6 @@ static int const RCTVideoUnset = -1;
       [_player play];
       [_player setRate:_rate];
     }
-    [_player setRate:_rate];
   }
   
   _paused = paused;


### PR DESCRIPTION
Is line 963 necessary? `playImmediatelyAtRate` already set the rate. I don't think we need it.
Tried in my own project and it works fine.

https://github.com/react-native-video/react-native-video/blob/faf8aed29bb566fe3b7a3125cc91845d68a62982/ios/Video/RCTVideo.m#L957-L964

