### PR TITLE
Add support for Android Media Session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### Version 5.2.2
+- Add basic support for Android Media Sessions on ExoPlayer [#3080](https://github.com/react-native-video/react-native-video/pull/3080)
+
 ### Version 5.2.0
 
 - Fix for tvOS native audio menu language selector

--- a/README.md
+++ b/README.md
@@ -435,6 +435,14 @@ To setup DRM please follow [this guide](./DRM.md)
 
 Platforms: Android Exoplayer, iOS
 
+#### enableMediaSession
+Controls whether the ExoPlayer creates an Android Media Session. This enables external controls such as hardware buttons (eg. Play/Pause on a tv remote), or Google Assistant
+
+* **false (default)** - No Media Session
+* **true** - Create Media Session
+
+Platforms: Android ExoPlayer
+
 #### filter
 Add video filter
 * **FilterType.NONE (default)** - No Filter
@@ -544,6 +552,18 @@ maxBitRate={2000000} // 2 megabits
 ```
 
 Platforms: Android ExoPlayer, iOS
+
+#### mediaSessionMetadata
+If `enableMediaSession` is true, this can be used to pass additional metadata to the session. This metadata can be displayed to the user by Google (eg. Asking Google Assistant "What's Playing?")
+
+Supports `title`, `description`, `subtitle`, and `imageUri`
+eg.
+
+```js
+mediaSessionMetadata={{ title: "Title", subtitle: "Subtitle", description: "Description", imageUri: "https://image.png" }}
+```
+
+Platforms: Android ExoPlayer
 
 #### minLoadRetryCount
 Sets the minimum number of times to retry loading data before failing and reporting an error to the application. Useful to recover from transient internet failures.

--- a/Video.js
+++ b/Video.js
@@ -473,6 +473,12 @@ Video.propTypes = {
   disableFocus: PropTypes.bool,
   controls: PropTypes.bool,
   enableMediaSession: PropTypes.bool,
+  mediaSessionMetadata: PropTypes.shape({
+    title: PropTypes.string,
+    subtitle: PropTypes.string,
+    description: PropTypes.string,
+    imageUri: PropTypes.string,
+  }),
   audioOnly: PropTypes.bool,
   currentTime: PropTypes.number,
   fullscreenAutorotate: PropTypes.bool,

--- a/Video.js
+++ b/Video.js
@@ -472,6 +472,7 @@ Video.propTypes = {
   reportBandwidth: PropTypes.bool,
   disableFocus: PropTypes.bool,
   controls: PropTypes.bool,
+  enableMediaSession: PropTypes.bool,
   audioOnly: PropTypes.bool,
   currentTime: PropTypes.number,
   fullscreenAutorotate: PropTypes.bool,

--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation('com.google.android.exoplayer:exoplayer:2.13.3') {
         exclude group: 'com.android.support'
     }
+    implementation('com.google.android.exoplayer:extension-mediasession:2.13.3')
 
     // All support libs must use the same version
     implementation "androidx.annotation:annotation:1.1.0"

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -165,6 +165,7 @@ class ReactExoplayerView extends FrameLayout implements
     private String[] drmLicenseHeader = null;
     private boolean controls;
     private boolean enableMediaSession = false;
+    private MediaDescriptionCompat.Builder mediaSessionMetadata = new MediaDescriptionCompat.Builder();
     // \ End props
 
     // React
@@ -438,6 +439,12 @@ class ReactExoplayerView extends FrameLayout implements
                         mediaSession = new MediaSessionCompat(getContext(), TAG);
                         mediaSessionConnector = new MediaSessionConnector(mediaSession);
                         mediaSessionConnector.setPlayer(player);
+                        mediaSessionConnector.setQueueNavigator(new TimelineQueueNavigator(mediaSession) {
+                            @Override
+                            public MediaDescriptionCompat getMediaDescription(Player player, int windowIndex) {
+                            return mediaSessionMetadata.build();
+                            }
+                        });
                         mediaSession.setActive(true);
                     }
                 }
@@ -1318,6 +1325,11 @@ class ReactExoplayerView extends FrameLayout implements
     public void setEnableMediaSession(boolean enableMediaSession) {
       this.enableMediaSession = enableMediaSession;
     }
+
+    public void setMediaSessionTitle(String title) { this.mediaSessionMetadata.setTitle((title)); }
+    public void setMediaSessionSubtitle(String subtitle) { this.mediaSessionMetadata.setSubtitle((subtitle)); }
+    public void setMediaSessionDescription(String description) { this.mediaSessionMetadata.setDescription((description)); }
+    public void setMediaSessionImage(String uri) { this.mediaSessionMetadata.setMediaUri((Uri.parse(uri))); }
 
     public void setFullscreen(boolean fullscreen) {
         if (fullscreen == isFullscreen) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -71,6 +71,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_HIDE_SHUTTER_VIEW = "hideShutterView";
     private static final String PROP_CONTROLS = "controls";
     private static final String PROP_ENABLE_MEDIA_SESSION = "enableMediaSession";
+    private static final String PROP_MEDIA_SESSION_METADATA = "mediaSessionMetadata";
 
     private ReactExoplayerConfig config;
 
@@ -318,6 +319,21 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_ENABLE_MEDIA_SESSION, defaultBoolean = false)
     public void setEnabledMediaSession(final ReactExoplayerView videoView, final boolean enableMediaSession) {
       videoView.setEnableMediaSession(enableMediaSession);
+    }
+
+    @ReactProp(name = PROP_MEDIA_SESSION_METADATA, defaultBoolean = false)
+    public void setMediaSessionMetadata(final ReactExoplayerView videoView, @Nullable ReadableMap mediaSessionMetadata) {
+      if (mediaSessionMetadata == null) return;
+
+      String title = mediaSessionMetadata.getString("title");
+      String subtitle = mediaSessionMetadata.getString("subtitle");
+      String description = mediaSessionMetadata.getString("description");
+      String imageUri = mediaSessionMetadata.getString("imageUri");
+
+      if (title != null) { videoView.setMediaSessionTitle(title); }
+      if (subtitle != null) { videoView.setMediaSessionSubtitle(subtitle); }
+      if (description != null) { videoView.setMediaSessionDescription(description); }
+      if (imageUri != null) { videoView.setMediaSessionImage(imageUri); }
     }
 
     @ReactProp(name = PROP_BUFFER_CONFIG)

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -70,6 +70,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SELECTED_VIDEO_TRACK_VALUE = "value";
     private static final String PROP_HIDE_SHUTTER_VIEW = "hideShutterView";
     private static final String PROP_CONTROLS = "controls";
+    private static final String PROP_ENABLE_MEDIA_SESSION = "enableMediaSession";
 
     private ReactExoplayerConfig config;
 
@@ -312,6 +313,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_CONTROLS, defaultBoolean = false)
     public void setControls(final ReactExoplayerView videoView, final boolean controls) {
         videoView.setControls(controls);
+    }
+
+    @ReactProp(name = PROP_ENABLE_MEDIA_SESSION, defaultBoolean = false)
+    public void setEnabledMediaSession(final ReactExoplayerView videoView, final boolean enableMediaSession) {
+      videoView.setEnableMediaSession(enableMediaSession);
     }
 
     @ReactProp(name = PROP_BUFFER_CONFIG)


### PR DESCRIPTION
# Media Session

This adds 2 props, `enableMediaSession` and `mediaSessionMetadata`. With these the video can create an Android Media Session and provide it with metadata.
Simply adding a media session like this allows the video to be controlled and respond to a number of external controls. Some examples include:
- Hardware buttons (eg. Play/Pause on a Google TV Remote)
- Google Assistant (eg. saying "Play"/"Pause"/"Stop")
- Other devices


## Testing
Because this opens the door to many controls there are number of ways it can be tested. I've been testing 2 different ways:

### Trigger pause/play event through adb
You can mimic the event of pressing a pause/play button through adb.
`adb shell input keyevent 126`
Key 126 is PLAY, 127 is PAUSE, 85 is PLAY/PAUSE. [See more event codes in the Android docs here](https://developer.android.com/reference/android/view/KeyEvent#KEYCODE_MEDIA_PLAY)

### Google Assistant
You can run on a device that has Google Assistant, then test instructions such as "Play"/"Pause"/"What's Playing?"
Pretty sure you can also use Google Assistant in emulators