### PR TITLE
[Android] fixes black splashes

### DIFF
--- a/API.md
+++ b/API.md
@@ -331,6 +331,7 @@ var styles = StyleSheet.create({
 | [selectedAudioTrack](#selectedaudiotrack)                                           | Android, iOS              |
 | [selectedTextTrack](#selectedtexttrack)                                             | Android, iOS              |
 | [selectedVideoTrack](#selectedvideotrack)                                           | Android                   |
+| [shutterColor](#shutterColor)                                                       | Android                   |
 | [source](#source)                                                                   | All                       |
 | [subtitleStyle](#subtitleStyle)                                                     | Android                   |
 | [textTracks](#texttracks)                                                           | Android, iOS              |
@@ -850,6 +851,14 @@ Type | Value | Description
 
 If a track matching the specified Type (and Value if appropriate) is unavailable, ABR will be used.
 
+Platforms: Android
+
+#### shutterColor
+Apply color to shutter view, if you see black flashes before video start then set shutterColor='transparent'
+
+won't work if useTextureView={false}
+
+black (default)
 Platforms: Android
 
 #### source

--- a/API.md
+++ b/API.md
@@ -854,11 +854,14 @@ If a track matching the specified Type (and Value if appropriate) is unavailable
 Platforms: Android
 
 #### shutterColor
-Apply color to shutter view, if you see black flashes before video start then set shutterColor='transparent'
+Apply color to shutter view, if you see black flashes before video start then set 
 
-won't work if useTextureView={false}
+```
+shutterColor='transparent'
+```
 
-black (default)
+- black (default)
+
 Platforms: Android
 
 #### source

--- a/Video.js
+++ b/Video.js
@@ -77,7 +77,7 @@ export default class Video extends Component {
     this.setNativeProps({ fullscreen: false });
   };
 
-  save = async (options?) => {
+  save = async (options) => {
     return await NativeModules.VideoManager.save(options, findNodeHandle(this._root));
   }
 
@@ -528,6 +528,7 @@ Video.propTypes = {
   useTextureView: PropTypes.bool,
   useSecureView: PropTypes.bool,
   hideShutterView: PropTypes.bool,
+  shutterColor: PropTypes.string,
   onLoadStart: PropTypes.func,
   onPlaybackStateChanged: PropTypes.func,
   onLoad: PropTypes.func,

--- a/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -116,6 +116,10 @@ public final class ExoPlayerView extends FrameLayout implements AdViewProvider {
         subtitleLayout.setPadding(style.getPaddingLeft(), style.getPaddingTop(), style.getPaddingRight(), style.getPaddingBottom());
     }
 
+    public void setShutterColor(Integer color) {
+        shutterView.setBackgroundColor(color);
+    }
+
     private void updateSurfaceView() {
         View view;
         if (!useTextureView || useSecureView) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -2032,6 +2032,10 @@ class ReactExoplayerView extends FrameLayout implements
         exoPlayerView.setSubtitleStyle(style);
     }
 
+    public void setShutterColor(Integer color) {
+        exoPlayerView.setShutterColor(color);
+    }
+
     @Override
     public void onAdEvent(AdEvent adEvent) {
         eventEmitter.receiveAdEvent(adEvent.getType().name());

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -1,9 +1,9 @@
 package com.brentvatne.exoplayer;
 
+import android.graphics.Color;
 import android.content.Context;
 import android.net.Uri;
 import android.text.TextUtils;
-import android.util.Log;
 
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
@@ -13,7 +13,6 @@ import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
-import com.facebook.react.bridge.ReactMethod;
 import com.google.android.exoplayer2.util.Util;
 import com.google.android.exoplayer2.DefaultLoadControl;
 import com.google.android.exoplayer2.upstream.RawResourceDataSource;
@@ -81,8 +80,8 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SELECTED_VIDEO_TRACK_VALUE = "value";
     private static final String PROP_HIDE_SHUTTER_VIEW = "hideShutterView";
     private static final String PROP_CONTROLS = "controls";
-
     private static final String PROP_SUBTITLE_STYLE = "subtitleStyle";
+    private static final String PROP_SHUTTER_COLOR = "shutterColor";
 
     private ReactExoplayerConfig config;
 
@@ -376,6 +375,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_SUBTITLE_STYLE)
     public void setSubtitleStyle(final ReactExoplayerView videoView, @Nullable final ReadableMap src) {
         videoView.setSubtitleStyle(SubtitleStyle.parse(src));
+    }
+
+    @ReactProp(name = PROP_SHUTTER_COLOR, customType = "Color")
+    public void setShutterColor(final ReactExoplayerView videoView, final Integer color) {
+        videoView.setShutterColor(color == null ? Color.BLACK : color);
     }
 
     @ReactProp(name = PROP_BUFFER_CONFIG)


### PR DESCRIPTION
closes #1128 #3148 
#### shutterColor
Apply color to shutter view, if you see black flashes before video start then set shutterColor='transparent'

won't work if useTextureView={false}

black (default)
Platforms: Android