### PR TITLE
Add google's maven repository to avoid to depend on JCenter dependency for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Version 5.2.1
+
+- Add Google's maven repository to avoid build error [#2552] (https://github.com/react-native-video/react-native-video/pull/2552) 
+
 ### Version 5.2.0
 
 - Fix for tvOS native audio menu language selector

--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -26,9 +26,14 @@ android {
     }
 }
 
+repositories {
+    // Remove this repository line after google releases to google() or mavenCentral()
+    maven { url "https://dl.google.com/android/maven2" }
+}
+
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation('com.google.android.exoplayer:exoplayer:2.13.2') {
+    implementation('com.google.android.exoplayer:exoplayer:2.13.3') {
         exclude group: 'com.android.support'
     }
 
@@ -37,7 +42,7 @@ dependencies {
     implementation "androidx.core:core:1.1.0"
     implementation "androidx.media:media:1.1.0"
 
-    implementation('com.google.android.exoplayer:extension-okhttp:2.13.2') {
+    implementation('com.google.android.exoplayer:extension-okhttp:2.13.3') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     }
     implementation 'com.squareup.okhttp3:okhttp:${OKHTTP_VERSION}'


### PR DESCRIPTION
### Description

This changes add a stable build for android without JCenter repository as bintray will shut down in Feb 1st 2022.
