### PR TITLE
fixes balck splash, thumbnail when used with textureview

### DIFF
--- a/API.md
+++ b/API.md
@@ -310,6 +310,9 @@ var styles = StyleSheet.create({
 | [fullscreenOrientation](#fullscreenorientation)                                     | iOS                       |
 | [headers](#headers)                                                                 | Android                   |
 | [hideShutterView](#hideshutterview)                                                 | Android                   |
+| [shutterColor](#shutterColor)                                                       | Android                   |
+| [frameQuality](#frameQuality)                                                       | Android                   |
+| [onFrameChange](#onFrameChange)                                                     | Android                   |
 | [ignoreSilentSwitch](#ignoresilentswitch)                                           | iOS                       |
 | [maxBitRate](#maxbitrate)                                                           | Android, iOS              |
 | [minLoadRetryCount](#minLoadRetryCount)                                             | Android                   |
@@ -581,6 +584,43 @@ Controls whether the ExoPlayer shutter view (black screen while loading) is enab
 
 * **false (default)** - Show shutter view 
 * **true** - Hide shutter view
+
+Platforms: Android
+
+#### shutterColor
+Apply color to shutter view, if you see black flashes before video start then set shutterColor='transparent'
+
+won't work if useTextureView={false}
+
+* **black (default)**
+
+Platforms: Android
+
+#### frameQuality
+Use this prop to set quality of Base64 encoded string image obtained by onFrameChange callback. 
+
+won't work if useTextureView={false}
+
+* **undefined (default)** - range [0-100]
+
+Platforms: Android
+
+#### onFrameChange
+Callback function that is when video frame changes
+It works only when frameQuality prop is set, return Base64 encoded string image.
+
+won't work if useTextureView={false}
+
+Example
+
+```
+  <Video
+    frameQuality={30}
+    onFrameChange={(imageString) => {
+      setImageSource(`data:image/jpeg;base64,${imageString}`)
+    }
+  />
+```
 
 Platforms: Android
 

--- a/Video.js
+++ b/Video.js
@@ -77,7 +77,7 @@ export default class Video extends Component {
     this.setNativeProps({ fullscreen: false });
   };
 
-  save = async (options?) => {
+  save = async (options) => {
     return await NativeModules.VideoManager.save(options, findNodeHandle(this._root));
   }
 
@@ -286,6 +286,12 @@ export default class Video extends Component {
     }
   };
 
+  _onFrameChange = (event) => {
+    if(this.props.onFrameChange) {
+      this.props.onFrameChange(event.nativeEvent.onFrameChange)
+    }
+  }
+
   getViewManagerConfig = viewManagerName => {
     if (!UIManager.getViewManagerConfig) {
       return UIManager[viewManagerName];
@@ -374,6 +380,7 @@ export default class Video extends Component {
       onPictureInPictureStatusChanged: this._onPictureInPictureStatusChanged,
       onRestoreUserInterfaceForPictureInPictureStop: this._onRestoreUserInterfaceForPictureInPictureStop,
       onReceiveAdEvent: this._onReceiveAdEvent,
+      onFrameChange: this._onFrameChange,
     });
 
     const posterStyle = {
@@ -535,6 +542,9 @@ Video.propTypes = {
   useTextureView: PropTypes.bool,
   useSecureView: PropTypes.bool,
   hideShutterView: PropTypes.bool,
+  shutterColor: PropTypes.string,
+  frameQuality: PropTypes.number,
+  onFrameChange: PropTypes.func,
   onLoadStart: PropTypes.func,
   onPlaybackStateChanged: PropTypes.func,
   onLoad: PropTypes.func,

--- a/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -221,6 +221,10 @@ public final class ExoPlayerView extends FrameLayout implements AdViewProvider {
         updateShutterViewVisibility();
     }
 
+    public void setShutterColor(Integer color) {
+        shutterView.setBackgroundColor(color);
+    }
+
     private final Runnable measureAndLayout = new Runnable() {
         @Override
         public void run() {

--- a/android/src/main/java/com/brentvatne/exoplayer/ImageUtil.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ImageUtil.java
@@ -1,0 +1,34 @@
+package com.brentvatne.exoplayer;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.util.Base64;
+import java.io.ByteArrayOutputStream;
+
+import javax.annotation.Nullable;
+
+public class ImageUtil
+{
+    public static Bitmap convert(String base64Str) throws IllegalArgumentException
+    {
+        byte[] decodedBytes = Base64.decode(
+                base64Str.substring(base64Str.indexOf(",")  + 1),
+                Base64.DEFAULT
+        );
+
+        return BitmapFactory.decodeByteArray(decodedBytes, 0, decodedBytes.length);
+    }
+
+    public static String convert(Bitmap bitmap) {
+        return convert(bitmap, 100);
+    }
+
+    public static String convert(Bitmap bitmap, Integer quality)
+    {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        bitmap.compress(Bitmap.CompressFormat.JPEG, quality, outputStream);
+
+        return Base64.encodeToString(outputStream.toByteArray(), Base64.DEFAULT);
+    }
+
+}

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -10,6 +10,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.ActivityManager;
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Handler;
@@ -258,10 +259,10 @@ class ReactExoplayerView extends FrameLayout implements
         if(frameQuality == null) return;
         ((Runnable) () -> {
             try {
-                System.out.println("frameQuality: " + frameQuality + " isSurfaceView: "  + (exoPlayerView.getVideoSurfaceView() instanceof TextureView));
                 if (exoPlayerView.getVideoSurfaceView() instanceof TextureView) {
-                    TextureView view = (TextureView) exoPlayerView.getVideoSurfaceView();
-                    final String base64Image = ImageUtil.convert(view.getBitmap(), frameQuality);
+                    Bitmap bitmap = ((TextureView) exoPlayerView.getVideoSurfaceView()).getBitmap();
+                    if(bitmap == null) return;
+                    final String base64Image = ImageUtil.convert(bitmap, frameQuality);
                     eventEmitter.setFrame(base64Image);
                 }
             } catch (Exception e) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -647,7 +647,9 @@ class ReactExoplayerView extends FrameLayout implements
         );
         DefaultRenderersFactory renderersFactory =
                 new DefaultRenderersFactory(getContext())
+                        .setEnableDecoderFallback(true)
                         .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF);
+
 
         // Create an AdsLoader.
         adsLoader = new ImaAdsLoader.Builder(themedReactContext).setAdEventListener(this).build();

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -905,10 +905,8 @@ class ReactExoplayerView extends FrameLayout implements
 
     private void releasePlayer() {
         if (player != null) {
-            if (adsLoader != null) {
-                adsLoader.setPlayer(null);
-            }
             updateResumePosition();
+            player.stop();
             player.release();
             player.removeListener(this);
             trackSelector = null;
@@ -916,6 +914,7 @@ class ReactExoplayerView extends FrameLayout implements
         }
         if (adsLoader != null) {
             adsLoader.release();
+            adsLoader.setPlayer(null);
         }
         adsLoader = null;
         progressHandler.removeMessages(SHOW_PROGRESS);

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -17,6 +17,8 @@ import android.os.Looper;
 import android.os.Message;
 import android.text.TextUtils;
 import android.util.Log;
+import android.view.SurfaceView;
+import android.view.TextureView;
 import android.view.View;
 import android.view.Window;
 import android.view.accessibility.CaptioningManager;
@@ -220,6 +222,7 @@ class ReactExoplayerView extends FrameLayout implements
     private long lastPos = -1;
     private long lastBufferDuration = -1;
     private long lastDuration = -1;
+    private Integer frameQuality;
 
     private final Handler progressHandler = new Handler(Looper.getMainLooper()) {
         @Override
@@ -244,11 +247,28 @@ class ReactExoplayerView extends FrameLayout implements
                         }
                         msg = obtainMessage(SHOW_PROGRESS);
                         sendMessageDelayed(msg, Math.round(mProgressUpdateInterval));
+                        setFrame();
                     }
                     break;
             }
         }
     };
+
+    private void setFrame() {
+        if(frameQuality == null) return;
+        ((Runnable) () -> {
+            try {
+                System.out.println("frameQuality: " + frameQuality + " isSurfaceView: "  + (exoPlayerView.getVideoSurfaceView() instanceof TextureView));
+                if (exoPlayerView.getVideoSurfaceView() instanceof TextureView) {
+                    TextureView view = (TextureView) exoPlayerView.getVideoSurfaceView();
+                    final String base64Image = ImageUtil.convert(view.getBitmap(), frameQuality);
+                    eventEmitter.setFrame(base64Image);
+                }
+            } catch (Exception e) {
+                System.out.println(e.toString());
+            }
+        }).run();
+    }
 
     public double getPositionInFirstPeriodMsForCurrentWindow(long currentPosition) {
         Timeline.Window window = new Timeline.Window();
@@ -1962,6 +1982,14 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setHideShutterView(boolean hideShutterView) {
         exoPlayerView.setHideShutterView(hideShutterView);
+    }
+
+    public void setShutterColor(Integer color) {
+        exoPlayerView.setShutterColor(color);
+    }
+
+    public void setFrameQuality(Integer quality) {
+        frameQuality = quality;
     }
 
     public void setBufferConfig(int newMinBufferMs, int newMaxBufferMs, int newBufferForPlaybackMs, int newBufferForPlaybackAfterRebufferMs, double newMaxHeapAllocationPercent, double newMinBackBufferMemoryReservePercent, double newMinBufferMemoryReservePercent) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -1,6 +1,7 @@
 package com.brentvatne.exoplayer;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.net.Uri;
 import android.text.TextUtils;
 import android.util.Log;
@@ -36,7 +37,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SRC_TYPE = "type";
     private static final String PROP_DRM = "drm";
     private static final String PROP_DRM_TYPE = "type";
-    private static final String PROP_DRM_LICENSESERVER = "licenseServer";
+    private static final String PROP_DRM_LICENSE_SERVER = "licenseServer";
     private static final String PROP_DRM_HEADERS = "headers";
     private static final String PROP_SRC_HEADERS = "requestHeaders";
     private static final String PROP_RESIZE_MODE = "resizeMode";
@@ -81,8 +82,9 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SELECTED_VIDEO_TRACK_VALUE = "value";
     private static final String PROP_HIDE_SHUTTER_VIEW = "hideShutterView";
     private static final String PROP_CONTROLS = "controls";
-
     private static final String PROP_SUBTITLE_STYLE = "subtitleStyle";
+    private static final String PROP_SHUTTER_COLOR = "shutterColor";
+    private static final String PROP_FRAME_QUALITY = "frameQuality";
 
     private ReactExoplayerConfig config;
 
@@ -128,7 +130,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     public void setDRM(final ReactExoplayerView videoView, @Nullable ReadableMap drm) {
         if (drm != null && drm.hasKey(PROP_DRM_TYPE)) {
             String drmType = drm.hasKey(PROP_DRM_TYPE) ? drm.getString(PROP_DRM_TYPE) : null;
-            String drmLicenseServer = drm.hasKey(PROP_DRM_LICENSESERVER) ? drm.getString(PROP_DRM_LICENSESERVER) : null;
+            String drmLicenseServer = drm.hasKey(PROP_DRM_LICENSE_SERVER) ? drm.getString(PROP_DRM_LICENSE_SERVER) : null;
             ReadableMap drmHeaders = drm.hasKey(PROP_DRM_HEADERS) ? drm.getMap(PROP_DRM_HEADERS) : null;
             if (drmType != null && drmLicenseServer != null && Util.getDrmUuid(drmType) != null) {
                 UUID drmUUID = Util.getDrmUuid(drmType);
@@ -366,6 +368,16 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_HIDE_SHUTTER_VIEW, defaultBoolean = false)
     public void setHideShutterView(final ReactExoplayerView videoView, final boolean hideShutterView) {
         videoView.setHideShutterView(hideShutterView);
+    }
+
+    @ReactProp(name = PROP_SHUTTER_COLOR, customType = "Color")
+    public void setShutterColor(final ReactExoplayerView videoView, final Integer color) {
+        videoView.setShutterColor(color == null ? Color.BLACK : color);
+    }
+
+    @ReactProp(name = PROP_FRAME_QUALITY)
+    public void setFrameQuality(final ReactExoplayerView videoView, @Nullable final Integer frameQuality) {
+        videoView.setFrameQuality(frameQuality);
     }
 
     @ReactProp(name = PROP_CONTROLS, defaultBoolean = false)

--- a/android/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -57,6 +57,7 @@ class VideoEventEmitter {
     private static final String EVENT_TEXT_TRACKS = "onTextTracks";
     private static final String EVENT_VIDEO_TRACKS = "onVideoTracks";
     private static final String EVENT_ON_RECEIVE_AD_EVENT = "onReceiveAdEvent";
+    private static final String EVENT_ON_FRAME_CHANGE = "onFrameChange";
 
     static final String[] Events = {
             EVENT_LOAD_START,
@@ -83,7 +84,8 @@ class VideoEventEmitter {
             EVENT_TEXT_TRACKS,
             EVENT_VIDEO_TRACKS,
             EVENT_BANDWIDTH,
-            EVENT_ON_RECEIVE_AD_EVENT
+            EVENT_ON_RECEIVE_AD_EVENT,
+            EVENT_ON_FRAME_CHANGE
     };
 
     @Retention(RetentionPolicy.SOURCE)
@@ -112,7 +114,8 @@ class VideoEventEmitter {
             EVENT_TEXT_TRACKS,
             EVENT_VIDEO_TRACKS,
             EVENT_BANDWIDTH,
-            EVENT_ON_RECEIVE_AD_EVENT
+            EVENT_ON_RECEIVE_AD_EVENT,
+            EVENT_ON_FRAME_CHANGE
     })
     @interface VideoEvents {
     }
@@ -440,6 +443,12 @@ class VideoEventEmitter {
         map.putString("event", event);
 
         receiveEvent(EVENT_ON_RECEIVE_AD_EVENT, map);
+    }
+
+    void setFrame(String base64Image) {
+        WritableMap map = Arguments.createMap();
+        map.putString(EVENT_ON_FRAME_CHANGE, base64Image);
+        receiveEvent(EVENT_ON_FRAME_CHANGE, map);
     }
 
     private void receiveEvent(@VideoEvents String type, WritableMap event) {


### PR DESCRIPTION
fixes https://github.com/react-native-video/react-native-video/issues/3148

Added props `frameQuality` and `onFrameChange` to get current frame thumbnail.

All three props work only when useTextureView={true} i.e., default 

Platforms: Android

#### shutterColor
Apply color to shutter view, if you see black flashes before video start then set shutterColor='transparent'

won't work if useTextureView={false}

* **black (default)**

Platforms: Android

#### frameQuality
Use this prop to set quality of Base64 encoded string image obtained by onFrameChange callback. 

won't work if useTextureView={false}

* **undefined (default)** - range [0-100]

Platforms: Android

#### onFrameChange
Callback function that is fired when video frame changes
It works only when frameQuality prop is set, return Base64 encoded string image.

won't work if useTextureView={false}

Example

```
  <Video
    frameQuality={30}
    onFrameChange={(imageString) => {
      setImageSource(`data:image/jpeg;base64,${imageString}`)
    }
  />
```