### PR TITLE
Added missing NSError initialization params on seek early return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix Exoplayer progress not reported when paused [#2664](https://github.com/react-native-video/react-native-video/pull/2664)
 - Call playbackRateChange onPlay and onPause [#1493](https://github.com/react-native-video/react-native-video/pull/1493)
 - Fix being unable to disable sideloaded texttracks in the AVPlayer [#2679](https://github.com/react-native-video/react-native-video/pull/2679)
+- Fixed crash when iOS seek method called reject on the promise [#2743](https://github.com/react-native-video/react-native-video/pull/2743)
 
 ### Version 6.0.0-alpha.1
 

--- a/ios/Video/Features/RCTPlayerOperations.swift
+++ b/ios/Video/Features/RCTPlayerOperations.swift
@@ -178,7 +178,7 @@ enum RCTPlayerOperations {
         
         return Promise<Bool>(on: .global()) { fulfill, reject in
             guard CMTimeCompare(current, cmSeekTime) != 0 else {
-                reject(NSError())
+                reject(NSError(domain: "", code: 0, userInfo: nil))
                 return
             }
             if !paused { player.pause() }


### PR DESCRIPTION
#### Describe the changes

Added the domain, code and userInfo to NSError initialization to prevent crash when reject is called