### PR TITLE
[Android] Fix app crash from NPE in Exoplayer error handler

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -947,7 +947,8 @@ class ReactExoplayerView extends FrameLayout implements
                 // Special case for decoder initialization failures.
                 MediaCodecRenderer.DecoderInitializationException decoderInitializationException =
                         (MediaCodecRenderer.DecoderInitializationException) cause;
-                if (decoderInitializationException.codecInfo.name == null) {
+                if (decoderInitializationException.codecInfo == null
+                        || decoderInitializationException.codecInfo.name == null) {
                     if (decoderInitializationException.getCause() instanceof MediaCodecUtil.DecoderQueryException) {
                         errorString = getResources().getString(R.string.error_querying_decoders);
                     } else if (decoderInitializationException.secureDecoderRequired) {


### PR DESCRIPTION
On certain devices / emulators, decoder errors will crash the app with the following stacktrace:

```
2022-01-14 20:20:12.783 16778-16778/com.pdsouza.testapp.debug E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.pdsouza.testapp.debug, PID: 16778
    java.lang.NullPointerException: Attempt to read from field 'java.lang.String com.google.android.exoplayer2.mediacodec.MediaCodecInfo.name' on a null object reference
        at com.brentvatne.exoplayer.ReactExoplayerView.onPlayerError(ReactExoplayerView.java:950)
        at com.google.android.exoplayer2.ExoPlayerImpl.lambda$updatePlaybackInfo$9(ExoPlayerImpl.java:1027)
        at com.google.android.exoplayer2.-$$Lambda$ExoPlayerImpl$Y5tnvNJdNEscTPhujmeSdRy1n7Y.invoke(Unknown Source:4)
        at com.google.android.exoplayer2.util.ListenerSet$ListenerHolder.invoke(ListenerSet.java:297)
        at com.google.android.exoplayer2.util.ListenerSet.lambda$queueEvent$0(ListenerSet.java:184)
        at com.google.android.exoplayer2.util.-$$Lambda$ListenerSet$NbKDn9xtItiyMgYZmjIx_Sv1FFQ.run(Unknown Source:6)
        at com.google.android.exoplayer2.util.ListenerSet.flushEvents(ListenerSet.java:205)
        at com.google.android.exoplayer2.ExoPlayerImpl.updatePlaybackInfo(ExoPlayerImpl.java:1101)
        at com.google.android.exoplayer2.ExoPlayerImpl.handlePlaybackInfo(ExoPlayerImpl.java:965)
        at com.google.android.exoplayer2.ExoPlayerImpl.lambda$new$1$ExoPlayerImpl(ExoPlayerImpl.java:181)
        at com.google.android.exoplayer2.-$$Lambda$ExoPlayerImpl$nOBJYkeEQ2uz3sBKLToLWmzrgZk.run(Unknown Source:4)
        at android.os.Handler.handleCallback(Handler.java:883)
        at android.os.Handler.dispatchMessage(Handler.java:100)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
```

The fix is a simple null check. Tested and verified to work on a Pixel 4 API 29 emulator with RN 0.65 while playing a video with the `audio/ac3` codec.

After the fix, the error is reported back correctly:

```
2022-01-14 23:21:24.793 10266-10372/com.pdsouza.test.debug E/ReactNativeJS: 'Error loading video', { error: 
       { errorException: 'com.google.android.exoplayer2.ExoPlaybackException: MediaCodecAudioRenderer error, index=1, format=Format(2, null, null, audio/ac3, null, -1, und, [-1, -1, -1.0], [6, 48000]), format_supported=NO_UNSUPPORTED_TYPE',
         errorString: 'This device does not provide a decoder for audio/ac3' } }
```

This issue has been reported by others previously and this PR should fix https://github.com/react-native-video/react-native-video/issues/2388.
