### PR TITLE
Fix lack of `onError` event for Windows

### DIFF
--- a/API.md
+++ b/API.md
@@ -352,7 +352,7 @@ var styles = StyleSheet.create({
 | [onBandwidthUpdate](#onbandwidthupdate)                                                         | Android                   |
 | [onBuffer](#onbuffer)                                                                           | Android, iOS              |
 | [onEnd](#onend)                                                                                 | All                       |
-| [onError](#onerror)                                                                             | Android, iOS              |
+| [onError](#onerror)                                                                             | Android, iOS, Windows UWP |
 | [onExternalPlaybackChange](#onexternalplaybackchange)                                           | iOS                       |
 | [onFullscreenPlayerWillPresent](#onfullscreenplayerwillpresent)                                 | Android, iOS              |
 | [onFullscreenPlayerDidPresent](#onfullscreenplayerdidpresent)                                   | Android, iOS              |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ## Next
+- Windows: fix `onError` not being raised [#3247](https://github.com/react-native-video/react-native-video/pull/3247)
 
 ### Version 6.0.0-alpha.8
 - All: Playing audio over earpiece [#2887](https://github.com/react-native-video/react-native-video/issues/2887)

--- a/windows/ReactNativeVideoCPP/ReactVideoView.cpp
+++ b/windows/ReactNativeVideoCPP/ReactVideoView.cpp
@@ -132,7 +132,13 @@ void ReactVideoView::OnMediaOpened(IInspectable const &, IInspectable const &) {
   });
 }
 
-void ReactVideoView::OnMediaFailed(IInspectable const &, IInspectable const &) {}
+void ReactVideoView::OnMediaFailed(IInspectable const &, IInspectable const &) {
+  runOnQueue([weak_this{get_weak()}]() {
+    if (auto strong_this{weak_this.get()}) {
+      strong_this->m_reactContext.DispatchEvent(*strong_this, L"topError", nullptr);
+    }
+  });
+}
 
 void ReactVideoView::OnMediaEnded(IInspectable const &, IInspectable const &) {
   runOnQueue([weak_this{get_weak()}]() {


### PR DESCRIPTION
The native code was receiving the event, but not reasing the event. Which [apparently](https://github.com/microsoft/react-native-windows/issues/4206) needs to be prefixed with "top" and then that turns into "onError".

Note that this raises the event, but no error object is included. Better than nothing.

#### How tested
```jsx
const [videoHasError, setVideoHasError] = useState(false);

...

const shouldShowVideo = videoThumbnail && hovering && !videoHasError;

...

        { shouldShowVideo &&
            <Video
              source={{uri: videoThumbnail.uri}}
              paused={!hovering}
              repeat={true}
              resizeMode='cover'
              onError={() => setVideoHasError(true)}
              style={{
                width: '100%',
                aspectRatio: videoThumbnail.width / videoThumbnail.height,
                borderRadius: 5,
                borderWidth: 1,
                borderColor: hovering ? 'black' : 'lightgray'
              }}
              />
        }
```

- [x] After you open the PR, update the CHANGELOG.md file with an entry pointing to your PR.
