### PR TITLE
fix: repeat video on iOS with AVPlayerLooper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix iOS RCTSwiftLog naming collision [#2868](https://github.com/react-native-video/react-native-video/issues/2868)
 - Added "homepage" to package.json [#2882](https://github.com/react-native-video/react-native-video/pull/2882)
 - Fix: memory leak issue on iOS [#2907](https://github.com/react-native-video/react-native-video/pull/2907)
+- Fix: improve looping on iOS [#2922](https://github.com/react-native-video/react-native-video/pull/2922)
 
 ### Version 6.0.0-alpha.3
 

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -280,10 +280,10 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                 }
                 
                 if #available(iOS 10.0, *) {
-                    self._player = self._player ?? AVQueuePlayer(playerItem: playerItem!)
+                    self._player = AVQueuePlayer(playerItem: playerItem!)
                     if self._repeat {
-                        self._playerLooper = self._playerLooper ?? AVPlayerLooper(player: self._player as! AVQueuePlayer, templateItem: playerItem!)
-                    } 
+                        self._playerLooper = AVPlayerLooper(player: self._player as! AVQueuePlayer, templateItem: playerItem!)
+                    }
                 } else {
                     self._player = self._player ?? AVPlayer()
                     DispatchQueue.global(qos: .default).async {

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -546,6 +546,13 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     @objc
     func setRepeat(_ `repeat`: Bool) {
         _repeat = `repeat`
+        if #available(iOS 10, *) {
+            if _repeat && _player != nil && _playerItem != nil {
+                _playerLooper = _playerLooper ?? AVPlayerLooper(player: _player as! AVQueuePlayer, templateItem: _playerItem!)
+            } else {
+                _playerLooper = nil
+            }
+        }
     }
     
     

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -847,6 +847,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     override func removeFromSuperview() {
         _player?.pause()
         _player = nil
+        _playerLooper = nil
         _playerObserver.clearPlayer()
         
         self.removePlayerLayer()


### PR DESCRIPTION
Hello and thank you for a great library! This is a shot at the fix proposed in #2817 

To test this is just to run the basic example in this repo. Maybe remove the alert at the end to get the sense of the smoother repeat 😄 

The solution proposed is to create a `AVQueuePlayer` with a `AVPlayerLooper` if supported (iOS >= 10) and fall back to the previous used `AVPlayer` if it's not. The `AVPlayerLooper` need to be references to not be disposed. The variable holding that reference is typed to `NSObject` to make it compatible with previous iOS versions not supporting `AVPlayerLooper`. The order of things matter and I had to move passing the `playerItem` to the `playerObserver` until after initiation of the player 
