### PR TITLE
added author in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "A <Video /> element for react-native",
     "main": "Video.js",
     "license": "MIT",
-    "author": "Eran Hammer",
+    "author": "Community Contributors",
     "repository": {
         "type": "git",
         "url": "git@github.com:react-native-video/react-native-video.git"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "A <Video /> element for react-native",
     "main": "Video.js",
     "license": "MIT",
+    "author": "Eran Hammer",
     "repository": {
         "type": "git",
         "url": "git@github.com:react-native-video/react-native-video.git"


### PR DESCRIPTION
#### Describe the changes

Added `author` to `package.json` as library was giving error because in `react-native-video.podspec` we have 
Line 11 : `s.author         = package['author']` and author was not available in package.json

Attached screenshot for the same

![Screenshot 2022-05-27 at 10 49 14 AM](https://user-images.githubusercontent.com/11848011/170634439-0d3b2a56-4fd2-47cb-a7f8-14bfaac3ec7f.png)