### PR TITLE
Upgrade exoplayer from 2.13.2 to 2.13.3

### DIFF
--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -28,7 +28,7 @@ android {
 
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation('com.google.android.exoplayer:exoplayer:2.13.2') {
+    implementation('com.google.android.exoplayer:exoplayer:2.13.3') {
         exclude group: 'com.android.support'
     }
 
@@ -37,7 +37,7 @@ dependencies {
     implementation "androidx.core:core:1.1.0"
     implementation "androidx.media:media:1.1.0"
 
-    implementation('com.google.android.exoplayer:extension-okhttp:2.13.2') {
+    implementation('com.google.android.exoplayer:extension-okhttp:2.13.3') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     }
     implementation 'com.squareup.okhttp3:okhttp:${OKHTTP_VERSION}'


### PR DESCRIPTION
Full Error Log:

error Failed to install the app. Make sure you have the Android development environment set up: https://reactnative.dev/docs/environment-setup.
Error: Command failed: ./gradlew app:installDebug -PreactNativeDevServerPort=8081

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:mergeDebugAssets'.
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Could not find com.google.android.exoplayer:exoplayer:2.13.2.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/com/google/android/exoplayer/exoplayer/2.13.2/exoplayer-2.13.2.pom
       - file:/home/devilslayer/.m2/repository/com/google/android/exoplayer/exoplayer/2.13.2/exoplayer-2.13.2.pom
       - file:/mnt/1EACD2FB2E5964FF/Development/Sandbox/vaderInterloper/node_modules/react-native/android/com/google/android/exoplayer/exoplayer/2.13.2/exoplayer-2.13.2.pom
       - file:/mnt/1EACD2FB2E5964FF/Development/Sandbox/vaderInterloper/node_modules/jsc-android/dist/com/google/android/exoplayer/exoplayer/2.13.2/exoplayer-2.13.2.pom
       - https://dl.google.com/dl/android/maven2/com/google/android/exoplayer/exoplayer/2.13.2/exoplayer-2.13.2.pom
       - https://www.jitpack.io/com/google/android/exoplayer/exoplayer/2.13.2/exoplayer-2.13.2.pom
     Required by:
         project :app > project :react-native-video
   > Could not find com.google.android.exoplayer:extension-okhttp:2.13.2.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/com/google/android/exoplayer/extension-okhttp/2.13.2/extension-okhttp-2.13.2.pom
       - file:/home/devilslayer/.m2/repository/com/google/android/exoplayer/extension-okhttp/2.13.2/extension-okhttp-2.13.2.pom
       - file:/mnt/1EACD2FB2E5964FF/Development/Sandbox/vaderInterloper/node_modules/react-native/android/com/google/android/exoplayer/extension-okhttp/2.13.2/extension-okhttp-2.13.2.pom
       - file:/mnt/1EACD2FB2E5964FF/Development/Sandbox/vaderInterloper/node_modules/jsc-android/dist/com/google/android/exoplayer/extension-okhttp/2.13.2/extension-okhttp-2.13.2.pom
       - https://dl.google.com/dl/android/maven2/com/google/android/exoplayer/extension-okhttp/2.13.2/extension-okhttp-2.13.2.pom
       - https://www.jitpack.io/com/google/android/exoplayer/extension-okhttp/2.13.2/extension-okhttp-2.13.2.pom
     Required by:
         project :app > project :react-native-video
         
         
         This PR is a fix for the above issue.