### PR TITLE
fix: remove dummy scaleX/Y & translateX/Y property

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -563,11 +563,6 @@ Video.propTypes = {
   onReceiveAdEvent: PropTypes.func,
 
   /* Required by react-native */
-  scaleX: PropTypes.number,
-  scaleY: PropTypes.number,
-  translateX: PropTypes.number,
-  translateY: PropTypes.number,
-  rotation: PropTypes.number,
   ...ViewPropTypes,
 };
 


### PR DESCRIPTION
#### Describe the changes

`scaleX`, `scaleY`, `translateX` and `translateY` is contained by `ViewProps`