### PR TITLE
chore(ci): bump actions node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
       - run: yarn --no-lockfile
       - run: yarn lint


### PR DESCRIPTION
## Summary
Bump ci actions runner node version to 16. This will fix some actions fails like [this one](https://github.com/react-native-video/react-native-video/actions/runs/5833199173/job/15820101638?pr=3204)

## Test Plan
- [x] Ci actions should work