### PR TITLE
fix: update debug JSBundle name & rootView component

### DIFF
--- a/examples/basic/ios/videoplayer/AppDelegate.mm
+++ b/examples/basic/ios/videoplayer/AppDelegate.mm
@@ -44,7 +44,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 #endif
 
   NSDictionary *initProps = [self prepareInitialProps];
-  UIView *rootView = RCTAppSetupDefaultRootView(bridge, @"videoplayer", initProps);
+  UIView *rootView = RCTAppSetupDefaultRootView(bridge, @"VideoPlayer", initProps);
 
   if (@available(iOS 13.0, *)) {
     rootView.backgroundColor = [UIColor systemBackgroundColor];
@@ -85,7 +85,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
 {
 #if DEBUG
-  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"src/index"];
 #else
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif


### PR DESCRIPTION
#### Describe the changes

Fix errors occurred in basic example on iOS simulator

- Before `index` to `src/index`

```
Error: Unable to resolve module ./index from /Users/sunbreak/w/Sunbreak/react-native-video.build/examples/basic/.

None of these files exist:
  * index(.native|.ios.js|.native.js|.js|.ios.jsx|.native.jsx|.jsx|.ios.json|.native.json|.json|.ios.ts|.native.ts|.ts|.ios.tsx|.native.tsx|.tsx)
  * index/index(.native|.ios.js|.native.js|.js|.ios.jsx|.native.jsx|.jsx|.ios.json|.native.json|.json|.ios.ts|.native.ts|.ts|.ios.tsx|.native.tsx|.tsx)
    at ModuleResolver.resolveDependency (/Users/sunbreak/w/Sunbreak/react-native-video.build/examples/basic/node_modules/metro/src/node-haste/DependencyGraph/ModuleResolution.js:152:15)
    at DependencyGraph.resolveDependency (/Users/sunbreak/w/Sunbreak/react-native-video.build/examples/basic/node_modules/metro/src/node-haste/DependencyGraph.js:264:43)
    at /Users/sunbreak/w/Sunbreak/react-native-video.build/examples/basic/node_modules/metro/src/lib/transformHelpers.js:170:21
    at Server._resolveRelativePath (/Users/sunbreak/w/Sunbreak/react-native-video.build/examples/basic/node_modules/metro/src/Server.js:1196:12)
    at async Server.requestProcessor [as _processBundleRequest] (/Users/sunbreak/w/Sunbreak/react-native-video.build/examples/basic/node_modules/metro/src/Server.js:484:37)
    at async Server._processRequest (/Users/sunbreak/w/Sunbreak/react-native-video.build/examples/basic/node_modules/metro/src/Server.js:435:9)
```

- Before `videoplayer` to `VideoPlayer`

```
 BUNDLE  src/index.js 

 LOG  Running "videoplayer" with {"rootTag":1,"initialProps":{}}
 ERROR  Invariant Violation: "videoplayer" has not been registered. This can happen if:
* Metro (the local dev server) is run from the wrong folder. Check if Metro is running, stop it and restart it in the current project.
* A module failed to load due to an error and `AppRegistry.registerComponent` wasn't called., js engine: hermes
```