### PR TITLE
Update ReactNativeVideoCPP.vcxproj

### DIFF
--- a/windows/ReactNativeVideoCPP/ReactNativeVideoCPP.vcxproj
+++ b/windows/ReactNativeVideoCPP/ReactNativeVideoCPP.vcxproj
@@ -162,4 +162,5 @@
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>
+  <Target Name="Deploy" />
 </Project>


### PR DESCRIPTION
This PR adds a no-op build step for Windows that is required to be defined on some versions of React Native for Windows