### PR TITLE
Fix iOS 15.4 race condition (HLS playback)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Version 5.2.1
 
-- Add Google's maven repository to avoid build error [#2552] (https://github.com/react-native-video/react-native-video/pull/2552) 
+- Add Google's maven repository to avoid build error [#2552] (https://github.com/react-native-video/react-native-video/pull/2552)
+- Fix iOS 15.4 HLS playback race condition [#2633](#https://github.com/react-native-video/react-native-video/pull/2633)
 
 ### Version 5.2.0
 

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -1064,8 +1064,8 @@ static int const RCTVideoUnset = -1;
   [self setSelectedTextTrack:_selectedTextTrack];
   [self setResizeMode:_resizeMode];
   [self setRepeat:_repeat];
-  [self setPaused:_paused];
   [self setControls:_controls];
+  [self setPaused:_paused];
   [self setAllowsExternalPlayback:_allowsExternalPlayback];
 }
 


### PR DESCRIPTION
Closes #2630 

Fix credits got to @kanongil.

This PR flips two lines changing the order in which the native API is called to ensure that the player is fully ready before being started.

To validate, install https://github.com/hueniverse/react-native-video-test on iOS 15.4 and compare playback with and without the fix.
