### PR TITLE
Disable pipController init if pictureInPicture is false

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -907,7 +907,7 @@ static int const RCTVideoUnset = -1;
 }
 
 - (void)setupPipController {
-  if (!_pipController && _playerLayer && [AVPictureInPictureController isPictureInPictureSupported]) {
+  if (!_pipController && _playerLayer && [AVPictureInPictureController isPictureInPictureSupported] && _pictureInPicture) {
     // Create new controller passing reference to the AVPlayerLayer
     _pipController = [[AVPictureInPictureController alloc] initWithPlayerLayer:_playerLayer];
     _pipController.delegate = self;


### PR DESCRIPTION
Disable pipController init if pictureInPicture is set to false prevents going to PIP mode on iOS when the app goes to the background. 

Tested on both iOS 14 and iOS 15 devices.

CC @hueniverse 