### PR TITLE
Guard against setting text tracks before player is initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added "homepage" to package.json [#2882](https://github.com/react-native-video/react-native-video/pull/2882)
 - Fix regression when fullscreen prop is used combined with controls [#2911](https://github.com/react-native-video/react-native-video/pull/2911)
 - Fix: memory leak issue on iOS [#2907](https://github.com/react-native-video/react-native-video/pull/2907)
+- Fix setting text tracks before player is initialized on iOS [#2935](https://github.com/react-native-video/react-native-video/pull/2935)
 
 ### Version 6.0.0-alpha.3
 

--- a/ios/Video/Features/RCTPlayerOperations.swift
+++ b/ios/Video/Features/RCTPlayerOperations.swift
@@ -132,6 +132,8 @@ enum RCTPlayerOperations {
         let type = criteria?.type
         let group:AVMediaSelectionGroup! = player?.currentItem?.asset.mediaSelectionGroup(forMediaCharacteristic: characteristic)
         var mediaOption:AVMediaSelectionOption!
+
+        guard group != nil else { return }
         
         if (type == "disabled") {
             // Do nothing. We want to ensure option is nil


### PR DESCRIPTION
#### Provide an example of how to test the change

Full repro steps can be found in [this issue](https://github.com/react-native-video/react-native-video/issues/2811).

TL;DR on iOS render the video player with a `source` pointing to a `.m3u8` playlist, `textTracks`, and `selectedTextTrack`, and observe the issue.

#### Describe the changes

This PR adds a guard against attempting to set text tracks on iOS before the `player` is actually initialized. See more in my [full comment here ](https://github.com/react-native-video/react-native-video/issues/2811#issuecomment-1279502277)
