### PR TITLE
fix: fix ios compile issue

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -297,7 +297,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                     }
 
                     self._player = self._player ?? AVPlayer()
-                    self._player.replaceCurrentItem(with: playerItem)
+                    self._player?.replaceCurrentItem(with: playerItem)
                     self._playerObserver.player = self._player
                     self.applyModifiers()
                     self._player?.actionAtItemEnd = .none


### PR DESCRIPTION
fix RCTVideo.swift:300:26 Value of optional type 'AVPlayer?' must be unwrapped to refer to member 'replaceCurrentItem' of wrapped base type 'AVPlayer'