### PR TITLE
clarify onProgress documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1113,7 +1113,7 @@ Platforms: all
 
 
 #### onProgress
-Callback function that is called every progressUpdateInterval seconds with info about which position the media is currently playing.
+Callback function that is called every progressUpdateInterval milliseconds with info about which position the media is currently playing.
 
 Property | Type | Description
 --- | --- | ---


### PR DESCRIPTION
The docs for `progressUpdateInterval` say that the value is in milliseconds, but the docs for `onProgress` said that the value was in seconds. This fixes the latter documentation to be consistent with the former.

This is a documentation-only update with no code changes.