### PR TITLE
Update repo org references to react-native-video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1482,10 +1482,10 @@ If you encounter an error `Could not find com.android.support:support-annotation
 - [ ] Bring API closer to HTML5 `<Video>` [reference](http://devdocs.io/html/element/video)
 
 [1]: https://github.com/brentvatne/react-native-login/blob/56c47a5d1e23781e86e19b27e10427fd6391f666/App/Screens/UserInfoScreen.js#L32-L35
-[2]: https://github.com/react-native-community/react-native-video/tree/master/example
+[2]: https://github.com/react-native-video/react-native-video/tree/master/examples
 [3]: https://developer.apple.com/library/ios/qa/qa1668/_index.html
-[4]: https://github.com/react-native-community/react-native-video/workflows/ci/badge.svg
-[5]: https://github.com/react-native-community/react-native-video/actions
+[4]: https://github.com/react-native-video/react-native-video/workflows/ci/badge.svg
+[5]: https://github.com/react-native-video/react-native-video/actions
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git@github.com:react-native-community/react-native-video.git"
+        "url": "git@github.com:react-native-video/react-native-video.git"
     },
     "devDependencies": {
         "@react-native-community/eslint-config": "^0.0.5",

--- a/react-native-video.podspec
+++ b/react-native-video.podspec
@@ -9,8 +9,8 @@ Pod::Spec.new do |s|
   s.description    = package['description']
   s.license        = package['license']
   s.author         = package['author']
-  s.homepage       = 'https://github.com/react-native-community/react-native-video'
-  s.source       = { :git => "https://github.com/react-native-community/react-native-video.git", :tag => "#{s.version}" }
+  s.homepage       = 'https://github.com/react-native-video/react-native-video'
+  s.source       = { :git => "https://github.com/react-native-video/react-native-video.git", :tag => "v#{s.version}" }
 
   s.ios.deployment_target = "8.0"
   s.tvos.deployment_target = "9.0"


### PR DESCRIPTION
`react-native-community` -> `react-native-video`

The latest tag in the repo `v5.2.0` was (correctly) pushed with the conventional `v` prefix for version tags. This PR also updates the `source` field in the [Podspec](https://guides.cocoapods.org/syntax/podspec.html) file to reflect that.