### PR TITLE
fix: fix the system status bar and touch twice to show control after going back from fullscreen

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1796,22 +1796,22 @@ class ReactExoplayerView extends FrameLayout implements
                         | SYSTEM_UI_FLAG_FULLSCREEN;
             }
             eventEmitter.fullscreenWillPresent();
+            if (controls) {
+                fullScreenPlayerView.show();
+            }
             post(() -> {
                 decorView.setSystemUiVisibility(uiOptions);
-                if (controls) {
-                    fullScreenPlayerView.show();
-                }
                 eventEmitter.fullscreenDidPresent();
             });
         } else {
             uiOptions = View.SYSTEM_UI_FLAG_VISIBLE;
             eventEmitter.fullscreenWillDismiss();
+            if (controls) {
+                fullScreenPlayerView.dismiss();
+                reLayout(exoPlayerView);
+            }
             post(() -> {
                 decorView.setSystemUiVisibility(uiOptions);
-                if (controls) {
-                    fullScreenPlayerView.dismiss();
-                    reLayout(exoPlayerView);
-                }
                 eventEmitter.fullscreenDidDismiss();
             });
         }


### PR DESCRIPTION
@freeboub My apologies, I mis-understood our previous conversation and i did not test it carefully

Current behaviour on master. The system status bar does not show anything and you need to touch twice before you can see the player control after going back from full screen
![Kapture 2022-09-13 at 23 09 56](https://user-images.githubusercontent.com/5212215/190073471-9d459de7-6324-4899-a186-32c5de796e74.gif)

Expected behaviour
![Kapture 2022-09-13 at 23 05 56](https://user-images.githubusercontent.com/5212215/190072782-83c3ab06-73e7-4cc0-bf53-692a75a38b96.gif)


