### PR TITLE
Ad Keeps On playing in background Even when the player is unmounted FIX

### DIFF
--- a/ios/Video/Features/RCTIMAAdsManager.swift
+++ b/ios/Video/Features/RCTIMAAdsManager.swift
@@ -17,6 +17,9 @@ class RCTIMAAdsManager: NSObject, IMAAdsLoaderDelegate, IMAAdsManagerDelegate {
     }
 
     func setUpAdsLoader() {
+        let settings = IMASettings()
+        settings.disableNowPlayingInfo = true
+        settings.enableBackgroundPlayback = false
         adsLoader = IMAAdsLoader(settings: nil)
         adsLoader.delegate = self
     }

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -883,7 +883,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         _player?.pause()
         _player = nil
         _playerObserver.clearPlayer()
-
+        _imaAdsManager.getAdsManager()?.destroy()
         self.removePlayerLayer()
 
         if let _playerViewController = _playerViewController {

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -883,6 +883,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         _player?.pause()
         _player = nil
         _playerObserver.clearPlayer()
+        _imaAdsManager.getAdsManager()?.pause()
         _imaAdsManager.getAdsManager()?.destroy()
         _imaAdsManager.getAdsLoader()?.contentComplete()
         _imaAdsManager = nil

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -884,6 +884,9 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         _player = nil
         _playerObserver.clearPlayer()
         _imaAdsManager.getAdsManager()?.destroy()
+        _imaAdsManager.getAdsLoader()?.contentComplete()
+        _imaAdsManager = nil
+        
         self.removePlayerLayer()
 
         if let _playerViewController = _playerViewController {

--- a/react-native-video.podspec
+++ b/react-native-video.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
     ss.source_files  = "ios/Video/**/*.{h,m,swift}"
     ss.dependency "PromisesSwift"
 
-    ss.ios.dependency 'GoogleAds-IMA-iOS-SDK', '~> 3.18.1'
+    ss.ios.dependency 'GoogleAds-IMA-iOS-SDK', '~> 3.2.1'
     ss.tvos.dependency 'GoogleAds-IMA-tvOS-SDK', '~> 4.2'
   end
 

--- a/react-native-video.podspec
+++ b/react-native-video.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
     ss.source_files  = "ios/Video/**/*.{h,m,swift}"
     ss.dependency "PromisesSwift"
 
-    ss.ios.dependency 'GoogleAds-IMA-iOS-SDK', '~> 3.2.1'
+    ss.ios.dependency 'GoogleAds-IMA-iOS-SDK', '~> 3.18.1'
     ss.tvos.dependency 'GoogleAds-IMA-tvOS-SDK', '~> 4.2'
   end
 


### PR DESCRIPTION
Added   _imaAdsManager.getAdsManager()?.destroy() in removeFromSuperview method to clear Ad state when the player is unmounted. 
Prevents Ad audio to play in background even when the player is unmounted. 