### PR TITLE
#836 Fix video endless loop when repeat set to false or not specified.

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -833,6 +833,7 @@ static int const RCTVideoUnset = -1;
     [item seekToTime:kCMTimeZero];
     [self applyModifiers];
   } else {
+    [self setPaused:true];
     [self removePlayerTimeObserver];
   }
 }


### PR DESCRIPTION
On video end set player pause.
