### PR TITLE
fix: keep playback state while seeking when video is ended on android

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1640,7 +1640,7 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setPausedModifier(boolean paused) {
         isPaused = paused;
-        notifyPlaybackState()
+        notifyPlaybackState();
     }
 
     public void setMutedModifier(boolean muted) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1627,16 +1627,20 @@ class ReactExoplayerView extends FrameLayout implements
         textTrackValue = value;
         setSelectedTrack(C.TRACK_TYPE_TEXT, textTrackType, textTrackValue);
     }
-
-    public void setPausedModifier(boolean paused) {
-        isPaused = paused;
+                
+    private void notifyPlaybackState() {
         if (player != null) {
-            if (!paused) {
+            if (!isPaused) {
                 startPlayback();
             } else {
                 pausePlayback();
             }
         }
+    }
+
+    public void setPausedModifier(boolean paused) {
+        isPaused = paused;
+        notifyPlaybackState()
     }
 
     public void setMutedModifier(boolean muted) {
@@ -1656,6 +1660,7 @@ class ReactExoplayerView extends FrameLayout implements
     public void seekTo(long positionMs) {
         if (player != null) {
             player.seekTo(positionMs);
+            notifyPlaybackState();
             eventEmitter.seek(player.getCurrentPosition(), positionMs);
         }
     }


### PR DESCRIPTION
# What is the problem?
Video will stay paused when `repeat={false}` and video is ended. When user tries to seek, the playback state will remain on pause.
After seeking back, the video should start playing without changing the `paused` prop, since this is the expected behavior. iOS is behaving the same way.

Screen record of the issue on Android:
https://user-images.githubusercontent.com/24797481/174677945-18a47430-9c5c-4216-a217-1d267d562b51.mov

# What's changed?

- Added a new method `notifyPlaybackState`
- Call `notifyPlaybackState` when seeking