### PR TITLE
Fix predictive back gesture handler on android video player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - iOS rate is reset to 1.0 after play/pause [#2167] (https://github.com/react-native-video/react-native-video/pull/2167)
 - Upgrade ExoPlayer to 2.13.2 [#2317] (https://github.com/react-native-video/react-native-video/pull/2317)
 - Fix AudioFocus pausing video when attempting to play [#2311] (https://github.com/react-native-video/react-native-video/pull/2311)
+- Fix back gesture handler on Android Video Player [#2896] (https://github.com/react-native-video/react-native-video/pull/2896)
 
 ### Version 5.1.0-alpha9
 

--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -3,6 +3,7 @@ package com.brentvatne.react;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
+import android.content.Context;
 import android.content.res.AssetFileDescriptor;
 import android.graphics.Matrix;
 import android.media.MediaPlayer;
@@ -11,6 +12,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Handler;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.WindowManager;
 import android.view.View;
@@ -42,6 +44,26 @@ import java.math.BigDecimal;
 
 import javax.annotation.Nullable;
 
+class CustomMediaController extends MediaController {
+    public CustomMediaController(Context context) {
+        super(context);
+    }
+
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
+        int keyCode = event.getKeyCode();
+        if (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_MENU) {
+            Activity activity = ((ThemedReactContext) this.getContext()).getCurrentActivity();
+            if (activity != null) {
+                activity.onBackPressed();
+            }
+            return true;
+        }
+        return super.dispatchKeyEvent(event);
+    }
+}
+
+
 @SuppressLint("ViewConstructor")
 public class ReactVideoView extends ScalableVideoView implements
     MediaPlayer.OnPreparedListener,
@@ -51,7 +73,7 @@ public class ReactVideoView extends ScalableVideoView implements
     MediaPlayer.OnCompletionListener,
     MediaPlayer.OnInfoListener,
     LifecycleEventListener,
-    MediaController.MediaPlayerControl {
+    CustomMediaController.MediaPlayerControl {
 
     public enum Events {
         EVENT_LOAD_START("onVideoLoadStart"),
@@ -112,7 +134,7 @@ public class ReactVideoView extends ScalableVideoView implements
     private Handler mProgressUpdateHandler = new Handler();
     private Runnable mProgressUpdateRunnable = null;
     private Handler videoControlHandler = new Handler();
-    private MediaController mediaController;
+    private CustomMediaController mediaController;
 
     private String mSrcUriString = null;
     private String mSrcType = "mp4";
@@ -226,7 +248,7 @@ public class ReactVideoView extends ScalableVideoView implements
 
     private void initializeMediaControllerIfNeeded() {
         if (mediaController == null) {
-            mediaController = new MediaController(this.getContext());
+            mediaController = new CustomMediaController(this.getContext());
         }
     }
 


### PR DESCRIPTION
This adds support for android devices which do no have "physical back button" so the only way to go back is using the new Android predictive back gesture. 
Before when we would use the back gesture we would end up in an infinite loop triggering & hiding the media controls and not being able to exit out of the video because the gesture is handled as a `onTouch` event.