### PR TITLE
Use more reliable method for detecting iOS view removal for cleanup

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -898,7 +898,13 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     // MARK: - Lifecycle
 
-    override func removeFromSuperview() {
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+
+        if (self.window != nil) {
+            return;
+        }
+
         _player?.pause()
         _player = nil
         _resouceLoaderDelegate = nil
@@ -917,8 +923,6 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
         _eventDispatcher = nil
         NotificationCenter.default.removeObserver(self)
-
-        super.removeFromSuperview()
     }
 
     // MARK: - Export


### PR DESCRIPTION
It seems that there are some corner cases where `removeFromSuperview` doesn't fire when parent view is removed. I can reliably reproduce it in my app (both physical device and simulator), in one place with a VideoPlayer placed deep inside nested native navigators.

When VideoPlayer's parent unmounts, and VideoPlayer itself unmounts (useEffect cleanup is triggered), the `removeFromSuperview` doesn't fire – this leaves the native VideoPlayer component allocated (and continuing the playback) with no way to kill it other than restarting the whole app.

Replacing `removeFromSuperview` with `didMoveToWindow` solves this. `didMoveToWindow` fires reliably.

relevant project's packages:
    "react-native": "^0.72.0",
    "@react-navigation/core": "^6.4.9",
    "@react-navigation/native": "^6.1.7",
    "@react-navigation/native-stack": "^6.9.13",

tested on:
iOS 15.7 physical device - removeFromSuperview is not called, didMoveToWindow is called
iOS 15.5 simulator - same
iOS 16.2 simulator - both removeFromSuperview and didMoveToWindow are called (didMoveToWindow is called first), so it seems to have been fixed in iOS 16
iOS 12.5.5 physical - same as iOS 16