### PR TITLE
Fix ids in exo_player_control_view

### DIFF
--- a/android/src/main/res/layout/exo_player_control_view.xml
+++ b/android/src/main/res/layout/exo_player_control_view.xml
@@ -14,27 +14,27 @@
         android:paddingTop="4dp"
         android:orientation="horizontal">
 
-        <ImageButton android:id="@id/exo_prev"
+        <ImageButton android:id="@+id/exo_prev"
             style="@style/ExoMediaButton.Previous"/>
 
-        <ImageButton android:id="@id/exo_rew"
+        <ImageButton android:id="@+id/exo_rew"
             style="@style/ExoMediaButton.Rewind"/>
         <FrameLayout
             android:id="@+id/exo_play_pause_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center">
-            <ImageButton android:id="@id/exo_play"
+            <ImageButton android:id="@+id/exo_play"
                 style="@style/ExoMediaButton.Play"/>
 
-            <ImageButton android:id="@id/exo_pause"
+            <ImageButton android:id="@+id/exo_pause"
                 style="@style/ExoMediaButton.Pause"/>
         </FrameLayout>
 
-        <ImageButton android:id="@id/exo_ffwd"
+        <ImageButton android:id="@+id/exo_ffwd"
             style="@style/ExoMediaButton.FastForward"/>
 
-        <ImageButton android:id="@id/exo_next"
+        <ImageButton android:id="@+id/exo_next"
             style="@style/ExoMediaButton.Next"/>
 
     </LinearLayout>
@@ -46,7 +46,7 @@
         android:gravity="center_vertical"
         android:orientation="horizontal">
 
-        <TextView android:id="@id/exo_position"
+        <TextView android:id="@+id/exo_position"
             android:layout_width="50dp"
             android:layout_height="wrap_content"
             android:textSize="14sp"
@@ -57,12 +57,12 @@
             android:textColor="#FFBEBEBE"/>
 
         <com.google.android.exoplayer2.ui.DefaultTimeBar
-            android:id="@id/exo_progress"
+            android:id="@+id/exo_progress"
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="26dp"/>
 
-        <TextView android:id="@id/exo_duration"
+        <TextView android:id="@+id/exo_duration"
             android:layout_width="50dp"
             android:layout_height="wrap_content"
             android:textSize="14sp"
@@ -73,7 +73,7 @@
             android:textColor="#FFBEBEBE"/>
 
         <ImageButton
-            android:id="@id/exo_fullscreen"
+            android:id="@+id/exo_fullscreen"
             style="@style/ExoMediaButton.FullScreen"
             android:layout_width="30dp"
             android:layout_height="30dp"


### PR DESCRIPTION
## Summary
In order to upgrade to Android Gradle Plugin (AGP) 8.0, we need to update  app build files to accommodate five important build behavior changes. This PR fixes ids in `exo_player_control_view` which will allow us to enable `nonTransitiveRClass` as a followup. This behaviour is enforced in AGP 8.0+. 

The difference between setting `@id/` and `@+id/` is described here https://proandroiddev.com/android-resource-id-under-the-hood-45196d69f1e6.

As a side bonus of enabling non-transitive R class, we will get app size decrease on Android, as R classes are quite big.

You can read more about it here https://medium.com/androiddevelopers/5-ways-to-prepare-your-app-build-for-android-studio-flamingo-release-da34616bb946

Fixes #2631  

## Test
Please test the flows that involve this method call to make sure it doesn't crash and work as intended.
