### PR TITLE
fix: fix tvos available compile errors

### DIFF
--- a/ios/Video/Features/RCTPlayerOperations.swift
+++ b/ios/Video/Features/RCTPlayerOperations.swift
@@ -8,7 +8,7 @@ let RCTVideoUnset = -1
  * Collection of mutating functions
  */
 enum RCTPlayerOperations {
-    
+
     static func setSideloadedText(player:AVPlayer?, textTracks:[TextTrack]?, criteria:SelectedTrackCriteria?) {
         let type = criteria?.type
         let textTracks:[TextTrack]! = textTracks ?? RCTVideoUtils.getTextTrackInfo(player)
@@ -22,9 +22,9 @@ enum RCTPlayerOperations {
                 break
             }
         }
-        
+
         var selectedTrackIndex:Int = RCTVideoUnset
-        
+
         if (type == "disabled") {
             // Select the last text index which is the disabled text track
             selectedTrackIndex = trackCount - firstTextIndex
@@ -53,7 +53,7 @@ enum RCTPlayerOperations {
                 }
             }
         }
-        
+
         // in the situation that a selected text track is not available (eg. specifies a textTrack not available)
         if (type != "disabled") && selectedTrackIndex == RCTVideoUnset {
             let captioningMediaCharacteristics = MACaptionAppearanceCopyPreferredCaptioningMediaCharacteristics(.user)
@@ -70,7 +70,7 @@ enum RCTPlayerOperations {
                 }
             }
         }
-                
+
         for i in firstTextIndex..<(trackCount) {
             var isEnabled = false
             if selectedTrackIndex != RCTVideoUnset {
@@ -79,13 +79,13 @@ enum RCTPlayerOperations {
             player?.currentItem?.tracks[i].isEnabled = isEnabled
         }
     }
-    
+
     // UNUSED
     static func setStreamingText(player:AVPlayer?, criteria:SelectedTrackCriteria?) {
         let type = criteria?.type
         let group:AVMediaSelectionGroup! = player?.currentItem?.asset.mediaSelectionGroup(forMediaCharacteristic: AVMediaCharacteristic.legible)
         var mediaOption:AVMediaSelectionOption!
-        
+
         if (type == "disabled") {
             // Do nothing. We want to ensure option is nil
         } else if (type == "language") || (type == "title") {
@@ -112,29 +112,29 @@ enum RCTPlayerOperations {
                 }
             }
         } else { // default. invalid type or "system"
-            #if TARGET_OS_TV
+            #if os(tvOS)
                 // Do noting. Fix for tvOS native audio menu language selector
             #else
                 player?.currentItem?.selectMediaOptionAutomatically(in: group)
                 return
             #endif
         }
-        
-        #if TARGET_OS_TV
+
+        #if os(tvOS)
             // Do noting. Fix for tvOS native audio menu language selector
         #else
             // If a match isn't found, option will be nil and text tracks will be disabled
             player?.currentItem?.select(mediaOption, in:group)
         #endif
     }
