### PR TITLE
add listeners for full screen iOS

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -747,9 +747,31 @@ static int const RCTVideoUnset = -1;
           if (CGRectEqualToRect(newRect, [UIScreen mainScreen].bounds)) {
             NSLog(@"in fullscreen");
 
-            [self.reactViewController.view setFrame:[UIScreen mainScreen].bounds];
-            [self.reactViewController.view setNeedsLayout];
-          } else NSLog(@"not fullscreen");
+          if (!_fullscreenPlayerPresented && _controls) {
+            _fullscreenPlayerPresented = YES;
+            if(self.onVideoFullscreenPlayerWillPresent) {
+              self.onVideoFullscreenPlayerWillPresent(@{@"target": self.reactTag});
+            }
+            if(self.onVideoFullscreenPlayerDidPresent) {
+              self.onVideoFullscreenPlayerDidPresent(@{@"target": self.reactTag});
+            }
+          }
+        } else {
+          NSLog(@"not fullscreen");
+          if (_fullscreenPlayerPresented && _controls) {
+            _fullscreenPlayerPresented = NO;
+            if(self.onVideoFullscreenPlayerWillDismiss) {
+              self.onVideoFullscreenPlayerWillDismiss(@{@"target": self.reactTag});
+            }
+            if(self.onVideoFullscreenPlayerDidDismiss) {
+              self.onVideoFullscreenPlayerDidDismiss(@{@"target": self.reactTag});
+            }
+          }
+        }
+        [self.reactViewController.view setFrame:[UIScreen mainScreen].bounds];
+        [self.reactViewController.view setNeedsLayout];
+            
+            
         }
 
         return;


### PR DESCRIPTION
reference PR https://github.com/react-native-video/react-native-video/pull/1669/files
also might help with this issue: https://github.com/react-native-video/react-native-video/issues/552

This attempts to apply the same fix, specifically when the native controls are active on IOS.

#### Provide an example of how to test the change

Add these props to the Video component 

    onFullscreenPlayerDidPresent={() => {
        console.log('Did Present in full  screen');
    }}
    onFullscreenPlayerWillPresent={() => {
        console.log('Will present in full screen');
    }}
    onFullscreenPlayerWillDismiss={() => {
        console.log('Will dismiss from full screen');
    }}
    onFullscreenPlayerDidDismiss={() => {
        console.log('Did dismiss from full screen');
    }}

#### Describe the changes 

Added listeners for:

- onFullscreenPlayerWillPresent
- onFullscreenPlayerDidPresent
- onFullscreenPlayerWillDismiss
- onFullscreenPlayerDidDismiss
