### PR TITLE
Fix typo in subtitleStyle docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -920,7 +920,7 @@ The following other types are supported on some platforms, but aren't fully docu
 
 Property | Description | Platforms
 --- | --- | ---
-fontSizeTrack | Adjust the font size of the subtitles. Default: font size of the device | Android
+fontSize | Adjust the font size of the subtitles. Default: font size of the device | Android
 paddingTop | Adjust the top padding of the subtitles. Default: 0| Android
 paddingBottom | Adjust the bottom padding of the subtitles. Default: 0| Android
 paddingLeft | Adjust the left padding of the subtitles. Default: 0| Android


### PR DESCRIPTION
It's `fontSize` not `fontSizeTrack`