### PR TITLE
Update Readme to include onBuffer event (#2141)

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ var styles = StyleSheet.create({
 |--|--|
 |[onAudioBecomingNoisy](#onaudiobecomingnoisy)|Android ExoPlayer, iOS|
 |[onBandwidthUpdate](#onbandwidthupdate)|Android ExoPlayer|
+|[onBuffer](#onbuffer)|Android ExoPlayer, iOS|
 |[onEnd](#onend)|All|
 |[onExternalPlaybackChange](#onexternalplaybackchange)|iOS|
 |[onFullscreenPlayerWillPresent](#onfullscreenplayerwillpresent)|Android ExoPlayer, Android MediaPlayer, iOS|
@@ -954,6 +955,24 @@ Example:
 Note: On Android ExoPlayer, you must set the [reportBandwidth](#reportbandwidth) prop to enable this event. This is due to the high volume of events generated.
 
 Platforms: Android ExoPlayer
+
+#### onBuffer
+Callback function that is called when the player buffers.
+
+Payload:
+
+Property | Type | Description
+--- | --- | ---
+isBuffering | boolean | Boolean indicating whether buffering is active
+
+Example:
+```
+{
+  isBuffering: true
+}
+```
+
+Platforms: Android ExoPlayer, iOS
 
 #### onEnd
 Callback function that is called when the player reaches the end of the media.


### PR DESCRIPTION
This PR adds documentation for the `onBuffer` callback function, resolving issue #2141.