### PR TITLE
Make sure modifiers are applied before playing

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -383,6 +383,7 @@ static int const RCTVideoUnset = -1;
       }
       
       self->_player = [AVPlayer playerWithPlayerItem:self->_playerItem];
+      [self applyModifiers];
       self->_player.actionAtItemEnd = AVPlayerActionAtItemEndNone;
       
       [self->_player addObserver:self forKeyPath:playbackRate options:0 context:nil];


### PR DESCRIPTION
### Problem

On iOS, a video with `allowsExternalPlayback={false}` will hijack an ongoing audio playback if playing on AirPlay.

Steps to reproduce:
1. Start audio playing via AirPlay.
2. Initialize component with `allowsExternalPlayback={false}`
3. Now the audio will unexpectedly be interrupted, while nothing will start playing on AirPlay.

### Fix
By setting the modifiers right after a player is initialised, we ensure all configuration is respected when playback starts.