### PR TITLE
Document the `onError` prop

### DIFF
--- a/API.md
+++ b/API.md
@@ -321,6 +321,7 @@ var styles = StyleSheet.create({
 |[onBandwidthUpdate](#onbandwidthupdate)|Android|
 |[onBuffer](#onbuffer)|Android, iOS|
 |[onEnd](#onend)|All|
+|[onError](#onerror)|Android, iOS|
 |[onExternalPlaybackChange](#onexternalplaybackchange)|iOS|
 |[onFullscreenPlayerWillPresent](#onfullscreenplayerwillpresent)|Android, iOS|
 |[onFullscreenPlayerDidPresent](#onfullscreenplayerdidpresent)|Android, iOS|
@@ -1011,6 +1012,17 @@ Platforms: Android, iOS
 Callback function that is called when the player reaches the end of the media.
 
 Payload: none
+
+Platforms: all
+
+#### onError
+Callback function that is called when the player experiences a playback error.
+
+Payload:
+
+Property | Type | Description
+--- | --- | ---
+error | object | Object containing properties with information about the error
 
 Platforms: all
 


### PR DESCRIPTION
The `onError` prop is not documented in the API docs. This fixes that.

I've not documented the individual properties of the `error` property because I'm not sure if they vary depending on the type of error, so best to be safe than sorry.