-    
+
     static func setMediaSelectionTrackForCharacteristic(player:AVPlayer?, characteristic:AVMediaCharacteristic, criteria:SelectedTrackCriteria?) {
         let type = criteria?.type
         let group:AVMediaSelectionGroup! = player?.currentItem?.asset.mediaSelectionGroup(forMediaCharacteristic: characteristic)
         var mediaOption:AVMediaSelectionOption!
 
         guard group != nil else { return }
-        
+
         if (type == "disabled") {
             // Do nothing. We want to ensure option is nil
         } else if (type == "language") || (type == "title") {
@@ -164,12 +164,12 @@ enum RCTPlayerOperations {
             player?.currentItem?.selectMediaOptionAutomatically(in: group)
             return
         }
-        
+
         if let group = group {
             // If a match isn't found, option will be nil and text tracks will be disabled
             player?.currentItem?.select(mediaOption, in:group)
         }
-        
+
     }
 
     static func seek(player: AVPlayer, playerItem:AVPlayerItem, paused:Bool, seekTime:Float, seekTolerance:Float) -> Promise<Bool> {
@@ -177,7 +177,7 @@ enum RCTPlayerOperations {
         let cmSeekTime:CMTime = CMTimeMakeWithSeconds(Float64(seekTime), preferredTimescale: Int32(timeScale))
         let current:CMTime = playerItem.currentTime()
         let tolerance:CMTime = CMTimeMake(value: Int64(seekTolerance), timescale: Int32(timeScale))
-        
+
         return Promise<Bool>(on: .global()) { fulfill, reject in
             guard CMTimeCompare(current, cmSeekTime) != 0 else {
                 reject(NSError(domain: "", code: 0, userInfo: nil))
@@ -190,7 +190,7 @@ enum RCTPlayerOperations {
             })
         }
     }
-    
+
     static func configureAudio(ignoreSilentSwitch:String, mixWithOthers:String) {
         let audioSession:AVAudioSession! = AVAudioSession.sharedInstance()
         var category:AVAudioSession.Category? = nil
@@ -213,6 +213,7 @@ enum RCTPlayerOperations {
                 try audioSession.setCategory(category, options: options)
             } catch {
                 debugPrint("[RCTPlayerOperations] Problem setting up AVAudioSession category and options. Error: \(error).")
+                #if !os(tvOS)
                 // Handle specific set category and option combination error
                 // setCategory:AVAudioSessionCategoryPlayback withOptions:mixWithOthers || duckOthers
                 // Failed to set category, error: 'what' Error Domain=NSOSStatusErrorDomain
@@ -225,6 +226,7 @@ enum RCTPlayerOperations {
                         debugPrint("[RCTPlayerOperations] Reseting AVAudioSession category and options problem. Error: \(error).")
                     }
                 }
+                #endif
             }
         } else if let category = category, options == nil {
             do {

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -548,7 +548,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             // Fallback on earlier versions
         }
     }
-    
+
     func setPlaybackRange(_ item:AVPlayerItem!, withVideoStart videoStart:Int64?, withVideoEnd videoEnd:Int64?) {
         if (videoStart != nil) {
             let start = CMTimeMake(value: videoStart!, timescale: 1000)
@@ -577,7 +577,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             _player?.isMuted = false
         }
 
-        if #available(iOS 12.0, *) {
+        if #available(iOS 12.0, tvOS 12.0, *) {
             _player?.preventsDisplaySleepDuringVideoPlayback = _preventsDisplaySleepDuringVideoPlayback
         } else {
             // Fallback on earlier versions

--- a/ios/Video/RCTVideoPlayerViewController.swift
+++ b/ios/Video/RCTVideoPlayerViewController.swift
@@ -1,13 +1,13 @@
 import AVKit
 
 class RCTVideoPlayerViewController: AVPlayerViewController {
-    
+
     weak var rctDelegate: RCTVideoPlayerViewControllerDelegate?
-    
+
     // Optional paramters
     var preferredOrientation:String?
     var autorotate:Bool?
-    
+
     func shouldAutorotate() -> Bool {
 
         if autorotate! || preferredOrientation == nil || (preferredOrientation!.lowercased() == "all") {
@@ -19,12 +19,12 @@ class RCTVideoPlayerViewController: AVPlayerViewController {
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        
+
         rctDelegate?.videoPlayerViewControllerWillDismiss(playerViewController: self)
         rctDelegate?.videoPlayerViewControllerDidDismiss(playerViewController: self)
     }
 
-    #if !TARGET_OS_TV
+    #if !os(tvOS)
 
     func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {
         return .all

--- a/react-native-video.podspec
+++ b/react-native-video.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/react-native-video/react-native-video.git", :tag => "v#{s.version}" }
 
   s.ios.deployment_target = "9.0"
-  s.tvos.deployment_target = "9.0"
+  s.tvos.deployment_target = "10.0"
 
   s.subspec "Video" do |ss|
     ss.source_files  = "ios/Video/**/*.{h,m,swift}"


### PR DESCRIPTION
This fixes multiple available errors descripted in the following issue:
#3206

#### Provide an example of how to test the change
The compilation of tvOS can be tested using the new tvOS example descripted in #3206.
I will open an additional PR for that topic.

#### Describe the changes
It bumps the minimum tvOS version to 10.0 as many features used in RCTVideoUtils, require this SDK version.
Additionally some tvOS checks got rewriten.
