### PR TITLE
Add player.getVideoBufferedDuration()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,19 @@ return (
 );
 ```
 
+#### getVideoBufferedDuration
+`getVideoBufferedDuration()`
+
+Return the current video buffered duration.
+
+Example:
+```js
+let bufferDuration = this.player.getVideoBufferedDuration();
+console.log({bufferDuration});
+```
+
+Platforms: Android 
+
 #### dismissFullscreenPlayer
 `dismissFullscreenPlayer()`
 

--- a/Video.js
+++ b/Video.js
@@ -52,6 +52,16 @@ export default class Video extends Component {
     return strObj;
   }
 
+  getVideoBufferedDuration = () => {
+    if (typeof this._root.getVideoBufferedDuration !== 'undefined') {
+      return this._root.getVideoBufferedDuration()
+    }
+    if (NativeModules.VideoManager.getVideoBufferedDuration !== 'undefined') {
+      return NativeModules.VideoManager.getVideoBufferedDuration()
+    }
+    return -1; // not supported
+  }
+
   seek = (time, tolerance = 100) => {
     if (isNaN(time)) {throw new Error('Specified time is not a number');}
 

--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -172,6 +172,10 @@ public class ReactVideoView extends ScalableVideoView implements
         };
     }
 
+    public float getVideoBufferedDuration() {
+        return mVideoBufferedDuration;
+    }
+
     @Override
     public boolean onTouchEvent(MotionEvent event) {
         if (mUseNativeControls) {


### PR DESCRIPTION
Addresses #2141 on Android. 

Implemented the 3rd suggested option.

The `getVideoBufferedDuration()` method returns the number of milliseconds buffered.

The current event-based code calculates `playableDuration` by converting `mVideoBufferedDuration` to seconds. Not sure if the conversion to seconds should be in the component implementation...

