### PR TITLE
fix: iOS Ads are reproduced with sound even if muted or volume set to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Version 6.0.0-alpha.5
 
+- iOS: make sure that the audio in ads is muted when the player is muted. [#3068](https://github.com/react-native-video/react-native-video/pull/3077)
 - iOS: ensure controls are not displayed when disabled by user [#3017](https://github.com/react-native-video/react-native-video/pull/3017)
 - iOS: app crashes on call to presentFullScreenPlayer [#2808](https://github.com/react-native-video/react-native-video/pull/2971)
 - Android: Fix publicated progress handler causing duplicated progress event [#2972](https://github.com/react-native-video/react-native-video/pull/2972)

--- a/ios/Video/Features/RCTIMAAdsManager.swift
+++ b/ios/Video/Features/RCTIMAAdsManager.swift
@@ -76,6 +76,10 @@ class RCTIMAAdsManager: NSObject, IMAAdsLoaderDelegate, IMAAdsManagerDelegate {
     // MARK: - IMAAdsManagerDelegate
 
     func adsManager(_ adsManager: IMAAdsManager, didReceive event: IMAAdEvent) {
+        // Mute ad if the main player is muted
+        if (_video.isMuted()) {
+            adsManager.volume = 0;
+        }
         // Play each ad once it has been loaded
         if event.type == IMAAdEventType.LOADED {
             adsManager.start()

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -497,6 +497,11 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     }
 
     @objc
+    func isMuted() -> Bool {
+        return _muted
+    }
+
+    @objc
     func setMuted(_ muted:Bool) {
         _muted = muted
         applyModifiers()


### PR DESCRIPTION
#### Description
This PR fixes the issue on iOS where the ad audio would start playing even when the player is set to mute. With this fix, the ad audio will not play when the player is muted, ensuring a seamless experience for users.

closes #3068 