### PR TITLE
feat: add full screen support based on expo-av implementation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation "androidx.annotation:annotation:1.1.0"
     implementation "androidx.core:core:1.1.0"
     implementation "androidx.media:media:1.1.0"
+    implementation 'androidx.activity:activity:1.4.0'
 
     implementation('com.google.android.exoplayer:extension-okhttp:2.17.1') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'

--- a/android/src/main/java/com/brentvatne/exoplayer/FullScreenPlayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/FullScreenPlayerView.java
@@ -6,6 +6,8 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
 
+import androidx.activity.OnBackPressedCallback;
+
 import com.google.android.exoplayer2.ui.PlayerControlView;
 
 public class FullScreenPlayerView extends Dialog {
@@ -13,13 +15,21 @@ public class FullScreenPlayerView extends Dialog {
   private final ExoPlayerView exoPlayerView;
   private ViewGroup parent;
   private final FrameLayout containerView;
+  private final OnBackPressedCallback onBackPressedCallback;
 
-  public FullScreenPlayerView(Context context, ExoPlayerView exoPlayerView, PlayerControlView playerControlView) {
+  public FullScreenPlayerView(Context context, ExoPlayerView exoPlayerView, PlayerControlView playerControlView, OnBackPressedCallback onBackPressedCallback) {
     super(context, android.R.style.Theme_Black_NoTitleBar_Fullscreen);
     this.playerControlView = playerControlView;
     this.exoPlayerView = exoPlayerView;
+    this.onBackPressedCallback = onBackPressedCallback;
     containerView = new FrameLayout(context);
     setContentView(containerView, generateDefaultLayoutParams());
+  }
+
+  @Override
+  public void onBackPressed() {
+    super.onBackPressed();
+    onBackPressedCallback.handleOnBackPressed();
   }
 
   @Override

--- a/android/src/main/java/com/brentvatne/exoplayer/FullScreenPlayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/FullScreenPlayerView.java
@@ -31,7 +31,7 @@ public class FullScreenPlayerView extends Dialog {
 
     if (playerControlView != null) {
       ImageButton imageButton = playerControlView.findViewById(com.brentvatne.react.R.id.exo_fullscreen);
-      imageButton.setBackgroundResource(com.google.android.exoplayer2.ui.R.drawable.exo_icon_fullscreen_exit);
+      imageButton.setImageResource(com.google.android.exoplayer2.ui.R.drawable.exo_icon_fullscreen_exit);
       imageButton.setContentDescription(getContext().getString(com.google.android.exoplayer2.ui.R.string.exo_controls_fullscreen_exit_description));
       parent.removeView(playerControlView);
       containerView.addView(playerControlView, generateDefaultLayoutParams());
@@ -48,7 +48,7 @@ public class FullScreenPlayerView extends Dialog {
 
     if (playerControlView != null) {
       ImageButton imageButton = playerControlView.findViewById(com.brentvatne.react.R.id.exo_fullscreen);
-      imageButton.setBackgroundResource(com.google.android.exoplayer2.ui.R.drawable.exo_icon_fullscreen_enter);
+      imageButton.setImageResource(com.google.android.exoplayer2.ui.R.drawable.exo_icon_fullscreen_enter);
       imageButton.setContentDescription(getContext().getString(com.google.android.exoplayer2.ui.R.string.exo_controls_fullscreen_enter_description));
       containerView.removeView(playerControlView);
       parent.addView(playerControlView, generateDefaultLayoutParams());

--- a/android/src/main/java/com/brentvatne/exoplayer/FullScreenPlayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/FullScreenPlayerView.java
@@ -35,7 +35,6 @@ public class FullScreenPlayerView extends Dialog {
       imageButton.setContentDescription(getContext().getString(com.google.android.exoplayer2.ui.R.string.exo_controls_fullscreen_exit_description));
       parent.removeView(playerControlView);
       containerView.addView(playerControlView, generateDefaultLayoutParams());
-
     }
 
     super.onStart();

--- a/android/src/main/java/com/brentvatne/exoplayer/FullScreenPlayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/FullScreenPlayerView.java
@@ -1,0 +1,71 @@
+package com.brentvatne.exoplayer;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.ImageButton;
+
+import com.google.android.exoplayer2.ui.PlayerControlView;
+
+public class FullScreenPlayerView extends Dialog {
+  private final PlayerControlView playerControlView;
+  private final ExoPlayerView exoPlayerView;
+  private ViewGroup parent;
+  private final FrameLayout containerView;
+
+  public FullScreenPlayerView(Context context, ExoPlayerView exoPlayerView, PlayerControlView playerControlView) {
+    super(context, android.R.style.Theme_Black_NoTitleBar_Fullscreen);
+    this.playerControlView = playerControlView;
+    this.exoPlayerView = exoPlayerView;
+    containerView = new FrameLayout(context);
+    setContentView(containerView, generateDefaultLayoutParams());
+  }
+
+  @Override
+  protected void onStart() {
+    parent = (FrameLayout)(exoPlayerView.getParent());
+
+    parent.removeView(exoPlayerView);
+    containerView.addView(exoPlayerView, generateDefaultLayoutParams());
+
+    if (playerControlView != null) {
+      ImageButton imageButton = playerControlView.findViewById(com.brentvatne.react.R.id.exo_fullscreen);
+      imageButton.setBackgroundResource(com.google.android.exoplayer2.ui.R.drawable.exo_icon_fullscreen_exit);
+      imageButton.setContentDescription(getContext().getString(com.google.android.exoplayer2.ui.R.string.exo_controls_fullscreen_exit_description));
+      parent.removeView(playerControlView);
+      containerView.addView(playerControlView, generateDefaultLayoutParams());
+
+    }
+
+    super.onStart();
+  }
+
+  @Override
+  protected void onStop() {
+    containerView.removeView(exoPlayerView);
+    parent.addView(exoPlayerView, generateDefaultLayoutParams());
+
+    if (playerControlView != null) {
+      ImageButton imageButton = playerControlView.findViewById(com.brentvatne.react.R.id.exo_fullscreen);
+      imageButton.setBackgroundResource(com.google.android.exoplayer2.ui.R.drawable.exo_icon_fullscreen_enter);
+      imageButton.setContentDescription(getContext().getString(com.google.android.exoplayer2.ui.R.string.exo_controls_fullscreen_enter_description));
+      containerView.removeView(playerControlView);
+      parent.addView(playerControlView, generateDefaultLayoutParams());
+    }
+
+    parent.requestLayout();
+    parent = null;
+
+    super.onStop();
+  }
+
+  private FrameLayout.LayoutParams generateDefaultLayoutParams() {
+    FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(
+        FrameLayout.LayoutParams.MATCH_PARENT,
+        FrameLayout.LayoutParams.MATCH_PARENT
+    );
+    layoutParams.setMargins(0, 0, 0, 0);
+    return layoutParams;
+  }
+}

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -17,6 +17,8 @@ import android.view.accessibility.CaptioningManager;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
 
+import androidx.activity.OnBackPressedCallback;
+
 import com.brentvatne.react.R;
 import com.brentvatne.receiver.AudioBecomingNoisyReceiver;
 import com.brentvatne.receiver.BecomingNoisyListener;
@@ -669,7 +671,12 @@ class ReactExoplayerView extends FrameLayout implements
         setControls(controls);
         applyModifiers();
         startBufferCheckTimer();
-        fullScreenPlayerView = new FullScreenPlayerView(getContext(), exoPlayerView, playerControlView);
+        fullScreenPlayerView = new FullScreenPlayerView(getContext(), exoPlayerView, playerControlView, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                setFullscreen(false);
+            }
+        });
     }
 
     private DrmSessionManager buildDrmSessionManager(UUID uuid, String licenseUrl, String[] keyRequestPropertiesArray) throws UnsupportedDrmException {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1770,6 +1770,16 @@ class ReactExoplayerView extends FrameLayout implements
         if (activity == null) {
             return;
         }
+
+        if (fullScreenPlayerView == null) {
+            fullScreenPlayerView = new FullScreenPlayerView(getContext(), exoPlayerView, playerControlView, new OnBackPressedCallback(true) {
+                @Override
+                public void handleOnBackPressed() {
+                    setFullscreen(false);
+                }
+            });
+        }
+
         Window window = activity.getWindow();
         View decorView = window.getDecorView();
         int uiOptions;

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -370,7 +370,6 @@ class ReactExoplayerView extends FrameLayout implements
 
         // Setting the player for the playerControlView
         playerControlView.setPlayer(player);
-        playerControlView.show();
         playPauseControlContainer = playerControlView.findViewById(R.id.exo_play_pause_container);
 
         // Invoking onClick event for exoplayerView
@@ -448,6 +447,7 @@ class ReactExoplayerView extends FrameLayout implements
             removeViewAt(indexOfPC);
         }
         addView(playerControlView, 1, layoutParams);
+        reLayout(playerControlView);
     }
 
     /**
@@ -595,7 +595,7 @@ class ReactExoplayerView extends FrameLayout implements
                 new DefaultRenderersFactory(getContext())
                         .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF);
         player = new ExoPlayer.Builder(getContext(), renderersFactory)
-                    .setTrackSelector​(self.trackSelector)
+                    .setTrackSelector(self.trackSelector)
                     .setBandwidthMeter(bandwidthMeter)
                     .setLoadControl(loadControl)
                     .build();

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -140,6 +140,7 @@ class ReactExoplayerView extends FrameLayout implements
     private Player.Listener eventListener;
 
     private ExoPlayerView exoPlayerView;
+    private FullScreenPlayerView fullScreenPlayerView;
 
     private DataSource.Factory mediaDataSourceFactory;
     private ExoPlayer player;
@@ -398,6 +399,10 @@ class ReactExoplayerView extends FrameLayout implements
                 setPausedModifier(true);
             }
         });
+
+        //Handling the fullScreenButton click event
+        ImageButton fullScreenButton = playerControlView.findViewById(R.id.exo_fullscreen);
+        fullScreenButton.setOnClickListener(v -> setFullscreen(!isFullscreen));
 
         // Invoking onPlaybackStateChanged and onPlayWhenReadyChanged events for Player
         eventListener = new Player.Listener() {
@@ -664,6 +669,7 @@ class ReactExoplayerView extends FrameLayout implements
         setControls(controls);
         applyModifiers();
         startBufferCheckTimer();
+        fullScreenPlayerView = new FullScreenPlayerView(getContext(), exoPlayerView, playerControlView);
     }
 
     private DrmSessionManager buildDrmSessionManager(UUID uuid, String licenseUrl, String[] keyRequestPropertiesArray) throws UnsupportedDrmException {
@@ -1770,14 +1776,15 @@ class ReactExoplayerView extends FrameLayout implements
                         | SYSTEM_UI_FLAG_FULLSCREEN;
             }
             eventEmitter.fullscreenWillPresent();
-            decorView.setSystemUiVisibility(uiOptions);
+            fullScreenPlayerView.show();
             eventEmitter.fullscreenDidPresent();
         } else {
             uiOptions = View.SYSTEM_UI_FLAG_VISIBLE;
             eventEmitter.fullscreenWillDismiss();
-            decorView.setSystemUiVisibility(uiOptions);
+            fullScreenPlayerView.dismiss();
             eventEmitter.fullscreenDidDismiss();
         }
+        post(() -> decorView.setSystemUiVisibility(uiOptions));
     }
 
     public void setUseTextureView(boolean useTextureView) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1796,15 +1796,24 @@ class ReactExoplayerView extends FrameLayout implements
                         | SYSTEM_UI_FLAG_FULLSCREEN;
             }
             eventEmitter.fullscreenWillPresent();
-            fullScreenPlayerView.show();
-            eventEmitter.fullscreenDidPresent();
+            post(() -> {
+                decorView.setSystemUiVisibility(uiOptions);
+                if (controls) {
+                    fullScreenPlayerView.show();
+                }
+                eventEmitter.fullscreenDidPresent();
+            });
         } else {
             uiOptions = View.SYSTEM_UI_FLAG_VISIBLE;
             eventEmitter.fullscreenWillDismiss();
-            fullScreenPlayerView.dismiss();
-            eventEmitter.fullscreenDidDismiss();
+            post(() -> {
+                decorView.setSystemUiVisibility(uiOptions);
+                if (controls) {
+                    fullScreenPlayerView.dismiss();
+                }
+                eventEmitter.fullscreenDidDismiss();
+            });
         }
-        post(() -> decorView.setSystemUiVisibility(uiOptions));
     }
 
     public void setUseTextureView(boolean useTextureView) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1810,6 +1810,7 @@ class ReactExoplayerView extends FrameLayout implements
                 decorView.setSystemUiVisibility(uiOptions);
                 if (controls) {
                     fullScreenPlayerView.dismiss();
+                    reLayout(exoPlayerView);
                 }
                 eventEmitter.fullscreenDidDismiss();
             });

--- a/android/src/main/res/layout/exo_player_control_view.xml
+++ b/android/src/main/res/layout/exo_player_control_view.xml
@@ -71,6 +71,14 @@
             android:paddingRight="4dp"
             android:includeFontPadding="false"
             android:textColor="#FFBEBEBE"/>
+
+        <ImageButton
+            android:id="@id/exo_fullscreen"
+            style="@style/ExoMediaButton.FullScreen"
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:layout_margin="4dp"
+            android:scaleType="fitCenter" />
     </LinearLayout>
 
 </LinearLayout>

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="ExoMediaButton.FullScreen">
+        <item name="android:src">@drawable/exo_icon_fullscreen_enter</item>
+        <item name="android:contentDescription">@string/exo_controls_fullscreen_enter_description</item>
+    </style>
+</resources>


### PR DESCRIPTION
I saw #2688. Based on the description, it seems the implementation affected the stability of v6. I have an implementation which touches the minimal code. My implementation is based on expo-av implementation and use Dialog to do full screen.

![Kapture 2022-07-13 at 11 38 58](https://user-images.githubusercontent.com/5212215/178809007-fe60b565-c8ad-409e-bc5c-e51add6da62d.gif)

