### PR TITLE
Exoplayer: Use same okhttp version as RN

### DIFF
--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -40,6 +40,6 @@ dependencies {
     implementation('com.google.android.exoplayer:extension-okhttp:2.11.4') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     }
-    implementation 'com.squareup.okhttp3:okhttp:3.14.3'
+    implementation 'com.squareup.okhttp3:okhttp:${OKHTTP_VERSION}'
 
 }


### PR DESCRIPTION
Because React Native uses okhttp, including exoplayer causes apps to use two different versions of okhttp.  This results in some unpredictable behavior.  Clients of `react-native-video` should be able to specify the same OKHTTP version to react-native and react-native video.

See where it's specified in react-native trunk: 
- https://github.com/facebook/react-native/blob/master/ReactAndroid/gradle.properties#L15
- https://github.com/facebook/react-native/blob/e1b6cd3f756aa034b11af6bf9960efb42bde8692/ReactAndroid/build.gradle#L452-L453
