### PR TITLE
Fix iOS RCTSwiftLog naming collision with rive-react-native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Changelog
+### Version 6.0.0-alpha4
+- Fix iOS RCTSwiftLog naming collision [#2868](https://github.com/react-native-video/react-native-video/issues/2868)
+
 ### Version 6.0.0-alpha3
-- fix ios build [#2854](https://gthub.com/react-native-video/react-native-video/pull/2854)
+- Fix ios build [#2854](https://github.com/react-native-video/react-native-video/pull/2854)
 
 ### Version 6.0.0-alpha.2
 

--- a/ios/Video/RCTVideoSwiftLog/RCTVideoSwiftLog.h
+++ b/ios/Video/RCTVideoSwiftLog/RCTVideoSwiftLog.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-@interface RCTSwiftLog : NSObject
+@interface RCTVideoSwiftLog : NSObject
 
 + (void)error:(NSString * _Nonnull)message file:(NSString * _Nonnull)file line:(NSUInteger)line;
 + (void)warn:(NSString * _Nonnull)message file:(NSString * _Nonnull)file line:(NSUInteger)line;

--- a/ios/Video/RCTVideoSwiftLog/RCTVideoSwiftLog.m
+++ b/ios/Video/RCTVideoSwiftLog/RCTVideoSwiftLog.m
@@ -1,8 +1,8 @@
 #import <React/RCTLog.h>
 
-#import "RCTSwiftLog.h"
+#import "RCTVideoSwiftLog.h"
 
-@implementation RCTSwiftLog
+@implementation RCTVideoSwiftLog
 
 + (void)info:(NSString *)message file:(NSString *)file line:(NSUInteger)line
 {

--- a/ios/Video/RCTVideoSwiftLog/RCTVideoSwiftLog.swift
+++ b/ios/Video/RCTVideoSwiftLog/RCTVideoSwiftLog.swift
@@ -26,23 +26,23 @@
  */
 
 func RCTLogError(_ message: String, _ file: String=#file, _ line: UInt=#line) {
-    RCTSwiftLog.error(message, file: file, line: line)
+    RCTVideoSwiftLog.error(message, file: file, line: line)
 }
 
 func RCTLogWarn(_ message: String, _ file: String=#file, _ line: UInt=#line) {
-    RCTSwiftLog.warn(message, file: file, line: line)
+    RCTVideoSwiftLog.warn(message, file: file, line: line)
 }
 
 func RCTLogInfo(_ message: String, _ file: String=#file, _ line: UInt=#line) {
-    RCTSwiftLog.info(message, file: file, line: line)
+    RCTVideoSwiftLog.info(message, file: file, line: line)
 }
 
 func RCTLog(_ message: String, _ file: String=#file, _ line: UInt=#line) {
-    RCTSwiftLog.log(message, file: file, line: line)
+    RCTVideoSwiftLog.log(message, file: file, line: line)
 }
 
 func RCTLogTrace(_ message: String, _ file: String=#file, _ line: UInt=#line) {
-    RCTSwiftLog.trace(message, file: file, line: line)
+    RCTVideoSwiftLog.trace(message, file: file, line: line)
 }
 
 func DebugLog(_ message: String) {


### PR DESCRIPTION
This PR will fix #2868, there may be other libraries where this collision should now be avoided, eg react-native-ios-context-menu ran into a similar issue and solved it in the same way https://github.com/dominicstop/react-native-ios-context-menu/commit/088254f53737822ded82b20ad499ad9c1307b70f

I've tested on an iPhone 14 emulator.