### PR TITLE
fix: iOS app crashes on call to presentFullScreenPlayer #2808

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Version 6.0.0-alpha.4
 
+- Fix: iOS app crashes on call to presentFullScreenPlayer [#2808](https://github.com/react-native-video/react-native-video/pull/2963)
 - ensure src is always provided to native player even if it is invalid [#2857](https://github.com/react-native-video/react-native-video/pull/2857)
 - Sample: Add react-native-video controls support [#2852](https://github.com/react-native-video/react-native-video/pull/2852)
 - Android: Switch Google's maven repository to default `google()` [#2860](https://github.com/react-native-video/react-native-video/pull/2860)

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -634,15 +634,16 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                 _presentingViewController = viewController
 
                 self.onVideoFullscreenPlayerWillPresent?(["target": reactTag as Any])
+                
+                if let playerViewController = _playerViewController {
+                    viewController.present(playerViewController, animated:true, completion:{
+                        self._playerViewController?.showsPlaybackControls = true
+                        self._fullscreenPlayerPresented = fullscreen
+                        self._playerViewController?.autorotate = self._fullscreenAutorotate
 
-                viewController.present(viewController, animated:true, completion:{
-                    self._playerViewController?.showsPlaybackControls = true
-                    self._fullscreenPlayerPresented = fullscreen
-                    self._playerViewController?.autorotate = self._fullscreenAutorotate
-
-                    self.onVideoFullscreenPlayerDidPresent?(["target": self.reactTag])
-
-                })
+                        self.onVideoFullscreenPlayerDidPresent?(["target": self.reactTag])
+                    })
+                }
             }
         } else if !fullscreen && _fullscreenPlayerPresented, let _playerViewController = _playerViewController {
             self.videoPlayerViewControllerWillDismiss(playerViewController: _playerViewController)


### PR DESCRIPTION
Fixes iOS app crashes on call to presentFullScreenPlayer. Closes https://github.com/react-native-video/react-native-video/issues/2808
