### PR TITLE
fix problem that all the callback parameters' value for windows are wrong

### DIFF
--- a/windows/ReactNativeVideoCPP/ReactVideoViewManager.cpp
+++ b/windows/ReactNativeVideoCPP/ReactVideoViewManager.cpp
@@ -100,10 +100,11 @@ ConstantProviderDelegate ReactVideoViewManager::ExportedCustomBubblingEventTypeC
 
 ConstantProviderDelegate ReactVideoViewManager::ExportedCustomDirectEventTypeConstants() noexcept {
   return [](winrt::Microsoft::ReactNative::IJSValueWriter const &constantWriter) {
-    WriteCustomDirectEventTypeConstant(constantWriter, "Load");
-    WriteCustomDirectEventTypeConstant(constantWriter, "End");
-    WriteCustomDirectEventTypeConstant(constantWriter, "Seek");
-    WriteCustomDirectEventTypeConstant(constantWriter, "Progress");
+    WriteCustomDirectEventTypeConstant(constantWriter, "VideoLoad");
+    WriteCustomDirectEventTypeConstant(constantWriter, "VideoEnd");
+    WriteCustomDirectEventTypeConstant(constantWriter, "VideoSeek");
+    WriteCustomDirectEventTypeConstant(constantWriter, "VideoProgress");
+    WriteCustomDirectEventTypeConstant(constantWriter, "VideoError");
   };
 }
 


### PR DESCRIPTION
# CHANGELOG (windows only)
- change the event's name to get the expected callback value  for  {onLoad & onProgress & onEnd & onSeek & onError}
- add callback value for onSeek & onError
- currentTime for windows now have milliseconds value
- add duration value for some events
- mediaPlayer choose the first audioTrack now. the history version choose the last audioTrack, which not match with iOS & Android.

# HISTORY PROBLEM
consider we have a demo like this
```TSX
<Video
  ref={videoRef}
  resizeMode={'contain'}
  controls={true}
  style={{width: 400, height: 300}}
  source={{
    uri:
      'http://oss.6tiantian.com/mp4_ZGE3MjA3YzYtNjkzMC00NzFhLTllOTMtYjdlZWE0MTRkZDJl.mp4',
  }}
  progressUpdateInterval={100}
  onLoad={(e) => {
    console.log('onLoad', e);
  }}
  onEnd={() => {
    console.log('onEnd');
  }}
  onProgress={(e) => {
    console.log('onProgress', e);
  }}
  onSeek={(e) => {
    console.log('onSeek', e);
  }}
  onError={(e) => {
    console.log('onError', e);
  }}>
</Video>
```
### the history version will have a log like this: ( history version log)
```
onLoad SyntheticEvent {dispatchConfig: {…}, _targetInst: FiberNode, nativeEvent: {…}, type: undefined, target: undefined, …}
onProgress SyntheticEvent {dispatchConfig: {…}, _targetInst: FiberNode, _dispatchInstances: FiberNode, nativeEvent: {…}, _dispatchListeners: ƒ, …}
...
onSeek SyntheticEvent {dispatchConfig: {…}, _targetInst: FiberNode, _dispatchInstances: FiberNode, nativeEvent: {…}, _dispatchListeners: ƒ, …}
...
onEnd
```

### what we expected is this:( PR version log)
```
onLoad {duration: 29.885, canPlaySlowForward: false, canStepBackward: false, currentTime: 0.0258333, canPlaySlow: false, …}
onProgress {currentTime: 0.04, playableDuration: 29.885, seekableDuration: 29.885}
...
onSeek {currentTime: 10, seekTime: 10}
...
onEnd
```

- i didn't find any issue related with this problem, so be catious.
- multi version compatiable test needed.

# Enviornments

D:\workspace\rn\RnTest>npx react-native --version
4.13.1

D:\workspace\rn\RnTest>npx react-native info
info Fetching system and libraries information...
System:
OS: Windows 10 10.0.19041
CPU: (16) ia32 AMD Ryzen 7 3700X 8-Core Processor
Memory: 6.05 GB / 15.94 GB
Binaries:
Node: 12.8.1 - D:\software\nodejs\node.EXE
Yarn: 1.22.4 - D:\software\Yarn\bin\yarn.CMD
npm: 6.14.4 - D:\software\nodejs\npm.CMD
Watchman: Not Found
SDKs:
Android SDK:
API Levels: 23, 28, 29
Build Tools: 26.0.2, 28.0.3, 29.0.3
System Images: android-28 | Google APIs Intel x86 Atom
Android NDK: Not Found
Windows SDK: Not Found
IDEs:
Android Studio: Not Found
Visual Studio: 16.8.30717.126 (Visual Studio Community 2019)
Languages:
Java: 1.8.0_241 - C:\Program Files\Java\jdk1.8.0_241\bin\javac.EXE
Python: Not Found
npmPackages:
@react-native-community/cli: Not Found
react: 16.11.0 => 16.11.0
react-native: 0.62.2 => 0.62.2
react-native-windows: 0.62.17 => 0.62.17
npmGlobalPackages:
react-native: Not Found