### PR TITLE
Request Audio Focus on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## Changelog
 
+- Request and respect audio focus on Android [#2318](https://github.com/react-native-video/react-native-video/pull/2318)
+
 ### Version 5.1.0-alpha9
 
 - Add ARM64 support for windows [#2137](https://github.com/react-native-community/react-native-video/pull/2137)
-- Request and respect audio focus on Android [#2318](https://github.com/react-native-video/react-native-video/pull/2318)
 
 ### Version 5.1.0-alpha8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Version 5.1.0-alpha9
 
 - Add ARM64 support for windows [#2137](https://github.com/react-native-community/react-native-video/pull/2137)
+- Request and respect audio focus on Android [#2318](https://github.com/react-native-video/react-native-video/pull/2318)
 
 ### Version 5.1.0-alpha8
 


### PR DESCRIPTION
Request and respect Android audio focus, pausing the video when focus is taken away.

This PR adds audio focus to the video player for Android.
1. When the video starts, audio focus is requested.  This will stop audio that may be playing in other apps.
2. While a video is playing, if audio focus is requested by another app, the video will temporarily reduce volume to 10% (in the case of AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) or pause the video for the other cases.

#### Update the documentation
No new props or events have been added

#### Provide an example of how to test the change
This can be tested on Android by having audio playing when the video is started, and then by starting audio in another app while the video is playing.  Audio Hog https://play.google.com/store/apps/details?id=com.ai.tools.audiohog&hl=en&gl=US is a useful app for triggering the different types of audio interruption.
