### PR TITLE
Fix DRM session failure causes playback failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ var styles = StyleSheet.create({
 * [automaticallyWaitsToMinimizeStalling](#automaticallyWaitsToMinimizeStalling)
 * [backBufferDurationMs](#backBufferDurationMs)
 * [bufferConfig](#bufferconfig)
+* [contentStartTime](#contentStartTime)
 * [controls](#controls)
 * [currentPlaybackTime](#currentPlaybackTime)
 * [disableFocus](#disableFocus)
@@ -412,10 +413,13 @@ Platforms: Android ExoPlayer, iOS
 
 #### controls
 Determines whether to show player controls.
-* ** false (default)** - Don't show player controls
+* **false (default)** - Don't show player controls
 * **true** - Show player controls
 
 Note on iOS, controls are always shown when in fullscreen mode.
+
+### contentStartTime
+The start time in ms for SSAI content. This determines at what time to load the video info like resolutions. Use this only when you have SSAI stream where ads resolution is not the same as content resolution.
 
 For Android MediaPlayer, you will need to build your own controls or use a package like [react-native-video-controls](https://github.com/itsnubix/react-native-video-controls) or [react-native-video-player](https://github.com/cornedor/react-native-video-player).
 

--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ Platforms: Android ExoPlayer, iOS
 
 #### controls
 Determines whether to show player controls.
+* ** false (default)** - Don't show player controls
 * **true** - Show player controls
 
 Note on iOS, controls are always shown when in fullscreen mode.

--- a/README.md
+++ b/README.md
@@ -278,7 +278,6 @@ var styles = StyleSheet.create({
 * [automaticallyWaitsToMinimizeStalling](#automaticallyWaitsToMinimizeStalling)
 * [backBufferDurationMs](#backBufferDurationMs)
 * [bufferConfig](#bufferconfig)
-* [contentStartTime](#contentStartTime)
 * [controls](#controls)
 * [currentPlaybackTime](#currentPlaybackTime)
 * [disableFocus](#disableFocus)
@@ -413,13 +412,9 @@ Platforms: Android ExoPlayer, iOS
 
 #### controls
 Determines whether to show player controls.
-* **false (default)** - Don't show player controls
 * **true** - Show player controls
 
 Note on iOS, controls are always shown when in fullscreen mode.
-
-### contentStartTime
-The start time in ms for SSAI content. This determines at what time to load the video info like resolutions. Use this only when you have SSAI stream where ads resolution is not the same as content resolution.
 
 For Android MediaPlayer, you will need to build your own controls or use a package like [react-native-video-controls](https://github.com/itsnubix/react-native-video-controls) or [react-native-video-player](https://github.com/cornedor/react-native-video-player).
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1315,7 +1315,8 @@ class ReactExoplayerView extends FrameLayout implements
             } else if(cause instanceof MediaDrmCallbackException || cause instanceof DrmSessionException) {
                 errorCode = "3005";
                 errorString = getResources().getString(R.string.unrecognized_media_format);
-                if (!hasDrmFailed) {
+                // DrmSessionExceptions can be caused by a lot internal reasons for failure, in most cases they can be safely retried and playback will recover
+                if (!hasDrmFailed || cause instanceof DrmSessionException) {
                     // When DRM fails to reach the app level certificate server it will fail with a source error so we assume that it is DRM related and try one more time
                     hasDrmFailed = true;
                     playerNeedsSource = true;
@@ -1402,7 +1403,6 @@ class ReactExoplayerView extends FrameLayout implements
     public void setSrc(final Uri uri, final String extension, Map<String, String> headers) {
         if (uri != null) {
             boolean isSourceEqual = uri.equals(srcUri);
-            
             hasDrmFailed = false;
             this.srcUri = uri;
             this.extension = extension;
@@ -1439,7 +1439,6 @@ class ReactExoplayerView extends FrameLayout implements
     public void setRawSrc(final Uri uri, final String extension) {
         if (uri != null) {
             boolean isSourceEqual = uri.equals(srcUri);
-
             this.srcUri = uri;
             this.extension = extension;
             this.mediaDataSourceFactory = buildDataSourceFactory(true);


### PR DESCRIPTION
#### Describe the changes
There are instances where DRM can fail during playback with a DRM session exception, this was usually caused by unmounting and then rapidly mounting React Native Video, causing the previous session to fail and emit an error to the new instance and fail playback. The DRM session exception can safely be retried one time since it is likely a transient issue.