### PR TITLE
Remove explicit SDK version for Windows builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ## Next
+- Windows: fix build error from over-specified SDK version [#3246](https://github.com/react-native-video/react-native-video/pull/3246)
 
 ### Version 6.0.0-alpha.8
 - All: Playing audio over earpiece [#2887](https://github.com/react-native-video/react-native-video/issues/2887)

--- a/windows/ReactNativeVideoCPP/ReactNativeVideoCPP.vcxproj
+++ b/windows/ReactNativeVideoCPP/ReactNativeVideoCPP.vcxproj
@@ -13,13 +13,16 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="ReactNativeWindowsProps">
     <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
   </PropertyGroup>
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.WindowsSdk.Default.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.WindowsSdk.Default.props')" />
+  <PropertyGroup Label="Fallback Windows SDK Versions">
+   <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0</WindowsTargetPlatformVersion>
+   <WindowsTargetPlatformMinVersion Condition=" '$(WindowsTargetPlatformMinVersion)' == '' ">10.0.16299.0</WindowsTargetPlatformMinVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>


### PR DESCRIPTION
Fix SDK build error if 10.0.16299.0 is not installed:
```
 i Build configuration: Debug
 i Build platform: x64
 × Build failed with message 4:10>C:\Users\redactedUser\.nuget\packages\microsoft.ui.xaml\2.8.0\build\Common.targets(10,5): error : Microsoft.UI.Xaml nuget package requires TargetPlatformMinVersion >= 10.0.17763.0 (current project is 16299) [D:\GitHub\redacted\node_modules\react-native-video\windows\ReactNativeVideoCPP\ReactNativeVideoCPP.vcxproj]. Check your build configuration.
```

See https://github.com/react-native-async-storage/async-storage/pull/810 for a similar fix.
And these
- https://github.com/react-native-picker/picker/pull/483
- https://github.com/react-native-clipboard/clipboard/pull/177
- https://github.com/software-mansion/react-native-screens/pull/1890

Previously, after bringing down package dependencies you'd have to retarget the SDK version for the module project.

This change was tested by applying a patch-package of the vcxproj to an RNW app and doing a clean build. Basically, if it builds, it's good. No runtime effect.

- [x] After you open the PR, update the CHANGELOG.md file with an entry pointing to your PR.