### PR TITLE
Fix issue using video player on FlatList - AVFoundationErrorDomain Code -11839

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -79,6 +79,10 @@ export default class Video extends Component {
     return await NativeModules.VideoManager.save(options, findNodeHandle(this._root));
   }
 
+  componentWillUnmount() {
+    NativeModules.VideoManager.destroy(findNodeHandle(this._root));
+  }
+
   restoreUserInterfaceForPictureInPictureStopCompleted = (restored) => {
     this.setNativeProps({ restoreUserInterfaceForPIPStopCompletionHandler: restored });
   };

--- a/ios/Video/RCTVideo.h
+++ b/ios/Video/RCTVideo.h
@@ -61,6 +61,7 @@ typedef NS_ENUM(NSInteger, RCTVideoError) {
 - (AVPlayerViewController*)createPlayerViewController:(AVPlayer*)player withPlayerItem:(AVPlayerItem*)playerItem;
 
 - (void)save:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+- (void)destroy;
 - (void)setLicenseResult:(NSString * )license;
 - (BOOL)setLicenseResultError:(NSString * )error;
 

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -1693,6 +1693,13 @@ static int const RCTVideoUnset = -1;
   }
 }
 
+- (void)destroy
+{
+  [_playerLayer.player pause];
+  _playerLayer.player = nil;
+  [_playerLayer removeFromSuperlayer];
+}
+
 - (void)setLicenseResult:(NSString *)license {
   NSData *respondData = [self base64DataFromBase64String:license];
   if (_loadingRequest != nil && respondData != nil) {

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -1695,9 +1695,12 @@ static int const RCTVideoUnset = -1;
 
 - (void)destroy
 {
-  [_playerLayer.player pause];
-  _playerLayer.player = nil;
-  [_playerLayer removeFromSuperlayer];
+  if (_playerLayer.player)
+  {
+    [_playerLayer.player pause];
+    _playerLayer.player = nil;
+  }
+  [self removeFromSuperview];
 }
 
 - (void)setLicenseResult:(NSString *)license {

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -85,6 +85,19 @@ RCT_REMAP_METHOD(save,
         }
     }];
 };
+RCT_REMAP_METHOD(destroy,
+         reactTag:(nonnull NSNumber *)reactTag)
+{
+    [self.bridge.uiManager prependUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTVideo *> *viewRegistry) {
+        RCTVideo *view = viewRegistry[reactTag];
+        if (![view isKindOfClass:[RCTVideo class]]) {
+            RCTLogError(@"Invalid view returned from registry, expecting RCTVideo, got: %@", view);
+        } else {
+            [view destroy];
+        }
+    }];
+};
+
 RCT_REMAP_METHOD(setLicenseResult,
          license:(NSString *)license
          reactTag:(nonnull NSNumber *)reactTag)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.2.0",
+    "version": "5.2.1",
     "description": "A <Video /> element for react-native",
     "main": "Video.js",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.2.1",
+    "version": "5.2.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.js",
     "license": "MIT",


### PR DESCRIPTION
## What

Issue: https://github.com/react-native-video/react-native-video/issues/2475

Using `react-native-video` with FlatList has the issue being reported above

## Why

I think the cause is the video player is not being deallocated when the component (here is the FlatList item) being unmounted.

## How

I guess we could deallocate the Video player using `componentWillUnmount` and support calling `destroy` method by native module.

I tested with FlatList this way and it worked but I don't know object C and I think there could be another way to fix this issue so this PR is for notifying and ask for help on this issue.

Please help me review it and comment your better idea. Thanks a lot!