### PR TITLE
Fix: Not showing video ads when the PIP mode is enabled on iOS

### DIFF
--- a/API.md
+++ b/API.md
@@ -667,6 +667,8 @@ Determine whether the media should played as picture in picture.
 * **false (default)** - Don't not play as picture in picture
 * **true** - Play the media as picture in picture
 
+NOTE: Video ads cannot start when you are using the PIP on iOS (more info available at [Google IMA SDK Docs](https://developers.google.com/interactive-media-ads/docs/sdks/ios/client-side/picture_in_picture?hl=en#starting_ads)). If you are using custom controls, you must disable your PIP button when you receive the ```STARTED``` event from ```onReceiveAdEvent``` and show it again when you receive the ```ALL_ADS_COMPLETED``` event.
+
 Platforms: iOS
 
 #### playInBackground

--- a/ios/Video/Features/RCTIMAAdsManager.swift
+++ b/ios/Video/Features/RCTIMAAdsManager.swift
@@ -5,14 +5,16 @@ import GoogleInteractiveMediaAds
 class RCTIMAAdsManager: NSObject, IMAAdsLoaderDelegate, IMAAdsManagerDelegate {
 
     private weak var _video: RCTVideo?
+    private var _pipEnabled:() -> Bool
 
     /* Entry point for the SDK. Used to make ad requests. */
     private var adsLoader: IMAAdsLoader!
     /* Main point of interaction with the SDK. Created by the SDK as the result of an ad request. */
     private var adsManager: IMAAdsManager!
 
-    init(video:RCTVideo!) {
+    init(video:RCTVideo!, pipEnabled:@escaping () -> Bool) {
         _video = video
+        _pipEnabled = pipEnabled
 
         super.init()
     }
@@ -86,6 +88,9 @@ class RCTIMAAdsManager: NSObject, IMAAdsLoaderDelegate, IMAAdsManagerDelegate {
         }
         // Play each ad once it has been loaded
         if event.type == IMAAdEventType.LOADED {
+            if (_pipEnabled()) {
+                return
+            }
             adsManager.start()
         }
 

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -65,6 +65,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     private var _filterName:String!
     private var _filterEnabled:Bool = false
     private var _presentingViewController:UIViewController?
+    private var _pictureInPictureEnabled = false
 
     /* IMA Ads */
     private var _adTagUrl:String?
@@ -120,10 +121,14 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         onPictureInPictureStatusChanged?([ "isActive": NSNumber(value: false)])
     }
 
+    func isPipEnabled () -> Bool {
+        return _pictureInPictureEnabled
+    }
+
     init(eventDispatcher:RCTEventDispatcher!) {
         super.init(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
 #if USE_GOOGLE_IMA
-        _imaAdsManager = RCTIMAAdsManager(video: self)
+        _imaAdsManager = RCTIMAAdsManager(video: self, pipEnabled: isPipEnabled)
 #endif
 
         _eventDispatcher = eventDispatcher
@@ -168,7 +173,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
 #if USE_GOOGLE_IMA
-        _imaAdsManager = RCTIMAAdsManager(video: self)
+        _imaAdsManager = RCTIMAAdsManager(video: self, pipEnabled: isPipEnabled)
 #endif
     }
 
@@ -458,6 +463,11 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             try audioSession.setCategory(.playback)
             try audioSession.setActive(true, options: [])
         } catch {
+        }
+        if (pictureInPicture) {
+            _pictureInPictureEnabled = true
+        } else {
+            _pictureInPictureEnabled = false
         }
         _pip?.setPictureInPicture(pictureInPicture)
 #endif


### PR DESCRIPTION
Fix: Not showing video ads when the PIP mode is enabled on iOS.

According to the Google IMA SDK, you cannot show video ads when the PIP mode is enabled (
https://developers.google.com/interactive-media-ads/docs/sdks/ios/client-side/picture_in_picture?hl=en#starting_ads).