### PR TITLE
feat: RN 0.73 support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,6 +17,7 @@ def configStringPath = (
 ).md5()
 
 android {
+    namespace 'com.brentvatne.react'
     compileSdkVersion safeExtGet('compileSdkVersion', 31)
     buildToolsVersion safeExtGet('buildToolsVersion', '30.0.2')
 


### PR DESCRIPTION
Adds `namespace` prop which is required by Gradle 8 (dep. of RN 0.73)
