### PR TITLE
Treat black screen as transparent before onLoad when using exoplayer

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -71,7 +71,7 @@ public final class ExoPlayerView extends FrameLayout {
 
         shutterView = new View(getContext());
         shutterView.setLayoutParams(layoutParams);
-        shutterView.setBackgroundColor(ContextCompat.getColor(context, android.R.color.black));
+        shutterView.setBackgroundColor(ContextCompat.getColor(context, android.R.color.transparent));
 
         subtitleLayout = new SubtitleView(context);
         subtitleLayout.setLayoutParams(layoutParams);

--- a/android-exoplayer/src/main/res/layout/exo_player_control_view.xml
+++ b/android-exoplayer/src/main/res/layout/exo_player_control_view.xml
@@ -5,7 +5,7 @@
     android:layout_height="wrap_content"
     android:layout_gravity="bottom"
     android:layoutDirection="ltr"
-    android:background="#CC000000"
+    android:background="@android:color/transparent"
     android:orientation="vertical">
 
     <LinearLayout

--- a/android-exoplayer/src/main/res/layout/exo_player_fullscreen_video.xml
+++ b/android-exoplayer/src/main/res/layout/exo_player_fullscreen_video.xml
@@ -3,7 +3,7 @@
     android:id="@+id/enclosing_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/black">
+    android:background="@android:color/transparent">
 
     <com.brentvatne.exoplayer.ExoPlayerView
         android:id="@+id/player_view"


### PR DESCRIPTION
hello.
I can not speak English very well.
I used the Android media player in this library, but there was a bug where autoplay (repeat) didn't work, so I replaced it with EXO-Player and changed the phenomenon that resets to a black screen before loading the video to be transparent. This will make it easier for developers to customize the background at the JavaScript level, and I think it can be used in common in the UI. thank you.