### PR TITLE
don't configure audio session if audio track is disabled

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -1071,9 +1071,9 @@ static int const RCTVideoUnset = -1;
 
 - (void)configureAudio
 {
-	if(_selectedAudioTrack == nil || [_selectedAudioTrack[@"type"] isEqualToString:@"disabled"]) {
-		return;
-	}
+    if(_selectedAudioTrack != nil && [_selectedAudioTrack[@"type"] isEqualToString:@"disabled"]) {
+        return;
+    }
     AVAudioSession *session = [AVAudioSession sharedInstance];
     AVAudioSessionCategory category = nil;
     AVAudioSessionCategoryOptions options = nil;

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -142,6 +142,11 @@ static int const RCTVideoUnset = -1;
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(applicationDidBecomeActive:)
+                                                 name:UIApplicationDidBecomeActiveNotification
+                                               object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(audioRouteChanged:)
                                                  name:AVAudioSessionRouteChangeNotification
                                                object:nil];
@@ -246,6 +251,12 @@ static int const RCTVideoUnset = -1;
   if (_playInBackground) {
     [_playerLayer setPlayer:_player];
     [_playerViewController setPlayer:_player];
+  }
+}
+
+-(void)applicationDidBecomeActive:(NSNotification*)notification {
+  if(!_playInBackground && !_paused && _player != nil) {
+    [_player play];
   }
 }
 

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -397,8 +397,8 @@ static int const RCTVideoUnset = -1;
         self->_player = [AVPlayer playerWithPlayerItem:self->_playerItem];
         [self applyModifiers];
       } else {
-        [self applyModifiers];
         [self->_player replaceCurrentItemWithPlayerItem:self->_playerItem];
+        [self applyModifiers];
       }
       self->_player.actionAtItemEnd = AVPlayerActionAtItemEndNone;
       
@@ -1644,7 +1644,6 @@ static int const RCTVideoUnset = -1;
     [_player removeObserver:self forKeyPath:externalPlaybackActive context:nil];
     _isExternalPlaybackActiveObserverRegistered = NO;
   }
-  _player = nil;
   
   [self removePlayerLayer];
   
@@ -1662,6 +1661,13 @@ static int const RCTVideoUnset = -1;
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   
   [super removeFromSuperview];
+}
+
+-(void)didMoveToWindow {
+  [super didMoveToWindow];
+  if(self.window != nil && _player != nil) {
+    [self applyModifiers];
+  }
 }
 
 #pragma mark - Export

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -382,7 +382,13 @@ static int const RCTVideoUnset = -1;
         self->_isExternalPlaybackActiveObserverRegistered = NO;
       }
       
-      self->_player = [AVPlayer playerWithPlayerItem:self->_playerItem];
+      if(self->_player == nil) {
+        self->_player = [AVPlayer playerWithPlayerItem:self->_playerItem];
+        [self applyModifiers];
+      } else {
+        [self applyModifiers];
+        [self->_player replaceCurrentItemWithPlayerItem:self->_playerItem];
+      }
       self->_player.actionAtItemEnd = AVPlayerActionAtItemEndNone;
       
       [self->_player addObserver:self forKeyPath:playbackRate options:0 context:nil];
@@ -907,7 +913,8 @@ static int const RCTVideoUnset = -1;
 }
 
 - (void)setupPipController {
-  if (!_pipController && _playerLayer && [AVPictureInPictureController isPictureInPictureSupported]) {
+  if (!_pipController && (_pictureInPicture || _playInBackground) && _playerLayer
+      && [AVPictureInPictureController isPictureInPictureSupported]) {
     // Create new controller passing reference to the AVPlayerLayer
     _pipController = [[AVPictureInPictureController alloc] initWithPlayerLayer:_playerLayer];
     _pipController.delegate = self;

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -1071,6 +1071,9 @@ static int const RCTVideoUnset = -1;
 
 - (void)configureAudio
 {
+	if(_selectedAudioTrack == nil || [_selectedAudioTrack[@"type"] isEqualToString:@"disabled"]) {
+		return;
+	}
     AVAudioSession *session = [AVAudioSession sharedInstance];
     AVAudioSessionCategory category = nil;
     AVAudioSessionCategoryOptions options = nil;


### PR DESCRIPTION
When playing a `Video` that has no audio, and also playing an audio track from another react native module, setting the audio session category seems to override or stops the other playing audio. Adding this check prevents the audio session from getting changed if the audio track is disabled.
