### PR TITLE
added homepage to package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Android: Switch Google's maven repository to default `google()` [#2860](https://github.com/react-native-video/react-native-video/pull/2860)
 - Android: Implement focusable prop so the video view can toggle whether it is focusable for non-touch devices [#2819](https://github.com/react-native-video/react-native-video/issues/2819)
 - Fix iOS RCTSwiftLog naming collision [#2868](https://github.com/react-native-video/react-native-video/issues/2868)
-- Added "homepage" to package.json [#2868](https://github.com/react-native-video/react-native-video/pull/2882)
+- Added "homepage" to package.json [#2882](https://github.com/react-native-video/react-native-video/pull/2882)
 
 ### Version 6.0.0-alpha.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Android: Switch Google's maven repository to default `google()` [#2860](https://github.com/react-native-video/react-native-video/pull/2860)
 - Android: Implement focusable prop so the video view can toggle whether it is focusable for non-touch devices [#2819](https://github.com/react-native-video/react-native-video/issues/2819)
 - Fix iOS RCTSwiftLog naming collision [#2868](https://github.com/react-native-video/react-native-video/issues/2868)
+- Added "homepage" to package.json [#2868](https://github.com/react-native-video/react-native-video/pull/2882)
 
 ### Version 6.0.0-alpha.3
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "main": "Video.js",
     "license": "MIT",
     "author": "Community Contributors",
+    "homepage": "https://github.com/react-native-video/react-native-video#readme",
     "repository": {
         "type": "git",
         "url": "git@github.com:react-native-video/react-native-video.git"


### PR DESCRIPTION
#### Describe the changes
Added "homepage" to package.json. This will let people see/click the link when hovering over this library in their own package.json file. Then it opens the link. Right now there is no link shown, and you have to manually google the library to go to the github repo. This just makes it a little easier.
