### PR TITLE
Fix/ensure player stop on invalid url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
-### Version 6.0.0-alpha3
+
+### Version 6.0.0-alpha.4
+- ensure src is always provided to native player even if it is invalid [#2857](https://github.com/react-native-video/react-native-video/pull/2857)
+
+### Version 6.0.0-alpha.3
 - fix ios build [#2854](https://gthub.com/react-native-video/react-native-video/pull/2854)
 
 ### Version 6.0.0-alpha.2

--- a/Video.js
+++ b/Video.js
@@ -285,7 +285,7 @@ export default class Video extends Component {
     const isNetwork = !!(uri && uri.match(/^https?:/i));
     const isAsset = !!(uri && uri.match(/^(assets-library|ph|ipod-library|file|content|ms-appx|ms-appdata):/i));
 
-    if (uri && !isNetwork && !isAsset) {
+    if ((uri || uri === '') && !isNetwork && !isAsset) {
       if (this.props.onError) {
         this.props.onError({error: {errorString: 'invalid url, player will stop', errorCode: 'INVALID_URL'}});
       }

--- a/Video.js
+++ b/Video.js
@@ -276,16 +276,20 @@ export default class Video extends Component {
     let uri = source.uri || '';
     if (uri && uri.match(/^\//)) {
       uri = `file://${uri}`;
-    } else if (uri === '') {
-      return null;
     }
 
     if (!uri) {
-      console.warn('Trying to load empty source.');
+      console.log('Trying to load empty source.');
     }
 
-    const isNetwork = !!(uri && uri.match(/^https?:/));
-    const isAsset = !!(uri && uri.match(/^(assets-library|ph|ipod-library|file|content|ms-appx|ms-appdata):/));
+    const isNetwork = !!(uri && uri.match(/^https?:/i));
+    const isAsset = !!(uri && uri.match(/^(assets-library|ph|ipod-library|file|content|ms-appx|ms-appdata):/i));
+
+    if (uri && !isNetwork && !isAsset) {
+      if (this.props.onError) {
+        this.props.onError({error: {errorString: 'invalid url, player will stop', errorCode: 'INVALID_URL'}});
+      }
+    }
 
     let nativeResizeMode;
     const RCTVideoInstance = this.getViewManagerConfig('RCTVideo');

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -386,11 +386,12 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     }
 
     private boolean startsWithValidScheme(String uriString) {
-        return uriString.startsWith("http://")
-                || uriString.startsWith("https://")
-                || uriString.startsWith("content://")
-                || uriString.startsWith("file://")
-                || uriString.startsWith("asset://");
+        String lowerCaseUri = uriString.toLowerCase();
+        return lowerCaseUri.startsWith("http://")
+                || lowerCaseUri.startsWith("https://")
+                || lowerCaseUri.startsWith("content://")
+                || lowerCaseUri.startsWith("file://")
+                || lowerCaseUri.startsWith("asset://");
     }
 
     private @ResizeMode.Mode int convertToIntDef(String resizeModeOrdinalString) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -182,6 +182,8 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
                 if (srcUri != null) {
                     videoView.setRawSrc(srcUri, extension);
                 }
+            } else {
+                videoView.clearSrc();
             }
         }
     }

--- a/examples/basic/src/VideoPlayer.android.tsx
+++ b/examples/basic/src/VideoPlayer.android.tsx
@@ -52,7 +52,7 @@ class VideoPlayer extends Component {
     require('./broadchurch.mp4'),
     {
       description: '(dash) sintel subtitles',
-      uri: 'Https://bitmovin-a.akamaihd.net/content/sintel/sintel.mpd',
+      uri: 'https://bitmovin-a.akamaihd.net/content/sintel/sintel.mpd',
     },
     {
       description: '(mp4) big buck bunny',

--- a/examples/basic/src/VideoPlayer.android.tsx
+++ b/examples/basic/src/VideoPlayer.android.tsx
@@ -51,7 +51,7 @@ class VideoPlayer extends Component {
     require('./broadchurch.mp4'),
     {
       description: '(dash) sintel subtitles',
-      uri: 'https://bitmovin-a.akamaihd.net/content/sintel/sintel.mpd',
+      uri: 'Https://bitmovin-a.akamaihd.net/content/sintel/sintel.mpd',
     },
     {
       description: '(mp4) big buck bunny',
@@ -65,6 +65,12 @@ class VideoPlayer extends Component {
       description: '(mp4|subtitles) demo with sintel Subtitles',
       uri:
         'http://www.youtube.com/api/manifest/dash/id/bf5bb2419360daf1/source/youtube?as=fmp4_audio_clear,fmp4_sd_hd_clear&sparams=ip,ipbits,expire,source,id,as&ip=0.0.0.0&ipbits=0&expire=19000000000&signature=51AF5F39AB0CEC3E5497CD9C900EBFEAECCCB5C7.8506521BFC350652163895D4C26DEE124209AA9E&key=ik0',
+      type: 'mpd',
+    },
+    {
+      description: 'invalid URL',
+      uri:
+        'mmt://www.youtube.com',
       type: 'mpd',
     },
     { description: '(no url) Stopped playback', uri: undefined },
@@ -246,8 +252,8 @@ class VideoPlayer extends Component {
   }
 
   onError = (err: any) => {
-    console.log(JSON.stringify(err))
-    this.toast(true, 'error: ' + err?.error?.code)
+    console.log(JSON.stringify(err?.error.errorCode))
+    this.toast(true, 'error: ' + err?.error.errorCode)
   }
 
   onEnd = () => {

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -219,6 +219,12 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     @objc
     func setSrc(_ source:NSDictionary!) {
         _source = VideoSource(source)
+        if (_source?.uri == nil || _source?.uri == "") {
+            DispatchQueue.global(qos: .default).async {
+                self._player?.replaceCurrentItem(with: nil)
+            }
+            return;
+        }
         removePlayerLayer()
         _playerObserver.player = nil
         _playerObserver.playerItem = nil


### PR DESCRIPTION
fix: https://github.com/react-native-video/react-native-video/issues/2260

#### Provide an example of how to test the change
sample updated to test the change

#### Focus the PR on only one area
This PR allows to stop playback when invalid url is provided

#### Describe the changes
- Allow to pass invalid url to player implementation
- send early error on JS part
- ensure exoplayer is stopped on native side