### PR TITLE
updated ReactVideoView.java to fix seeking issue on android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Update basic example applications (React Native 0.63.4) [#2527](https://github.com/react-native-video/react-native-video/pull/2527)
 - Fix volume reset issue in exoPlayer [#2371](https://github.com/react-native-video/react-native-video/pull/2371)
 - Change WindowsTargetPlatformVersion to 10.0 [#2706](https://github.com/react-native-video/react-native-video/pull/2706)
+- Fixed Android seeking bug [#2712](https://github.com/react-native-video/react-native-video/pull/2712)
 
 ### Version 5.2.0
 

--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -637,7 +637,7 @@ public class ReactVideoView extends ScalableVideoView implements
     public void seekTo(int msec) {
         if (mMediaPlayerValid) {
             mSeekTime = msec;
-            mMediaPlayer.seekTo(msec,3);
+            mMediaPlayer.seekTo(msec, MediaPlayer.SEEK_CLOSEST);
             if (isCompleted && mVideoDuration != 0 && msec < mVideoDuration) {
                 isCompleted = false;
             }

--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -637,7 +637,7 @@ public class ReactVideoView extends ScalableVideoView implements
     public void seekTo(int msec) {
         if (mMediaPlayerValid) {
             mSeekTime = msec;
-            super.seekTo(msec);
+            mMediaPlayer.seekTo(msec,3);
             if (isCompleted && mVideoDuration != 0 && msec < mVideoDuration) {
                 isCompleted = false;
             }


### PR DESCRIPTION
This PR fixes a bug when trying to seek in the Video component on Android. Before, the video would skip to the beginning of the video if the user tried to seek, but now it works as expected.

To test, simply use the video component on android, and you are now able to seek.
