### PR TITLE
fix(android): clear progress handler before adding new one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Version 6.0.0-alpha.5
 
+ - Android: Fix publicated progress handler causing duplicated progress event [#2972](https://github.com/react-native-video/react-native-video/pull/2972)
  - Feature: Add VAST support for AVOD [#2923](https://github.com/react-native-video/react-native-video/pull/2923)
  - Sample: Upgrade react-native version of basic sample [#2960](https://github.com/react-native-video/react-native-video/pull/2960)
 

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1070,6 +1070,7 @@ class ReactExoplayerView extends FrameLayout implements
                 text += "ready";
                 eventEmitter.ready();
                 onBuffering(false);
+                clearProgressMessageHandler(); // ensure there is no other message
                 startProgressHandler();
                 videoLoaded();
                 if (selectTrackWhenReady && isUsingContentResolution) {


### PR DESCRIPTION
#### Describe the changes
Fix duplicated onProgress call on android.
It was happening after a playback paused (maybe also after connection issues)

Ticket: https://github.com/react-native-video/react-native-video/issues/2934