### PR TITLE
Reference UIManager directly, not via NativeModules

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { StyleSheet, requireNativeComponent, NativeModules, View, ViewPropTypes, Image, Platform, findNodeHandle } from 'react-native';
+import { StyleSheet, requireNativeComponent, NativeModules, View, ViewPropTypes, Image, Platform, findNodeHandle, UIManager } from 'react-native';
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 import TextTrackType from './TextTrackType';
 import FilterType from './FilterType';
@@ -254,10 +254,10 @@ export default class Video extends Component {
     }
   }
   getViewManagerConfig = viewManagerName => {
-    if (!NativeModules.UIManager.getViewManagerConfig) {
-      return NativeModules.UIManager[viewManagerName];
+    if (!UIManager.getViewManagerConfig) {
+      return UIManager[viewManagerName];
     }
-    return NativeModules.UIManager.getViewManagerConfig(viewManagerName);
+    return UIManager.getViewManagerConfig(viewManagerName);
   };
 
   render() {


### PR DESCRIPTION
Fixes initialization bug where `NativeModules.UIManager` has not yet been initialized before `render` is called and constants are accessed.

While debugging today, I was hitting a crash caused by the failure of `UIManager` to have fully intialize various propeties, including the constant values, of `RCTVideo`, which meant that this call:

```
    const RCTVideoInstance = this.getViewManagerConfig('RCTVideo');
```

would return null, and this call would crash:

```RCTVideoInstance.Constants.ScaleToFill;```

By referring to `UIManager` instead of `NativeModules.UIManager`, we seem to force initialization of the constants in time for their access within the `render` method of `Video.js`

This project also appears to be the only [one on the internet](https://www.google.com/search?q=%22NativeModules.UIManager%22&oq=%22NativeModules.UIManager%22) that accesses UIManager via NativeModules.

This is related to: https://github.com/react-native-video/react-native-video/issues/2295