### PR TITLE
fix: Player in Player (PiP) restoreUserInterface from crashing the application

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -2020,7 +2020,6 @@ didCancelLoadingRequest:(AVAssetResourceLoadingRequest *)loadingRequest {
 }
 
 - (void)pictureInPictureController:(AVPictureInPictureController *)pictureInPictureController restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:(void (^)(BOOL))completionHandler {
-  NSAssert(_restoreUserInterfaceForPIPStopCompletionHandler == NULL, @"restoreUserInterfaceForPIPStopCompletionHandler was not called after picture in picture was exited.");
   if (self.onRestoreUserInterfaceForPictureInPictureStop) {
     self.onRestoreUserInterfaceForPictureInPictureStop(@{});
   }


### PR DESCRIPTION
#### Provide an example of how to test the change
1. Create a React Native app
2. Install react-native-video using this branch
3. Create a `<Video>`  inside App.jsx with the following code:

```jsx
const VIDEO_SOURCE = {
  uri: "https://cdn81168665.blazingcdn.net/timeline/hartley-e001-s001a-01-2b6d4c/stream/index.m3u8",
}
const bufferConfig = {
  minBufferMs: 100,
  maxBufferMs: 50000,
  bufferForPlaybackMs: 100,
  bufferForPlaybackAfterRebufferMs: 100,
}
const [isPip, setPip] = useState(false)
 <Video
        paused={false}
        ref={videoRef}
        style={styles.video}
        source={VIDEO_SOURCE}
        resizeMode="contain"
        onProgress={onVideoProgress}
        controls={false}
        muted={false}
        pictureInPicture={isPip}
        onPictureInPictureStatusChanged={(
          data: OnPictureInPictureStatusData,
        ) => {
        }}
        rate={1.0}
        progressUpdateInterval={250}
        ignoreSilentSwitch="ignore"
        automaticallyWaitsToMinimizeStalling={false}
        bufferConfig={bufferConfig}
      />
   <Button onPress={() => setPip(!isPip)} />
```
4. Launch the app and enable PiP by clicking the button. Then click the button on the top right inside PiP to exit PiP. Keep doing this without any crashes (before there was a crash due to the `NSAssert`)

#### Describe the changes

Previously when exiting PiP it would crash the application due to the `NSAssert` I removed, now it won't crash the app due to this race condition.

https://stackoverflow.com/questions/1375786/whats-the-point-of-nsassert-actually