### PR TITLE
Bump shaka-player to 3.3.2

### DIFF
--- a/DRMType.js
+++ b/DRMType.js
@@ -2,5 +2,5 @@ export default {
     WIDEVINE: 'widevine',
     PLAYREADY: 'playready',
     CLEARKEY: 'clearkey',
-    FAIRPLAY: 'fairplay'
+    FAIRPLAY: 'fairplay',
 };

--- a/Video.js
+++ b/Video.js
@@ -249,7 +249,7 @@ export default class Video extends Component {
           NativeModules.VideoManager.setLicenseError && NativeModules.VideoManager.setLicenseError(error, findNodeHandle(this._root));
         });
       } else {
-        NativeModules.VideoManager.setLicenseError && NativeModules.VideoManager.setLicenseError("No spc received", findNodeHandle(this._root));
+        NativeModules.VideoManager.setLicenseError && NativeModules.VideoManager.setLicenseError('No spc received', findNodeHandle(this._root));
       }
     }
   }
@@ -403,7 +403,7 @@ Video.propTypes = {
   ]),
   drm: PropTypes.shape({
     type: PropTypes.oneOf([
-      DRMType.CLEARKEY, DRMType.FAIRPLAY, DRMType.WIDEVINE, DRMType.PLAYREADY
+      DRMType.CLEARKEY, DRMType.FAIRPLAY, DRMType.WIDEVINE, DRMType.PLAYREADY,
     ]),
     licenseServer: PropTypes.string,
     headers: PropTypes.shape({}),

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "dependencies": {
         "keymirror": "^0.1.1",
         "prop-types": "^15.7.2",
-        "shaka-player": "^2.5.9"
+        "shaka-player": "^3.3.1"
     },
     "scripts": {
         "lint": "yarn eslint *.js"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "dependencies": {
         "keymirror": "^0.1.1",
         "prop-types": "^15.7.2",
-        "shaka-player": "^3.3.1"
+        "shaka-player": "^3.3.2"
     },
     "scripts": {
         "lint": "yarn eslint *.js"


### PR DESCRIPTION
shaka-player 2.5.9 is out-of-date and contains transitive dependencies with security vulnerabilities

### What's changing?
Updated shaka-player to latest version 3.3.1.

### Testing
In testing locally, react-native-video did not work on web even prior to the shaka-player update.

I followed the steps in the README to create an example web project using react-native-dom. In order to use react-native-dom, I had to use `react-native:0.55.0` and  `react-native-dom:0.2.0` per https://github.com/vincentriemer/react-native-dom/issues/109. When trying to run the server with `react-native start`, I got this error
```
bundling failed: ReferenceError: SHA-1 for file: react-native-video/examples/dom/node_modules/react-native/Libraries/polyfills/console.js
at DependencyGraph.getSha1 (/react-native-video/examples/dom/node_modules/metro/src/node-haste/DependencyGraph.js:258
```

I also tried creating another example project using webpack 5 and react-native-web. I successfully ran `webpack-dev-server --config ./webpack.js --entry ./index.web.tsx`, but ran into a variety of runtime errors in Video.js such as: https://github.com/react-native-video/react-native-video/issues/1542

I believe that since web support is already broken, it is safe to merge this shaka-player update. Any other improvements/fixes for the web platform can be addressed in a separate PR.
