### PR TITLE
#2665 - fix maxbitrate property being ignored on Android 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Fixed Android seeking bug [#2712](https://github.com/react-native-video/react-native-video/pull/2712)
 - Fixed `onReadyForDisplay` not being called [#2721](https://github.com/react-native-video/react-native-video/pull/2721)
 - Fix type of `_eventDispatcher` on iOS target to match `bridge.eventDispatcher()` [#2720](https://github.com/react-native-video/react-native-video/pull/2720)
+- Fix maxBitRate property being ignored on Android [#2670](https://github.com/react-native-video/react-native-video/pull/2670)
 
 ### Version 5.2.0
 

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1018,14 +1018,14 @@ class ReactExoplayerView extends FrameLayout implements
         if (loadVideoStarted) {
             loadVideoStarted = false;
             if (audioTrackType != null) {
-				setSelectedAudioTrack(audioTrackType, audioTrackValue);
-			}
-		    if (videoTrackType != null) {
-				setSelectedVideoTrack(videoTrackType, videoTrackValue);
-			}
-		    if (textTrackType != null) {
-				setSelectedTextTrack(textTrackType, textTrackValue);
-			}
+                setSelectedAudioTrack(audioTrackType, audioTrackValue);
+            }
+            if (videoTrackType != null) {
+                setSelectedVideoTrack(videoTrackType, videoTrackValue);
+            }
+            if (textTrackType != null) {
+                setSelectedTextTrack(textTrackType, textTrackValue);
+            }
             Format videoFormat = player.getVideoFormat();
             int width = videoFormat != null ? videoFormat.width : 0;
             int height = videoFormat != null ? videoFormat.height : 0;

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1017,9 +1017,15 @@ class ReactExoplayerView extends FrameLayout implements
     private void videoLoaded() {
         if (loadVideoStarted) {
             loadVideoStarted = false;
-            setSelectedAudioTrack(audioTrackType, audioTrackValue);
-            setSelectedVideoTrack(videoTrackType, videoTrackValue);
-            setSelectedTextTrack(textTrackType, textTrackValue);
+            if (audioTrackType != null) {
+				setSelectedAudioTrack(audioTrackType, audioTrackValue);
+			}
+			if (videoTrackType != null) {
+				setSelectedVideoTrack(videoTrackType, videoTrackValue);
+			}
+			if (textTrackType != null) {
+				setSelectedTextTrack(textTrackType, textTrackValue);
+			}
             Format videoFormat = player.getVideoFormat();
             int width = videoFormat != null ? videoFormat.width : 0;
             int height = videoFormat != null ? videoFormat.height : 0;

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1020,10 +1020,10 @@ class ReactExoplayerView extends FrameLayout implements
             if (audioTrackType != null) {
 				setSelectedAudioTrack(audioTrackType, audioTrackValue);
 			}
-			if (videoTrackType != null) {
+		    if (videoTrackType != null) {
 				setSelectedVideoTrack(videoTrackType, videoTrackValue);
 			}
-			if (textTrackType != null) {
+		    if (textTrackType != null) {
 				setSelectedTextTrack(textTrackType, textTrackValue);
 			}
             Format videoFormat = player.getVideoFormat();


### PR DESCRIPTION

#### Update the documentation
- No new property added

#### Update the changelog
- updated change log

#### Provide an example of how to test the change
- Test steps can be found on issue page [#2665](https://github.com/react-native-video/react-native-video/issues/2665) 

#### Focus the PR on only one area
- single fix

#### Describe the changes
- Inside ReactExoplayerView.java `videoLoaded()`, added guards to check type before allowing track selection overwrite. If type is null, don't do a track selection overwrite as that would cause a default `type=auto` overwrite to happen where it allows all available tracks to be used for ABR.
