### PR TITLE
fix: remove dummy nativeOnly

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -416,13 +416,6 @@ Video.propTypes = {
     FilterType.SEPIA,
   ]),
   filterEnabled: PropTypes.bool,
-  /* Native only */
-  src: PropTypes.object,
-  seek: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.object,
-  ]),
-  fullscreen: PropTypes.bool,
   onVideoLoadStart: PropTypes.func,
   onVideoLoad: PropTypes.func,
   onVideoBuffer: PropTypes.func,
@@ -566,10 +559,4 @@ Video.propTypes = {
   ...ViewPropTypes,
 };
 
-const RCTVideo = requireNativeComponent('RCTVideo', Video, {
-  nativeOnly: {
-    src: true,
-    seek: true,
-    fullscreen: true,
-  },
-});
+const RCTVideo = requireNativeComponent('RCTVideo');


### PR DESCRIPTION
We are working on fabric support for video. This is the first one

#### Describe the changes

According to https://github.com/facebook/react-native/issues/28351#issuecomment-602755235, `requireNativeComponent` recieves only one argument since react-native@0.56

According to https://github.com/facebook/react-native/tree/v0.69.4/Libraries/Components/Switch, native only properties are declared in `<ComponentName>NativeComponent.js`, e.g. `on`, `enabled` and `trackTintColor`