### PR TITLE
fix(ios): ensure audio and subtitle tracks are well reported

### DIFF
--- a/ios/Video/Features/RCTVideoUtils.swift
+++ b/ios/Video/Features/RCTVideoUtils.swift
@@ -103,10 +103,14 @@ enum RCTVideoUtils {
                 title = value as! String
             }
             let language:String! = currentOption?.extendedLanguageTag ?? ""
+
+            let selectedOption: AVMediaSelectionOption? = player.currentItem?.currentMediaSelection.selectedMediaOption(in: group!)
+
             let audioTrack = [
                 "index": NSNumber(value: i),
                 "title": title,
-                "language": language
+                "language": language ?? "",
+                "selected": currentOption?.displayName == selectedOption?.displayName
             ] as [String : Any]
             audioTracks.add(audioTrack)
         }
@@ -129,10 +133,13 @@ enum RCTVideoUtils {
                 title = value as! String
             }
             let language:String! = currentOption?.extendedLanguageTag ?? ""
+            let selectedOpt = player.currentItem?.currentMediaSelection
+            let selectedOption: AVMediaSelectionOption? = player.currentItem?.currentMediaSelection.selectedMediaOption(in: group!)
             let textTrack = TextTrack([
                 "index": NSNumber(value: i),
                 "title": title,
-                "language": language
+                "language": language,
+                "selected": currentOption?.displayName == selectedOption?.displayName
             ])
             textTracks.append(textTrack)
         }

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1007,6 +1007,8 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         }
 
         if _videoLoadStarted {
+            let audioTracks = RCTVideoUtils.getAudioTrackInfo(_player)
+            let textTracks = RCTVideoUtils.getTextTrackInfo(_player).map(\.json)
             onVideoLoad?(["duration": NSNumber(value: duration),
                           "currentTime": NSNumber(value: Float(CMTimeGetSeconds(_playerItem.currentTime()))),
                           "canPlayReverse": NSNumber(value: _playerItem.canPlayReverse),
@@ -1020,8 +1022,8 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                             "height": width != nil ? NSNumber(value: height!) : "undefinded",
                             "orientation": orientation
                           ],
-                          "audioTracks": RCTVideoUtils.getAudioTrackInfo(_player),
-                          "textTracks": _textTracks ?? RCTVideoUtils.getTextTrackInfo(_player),
+                          "audioTracks": audioTracks,
+                          "textTracks": textTracks,
                           "target": reactTag as Any])
         }
         _videoLoadStarted = false


### PR DESCRIPTION
IOS: ensure audio and subtitle tracks are well reported in onLoad.
I tested only with embed tracks, to be checked on externally loaded tracks