### PR TITLE
fix: remove dummy needsToRestoreUserInterfaceForPictureInPictureStop

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -557,7 +557,6 @@ Video.propTypes = {
   onAudioFocusChanged: PropTypes.func,
   onAudioBecomingNoisy: PropTypes.func,
   onPictureInPictureStatusChanged: PropTypes.func,
-  needsToRestoreUserInterfaceForPictureInPictureStop: PropTypes.func,
   onExternalPlaybackChange: PropTypes.func,
   adTagUrl: PropTypes.string,
   onReceiveAdEvent: PropTypes.func,


### PR DESCRIPTION
#### Describe the changes

`needsToRestoreUserInterfaceForPictureInPictureStop` was introduced accidentally by https://github.com/react-native-video/react-native-video/commit/62dc913