### PR TITLE
Only setup pip if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Add ARM64 support for windows [#2137](https://github.com/react-native-community/react-native-video/pull/2137)
 - Fix deprecated API bug for windows [#2119](https://github.com/react-native-video/react-native-video/pull/2119)
 - Added `rate` property and autolinking support for windows [#2206](https://github.com/react-native-video/react-native-video/pull/2206)
+- Fix `pictureInPicture` being disabled [#2297](https://github.com/react-native-community/react-native-video/pull/2297)
 
 ### Version 5.1.0-alpha8
 

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -908,7 +908,7 @@ static int const RCTVideoUnset = -1;
 }
 
 - (void)setupPipController {
-  if (!_pipController && _playerLayer && [AVPictureInPictureController isPictureInPictureSupported] && _pictureInPicture) {
+  if (_pictureInPicture && !_pipController && _playerLayer && [AVPictureInPictureController isPictureInPictureSupported]) {
     // Create new controller passing reference to the AVPlayerLayer
     _pipController = [[AVPictureInPictureController alloc] initWithPlayerLayer:_playerLayer];
     _pipController.delegate = self;


### PR DESCRIPTION
#### Update the documentation
Not relevant as this fixes an issue with `pictureInPicture`.

#### Update the changelog
- [x] Update changelog

#### Provide an example of how to test the change
It is not possible to disable Picture in Picture on newer iOS.

Given a video with `pictureInPicture={false}` will still make the video play on the Homescreen when app is backgrounded.

#### Describe the changes
This change ensures, that `AVPictureInPictureController` will only be initiated if needed.
