### PR TITLE
feat(ios): Add optional delegate to retrieve player in native side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Next version
+
+- Add optional delegate for RCTVideoPlayerViewController to access the player on native side [#2533](https://github.com/react-native-video/react-native-video/pull/2533)
+
 ### Version 5.2.0
 
 - Fix for tvOS native audio menu language selector

--- a/docs/nativeSideUsage.md
+++ b/docs/nativeSideUsage.md
@@ -1,0 +1,35 @@
+# Native side usage
+
+## iOS
+
+You will need to set a delegate for RNVideo's player.
+
+Create a MyVideoPlayerDelegate.swift (works only in equivalent objective-c code) file in your project :
+
+```swift
+import AVFoundation
+
+@objc(MyVideoPlayerDelegate)
+class MyVideoPlayerDelegate : NSObject, RCTVideoPlayerDelegate {
+  func playerDidAppear(_ player: AVPlayer!) {
+    // do something when player is mounted
+  }
+
+  func playerDidDisappear() {
+    // do something when player is unmounted
+  }
+}
+```
+
+In AppDelegate.m:
+
+```obj-c
+#import "RCTVideoPlayerViewController.h"
+
+...
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+    MyVideoPlayerDelegate *myVideoPlayerDelegate = [[MyVideoPlayerDelegate alloc] init];
+    RCTVideoPlayerViewController.videoPlayerDelegate = myVideoPlayerDelegate;
+```

--- a/ios/RCTVideo.xcodeproj/project.pbxproj
+++ b/ios/RCTVideo.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		D1107C072110259000073188 /* RCTVideo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCTVideo.h; path = Video/RCTVideo.h; sourceTree = "<group>"; };
 		D1107C082110259000073188 /* RCTVideoPlayerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCTVideoPlayerViewController.m; path = Video/RCTVideoPlayerViewController.m; sourceTree = "<group>"; };
 		D1107C092110259000073188 /* RCTVideoManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCTVideoManager.h; path = Video/RCTVideoManager.h; sourceTree = "<group>"; };
+		FF34A23B273BB77E0046DCE9 /* RCTVideoPlayerDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RCTVideoPlayerDelegate.h; path = Video/RCTVideoPlayerDelegate.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,6 +96,7 @@
 				D1107C012110259000073188 /* RCTVideoPlayerViewController.h */,
 				D1107C082110259000073188 /* RCTVideoPlayerViewController.m */,
 				D1107C022110259000073188 /* RCTVideoPlayerViewControllerDelegate.h */,
+				FF34A23B273BB77E0046DCE9 /* RCTVideoPlayerDelegate.h */,
 				D1107C042110259000073188 /* UIView+FindUIViewController.h */,
 				D1107C032110259000073188 /* UIView+FindUIViewController.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
@@ -163,6 +165,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 58B511D21A9E6C8500147676;

--- a/ios/Video/RCTVideoPlayerDelegate.h
+++ b/ios/Video/RCTVideoPlayerDelegate.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+#import "AVKit/AVKit.h"
+
+@protocol RCTVideoPlayerDelegate <NSObject>
+- (void)playerDidAppear:(AVPlayer *)player;
+- (void)playerDidDisappear;
+@end

--- a/ios/Video/RCTVideoPlayerViewController.h
+++ b/ios/Video/RCTVideoPlayerViewController.h
@@ -9,6 +9,7 @@
 #import <AVKit/AVKit.h>
 #import "RCTVideo.h"
 #import "RCTVideoPlayerViewControllerDelegate.h"
+#import "RCTVideoPlayerDelegate.h"
 
 @interface RCTVideoPlayerViewController : AVPlayerViewController
 @property (nonatomic, weak) id<RCTVideoPlayerViewControllerDelegate> rctDelegate;
@@ -16,5 +17,6 @@
 // Optional paramters
 @property (nonatomic, weak) NSString* preferredOrientation;
 @property (nonatomic) BOOL autorotate;
+@property (class, nonatomic, copy) id<RCTVideoPlayerDelegate> _Nullable videoPlayerDelegate;
 
 @end

--- a/ios/Video/RCTVideoPlayerViewController.m
+++ b/ios/Video/RCTVideoPlayerViewController.m
@@ -6,6 +6,14 @@
 
 @implementation RCTVideoPlayerViewController
 
+static id<RCTVideoPlayerDelegate> _videoPlayerDelegate = nil;
+
++ (void)setVideoPlayerDelegate:(id<RCTVideoPlayerDelegate>)videoPlayerDelegate {
+  _videoPlayerDelegate = videoPlayerDelegate;
+}
+
++ (id<RCTVideoPlayerDelegate>) videoPlayerDelegate { return _videoPlayerDelegate; }
+
 - (BOOL)shouldAutorotate {
 
   if (self.autorotate || self.preferredOrientation.lowercaseString == nil || [self.preferredOrientation.lowercaseString isEqualToString:@"all"])
@@ -13,12 +21,21 @@
   
   return NO;
 }
-
+- (void)viewDidAppear:(BOOL)animated
+{
+  [super viewDidAppear:animated];
+  if (_videoPlayerDelegate != nil) {
+    [_videoPlayerDelegate playerDidAppear:self.player];
+  }
+}
 - (void)viewDidDisappear:(BOOL)animated
 {
   [super viewDidDisappear:animated];
   [_rctDelegate videoPlayerViewControllerWillDismiss:self];
   [_rctDelegate videoPlayerViewControllerDidDismiss:self];
+  if (_videoPlayerDelegate != nil) {
+    [_videoPlayerDelegate playerDidDisappear];
+  }
 }
 
 #if !TARGET_OS_TV


### PR DESCRIPTION
Useful when you want to access the player in native side (eg. for SharePlay/GroupActivities)

Related issue #2444

In AppDelegate.m:

```obj-c
#import "RCTVideoPlayerViewController.h"

...

- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
{
    MyVideoPlayerDelegate *myVideoPlayerDelegate = [[MyVideoPlayerDelegate alloc] init];
    RCTVideoPlayerViewController.videoPlayerDelegate = myVideoPlayerDelegate;
```

In MyVideoPlayerDelegate.swift (works also in equivalent objective-c...)

```swift
import AVFoundation

@objc(MyVideoPlayerDelegate)
class MyVideoPlayerDelegate : NSObject, RCTVideoPlayerDelegate {
  func playerDidAppear(_ player: AVPlayer!) {
    // do something when player is mounted
  }

  func playerDidDisappear() {
    // do something when player is unmounted
  }
}
```


