### PR TITLE
Fix onReadyForDisplay not being called on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Fix volume reset issue in exoPlayer [#2371](https://github.com/react-native-video/react-native-video/pull/2371)
 - Change WindowsTargetPlatformVersion to 10.0 [#2706](https://github.com/react-native-video/react-native-video/pull/2706)
 - Fixed Android seeking bug [#2712](https://github.com/react-native-video/react-native-video/pull/2712)
+- Fixed `onReadyForDisplay` not being called [#2721](https://github.com/react-native-video/react-native-video/pull/2721)
 
 ### Version 5.2.0
 

--- a/ios/Video/Features/RCTPlayerObserver.swift
+++ b/ios/Video/Features/RCTPlayerObserver.swift
@@ -64,7 +64,7 @@ class RCTPlayerObserver: NSObject {
             removePlayerLayerObserver()
         }
         didSet {
-            if playerLayer == nil {
+            if playerLayer != nil {
                 addPlayerLayerObserver()
             }
         }


### PR DESCRIPTION
## Description

* Flipped `playerLayer` nil check on set to start observer correctly

## Testing

* `onReadyForDisplay` should be called normally now