### PR TITLE
Get thumbnail as base64Image

### DIFF
--- a/API.md
+++ b/API.md
@@ -540,6 +540,14 @@ Whether this video view should be focusable with a non-touch input device, eg. r
 Platforms: Android
 
 
+#### frameQuality
+Setting this prop will fire [onFrameChange](#onframechange) callback
+
+* **0 (default)** - Don't display the video in fullscreen
+* **1** - Display the video in fullscreen
+
+Platforms: iOS
+
 #### fullscreen
 Controls whether the player enters fullscreen on play.
 * **false (default)** - Don't display the video in fullscreen
@@ -1130,6 +1138,19 @@ Example:
 ```
 
 Platforms: iOS
+
+#### onFrameChange
+callback function that is called for each frame when [frameQuality](#framequality) > 0`, results each frame as base64Image(thumbnail)
+
+```javascript
+  <Video
+    {...videoProps}
+    frameQuality={0.3} // required to fire callback
+    onFrameChange={(thumbnail: string) => setThumbnail(thumbnail)}
+  />
+```
+
+Platform: iOS, Android
 
 #### onFullscreenPlayerWillPresent
 Callback function that is called when the player is about to enter fullscreen mode.

--- a/API.md
+++ b/API.md
@@ -546,7 +546,7 @@ Setting this prop will fire [onFrameChange](#onframechange) callback
 * **0 (default)** - Don't display the video in fullscreen
 * **1** - Display the video in fullscreen
 
-Platforms: iOS
+Platforms: Android, iOS
 
 #### fullscreen
 Controls whether the player enters fullscreen on play.

--- a/Video.js
+++ b/Video.js
@@ -77,7 +77,7 @@ export default class Video extends Component {
     this.setNativeProps({ fullscreen: false });
   };
 
-  save = async (options?) => {
+  save = async (options) => {
     return await NativeModules.VideoManager.save(options, findNodeHandle(this._root));
   }
 
@@ -170,6 +170,12 @@ export default class Video extends Component {
       this.props.onTimedMetadata(event.nativeEvent);
     }
   };
+
+  _onFrameChange = (event) => {
+    if(this.props.onFrameChange) {
+      this.props.onFrameChange(event.nativeEvent.base64ImageString);
+    }
+  }
 
   _onFullscreenPlayerWillPresent = (event) => {
     if (this.props.onFullscreenPlayerWillPresent) {
@@ -345,6 +351,7 @@ export default class Video extends Component {
         startTime: source.startTime || 0,
         endTime: source.endTime
       },
+      onFrameChange: this._onFrameChange,
       onVideoLoadStart: this._onLoadStart,
       onVideoPlaybackStateChanged: this._onPlaybackStateChanged,
       onVideoLoad: this._onLoad,
@@ -415,6 +422,8 @@ Video.propTypes = {
     FilterType.TRANSFER,
     FilterType.SEPIA,
   ]),
+  frameQuality: PropTypes.number,
+  onFrameChange: PropTypes.func,
   filterEnabled: PropTypes.bool,
   onVideoLoadStart: PropTypes.func,
   onVideoLoad: PropTypes.func,

--- a/android/src/main/java/com/brentvatne/exoplayer/ImageUtil.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ImageUtil.java
@@ -1,0 +1,34 @@
+package com.brentvatne.exoplayer;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.util.Base64;
+import java.io.ByteArrayOutputStream;
+
+import javax.annotation.Nullable;
+
+public class ImageUtil
+{
+    // public static Bitmap convert(String base64Str) throws IllegalArgumentException
+    // {
+    //     byte[] decodedBytes = Base64.decode(
+    //             base64Str.substring(base64Str.indexOf(",")  + 1),
+    //             Base64.DEFAULT
+    //     );
+
+    //     return BitmapFactory.decodeByteArray(decodedBytes, 0, decodedBytes.length);
+    // }
+
+    // public static String convert(Bitmap bitmap) {
+    //     return convert(bitmap, 100);
+    // }
+
+    public static String convert(Bitmap bitmap, Integer quality)
+    {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        bitmap.compress(Bitmap.CompressFormat.JPEG, quality, outputStream);
+
+        return Base64.encodeToString(outputStream.toByteArray(), Base64.DEFAULT);
+    }
+
+}

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -10,6 +10,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.ActivityManager;
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Handler;
@@ -17,6 +18,8 @@ import android.os.Looper;
 import android.os.Message;
 import android.text.TextUtils;
 import android.util.Log;
+import android.view.SurfaceView;
+import android.view.TextureView;
 import android.view.View;
 import android.view.Window;
 import android.view.accessibility.CaptioningManager;
@@ -220,6 +223,7 @@ class ReactExoplayerView extends FrameLayout implements
     private long lastPos = -1;
     private long lastBufferDuration = -1;
     private long lastDuration = -1;
+    private Integer frameQuality;
 
     private final Handler progressHandler = new Handler(Looper.getMainLooper()) {
         @Override
@@ -244,11 +248,29 @@ class ReactExoplayerView extends FrameLayout implements
                         }
                         msg = obtainMessage(SHOW_PROGRESS);
                         sendMessageDelayed(msg, Math.round(mProgressUpdateInterval));
+                        setFrame();
                     }
                     break;
             }
         }
     };
