### PR TITLE
Fix/ios crash present full screen player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Version 6.0.0-alpha.4
 
+- Fix: iOS app crashes on call to presentFullScreenPlayer [#2808](https://github.com/react-native-video/react-native-video/pull/2971)
 - ensure src is always provided to native player even if it is invalid [#2857](https://github.com/react-native-video/react-native-video/pull/2857)
 - Sample: Add react-native-video controls support [#2852](https://github.com/react-native-video/react-native-video/pull/2852)
 - Android: Switch Google's maven repository to default `google()` [#2860](https://github.com/react-native-video/react-native-video/pull/2860)

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -635,14 +635,16 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
                 self.onVideoFullscreenPlayerWillPresent?(["target": reactTag as Any])
 
-                viewController.present(viewController, animated:true, completion:{
-                    self._playerViewController?.showsPlaybackControls = true
-                    self._fullscreenPlayerPresented = fullscreen
-                    self._playerViewController?.autorotate = self._fullscreenAutorotate
+                if let playerViewController = _playerViewController {
+                    viewController.present(playerViewController, animated:true, completion:{
+                        self._playerViewController?.showsPlaybackControls = true
+                        self._fullscreenPlayerPresented = fullscreen
+                        self._playerViewController?.autorotate = self._fullscreenAutorotate
 
-                    self.onVideoFullscreenPlayerDidPresent?(["target": self.reactTag])
+                        self.onVideoFullscreenPlayerDidPresent?(["target": self.reactTag])
 
-                })
+                    })
+                }
             }
         } else if !fullscreen && _fullscreenPlayerPresented, let _playerViewController = _playerViewController {
             self.videoPlayerViewControllerWillDismiss(playerViewController: _playerViewController)

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -324,7 +324,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                         "target": self.reactTag
                     ])
                 }.catch{_ in }
-            _videoLoadStarted = true
+            self._videoLoadStarted = true
         }
     }
 


### PR DESCRIPTION
Fixes iOS app crashes on call to presentFullScreenPlayer. Closes https://github.com/react-native-video/react-native-video/issues/2808