+
+    private void setFrame() {
+        if(frameQuality == null) return;
+        if(frameQuality > 1) frameQuality = 1;
+        ((Runnable) () -> {
+            try {
+                if (exoPlayerView.getVideoSurfaceView() instanceof TextureView) {
+                    Bitmap bitmap = ((TextureView) exoPlayerView.getVideoSurfaceView()).getBitmap();
+                    if(bitmap == null) return;
+                    final String base64Image = ImageUtil.convert(bitmap, frameQuality);
+                    eventEmitter.setFrame(base64Image);
+                }
+            } catch (Exception e) {
+                System.out.println(e.toString());
+            }
+        }).run();
+    }
 
     public double getPositionInFirstPeriodMsForCurrentWindow(long currentPosition) {
         Timeline.Window window = new Timeline.Window();
@@ -1962,6 +1984,10 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setHideShutterView(boolean hideShutterView) {
         exoPlayerView.setHideShutterView(hideShutterView);
+    }
+    
+    public void setFrameQuality(Integer quality) {
+        frameQuality = quality;
     }
 
     public void setBufferConfig(int newMinBufferMs, int newMaxBufferMs, int newBufferForPlaybackMs, int newBufferForPlaybackAfterRebufferMs, double newMaxHeapAllocationPercent, double newMinBackBufferMemoryReservePercent, double newMinBufferMemoryReservePercent) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -258,6 +258,7 @@ class ReactExoplayerView extends FrameLayout implements
     private void setFrame() {
         if(frameQuality == null) return;
         if(frameQuality > 1) frameQuality = 1;
+        frameQuality = Math.round(frameQuality * 100);
         ((Runnable) () -> {
             try {
                 if (exoPlayerView.getVideoSurfaceView() instanceof TextureView) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -36,7 +36,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SRC_TYPE = "type";
     private static final String PROP_DRM = "drm";
     private static final String PROP_DRM_TYPE = "type";
-    private static final String PROP_DRM_LICENSESERVER = "licenseServer";
+    private static final String PROP_DRM_LICENSE_SERVER = "licenseServer";
     private static final String PROP_DRM_HEADERS = "headers";
     private static final String PROP_SRC_HEADERS = "requestHeaders";
     private static final String PROP_RESIZE_MODE = "resizeMode";
@@ -81,8 +81,8 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SELECTED_VIDEO_TRACK_VALUE = "value";
     private static final String PROP_HIDE_SHUTTER_VIEW = "hideShutterView";
     private static final String PROP_CONTROLS = "controls";
-
     private static final String PROP_SUBTITLE_STYLE = "subtitleStyle";
+    private static final String PROP_FRAME_QUALITY = "frameQuality";
 
     private ReactExoplayerConfig config;
 
@@ -128,7 +128,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     public void setDRM(final ReactExoplayerView videoView, @Nullable ReadableMap drm) {
         if (drm != null && drm.hasKey(PROP_DRM_TYPE)) {
             String drmType = drm.hasKey(PROP_DRM_TYPE) ? drm.getString(PROP_DRM_TYPE) : null;
-            String drmLicenseServer = drm.hasKey(PROP_DRM_LICENSESERVER) ? drm.getString(PROP_DRM_LICENSESERVER) : null;
+            String drmLicenseServer = drm.hasKey(PROP_DRM_LICENSE_SERVER) ? drm.getString(PROP_DRM_LICENSE_SERVER) : null;
             ReadableMap drmHeaders = drm.hasKey(PROP_DRM_HEADERS) ? drm.getMap(PROP_DRM_HEADERS) : null;
             if (drmType != null && drmLicenseServer != null && Util.getDrmUuid(drmType) != null) {
                 UUID drmUUID = Util.getDrmUuid(drmType);
@@ -171,15 +171,15 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
             }
         } else {
             int identifier = context.getResources().getIdentifier(
-                uriString,
-                "drawable",
-                context.getPackageName()
+                    uriString,
+                    "drawable",
+                    context.getPackageName()
             );
             if (identifier == 0) {
                 identifier = context.getResources().getIdentifier(
-                    uriString,
-                    "raw",
-                    context.getPackageName()
+                        uriString,
+                        "raw",
+                        context.getPackageName()
                 );
             }
             if (identifier > 0) {
@@ -222,7 +222,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
 
     @ReactProp(name = PROP_SELECTED_VIDEO_TRACK)
     public void setSelectedVideoTrack(final ReactExoplayerView videoView,
-                                     @Nullable ReadableMap selectedVideoTrack) {
+                                      @Nullable ReadableMap selectedVideoTrack) {
         String typeString = null;
         Dynamic value = null;
         if (selectedVideoTrack != null) {
@@ -236,7 +236,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
 
     @ReactProp(name = PROP_SELECTED_AUDIO_TRACK)
     public void setSelectedAudioTrack(final ReactExoplayerView videoView,
-                                     @Nullable ReadableMap selectedAudioTrack) {
+                                      @Nullable ReadableMap selectedAudioTrack) {
         String typeString = null;
         Dynamic value = null;
         if (selectedAudioTrack != null) {
@@ -366,6 +366,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_HIDE_SHUTTER_VIEW, defaultBoolean = false)
     public void setHideShutterView(final ReactExoplayerView videoView, final boolean hideShutterView) {
         videoView.setHideShutterView(hideShutterView);
+    }
+
+    @ReactProp(name = PROP_FRAME_QUALITY)
+    public void setFrameQuality(final ReactExoplayerView videoView, @Nullable final Integer frameQuality) {
+        videoView.setFrameQuality(frameQuality);
     }
 
     @ReactProp(name = PROP_CONTROLS, defaultBoolean = false)

--- a/android/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -57,6 +57,7 @@ class VideoEventEmitter {
     private static final String EVENT_TEXT_TRACKS = "onTextTracks";
     private static final String EVENT_VIDEO_TRACKS = "onVideoTracks";
     private static final String EVENT_ON_RECEIVE_AD_EVENT = "onReceiveAdEvent";
+    private static final String EVENT_ON_FRAME_CHANGE = "onFrameChange";
 
     static final String[] Events = {
             EVENT_LOAD_START,
@@ -83,7 +84,8 @@ class VideoEventEmitter {
             EVENT_TEXT_TRACKS,
             EVENT_VIDEO_TRACKS,
             EVENT_BANDWIDTH,
-            EVENT_ON_RECEIVE_AD_EVENT
+            EVENT_ON_RECEIVE_AD_EVENT,
+            EVENT_ON_FRAME_CHANGE
     };
 
     @Retention(RetentionPolicy.SOURCE)
@@ -112,7 +114,8 @@ class VideoEventEmitter {
             EVENT_TEXT_TRACKS,
             EVENT_VIDEO_TRACKS,
             EVENT_BANDWIDTH,
-            EVENT_ON_RECEIVE_AD_EVENT
+            EVENT_ON_RECEIVE_AD_EVENT,
+            EVENT_ON_FRAME_CHANGE
     })
     @interface VideoEvents {
     }
@@ -440,6 +443,12 @@ class VideoEventEmitter {
         map.putString("event", event);
 
         receiveEvent(EVENT_ON_RECEIVE_AD_EVENT, map);
+    }
+
+    void setFrame(String base64Image) {
+        WritableMap map = Arguments.createMap();
+        map.putString("base64ImageString", base64Image);
+        receiveEvent(EVENT_ON_FRAME_CHANGE, map);
     }
 
     private void receiveEvent(@VideoEvents String type, WritableMap event) {

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -35,6 +35,7 @@ RCT_EXPORT_VIEW_PROPERTY(filterEnabled, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(progressUpdateInterval, float);
 RCT_EXPORT_VIEW_PROPERTY(restoreUserInterfaceForPIPStopCompletionHandler, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(localSourceEncryptionKeyScheme, NSString);
+RCT_EXPORT_VIEW_PROPERTY(frameQuality, float);
 
 /* Should support: onLoadStart, onLoad, and onError to stay consistent with Image */
 RCT_EXPORT_VIEW_PROPERTY(onVideoLoadStart, RCTDirectEventBlock);
@@ -60,6 +61,7 @@ RCT_EXPORT_VIEW_PROPERTY(onGetLicense, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onPictureInPictureStatusChanged, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onRestoreUserInterfaceForPictureInPictureStop, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onReceiveAdEvent, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onFrameChange, RCTDirectEventBlock);
 
 RCT_EXTERN_METHOD(save:(NSDictionary *)options
         reactTag:(nonnull NSNumber *)reactTag


### PR DESCRIPTION

#### frameQuality
Setting this prop will fire [onFrameChange](#onframechange) callback

* **0 (default)** - Don't display the video in fullscreen
* **1** - Display the video in fullscreen

Platforms: iOS, Android

---

#### onFrameChange
callback function that is called for each frame when [frameQuality](#framequality) > 0`, results each frame as base64Image(thumbnail)

```javascript
  <Video
    {...videoProps}
    frameQuality={0.3} // required to fire callback
    onFrameChange={(thumbnail: string) => setThumbnail(thumbnail)}
  />
```

Platform: iOS, Android