### PR TITLE
fix: Player shows black screen on re-enter (iOS)

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -197,7 +197,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     @objc func applicationWillEnterForeground(notification:NSNotification!) {
         self.applyModifiers()
-        if _playInBackground {
+        if !_playInBackground {
             _playerLayer?.player = _player
             _playerViewController?.player = _player
         }


### PR DESCRIPTION
I've identified an issue on iOS where, when not using PIP (Picture-in-Picture) playback, transitioning the app to the background while a video is playing and then returning to the foreground results in only the audio playing with a black screen.

I believe this is due to the mismatched conditions: setting the player to nil when entering the background with the !_playInBackground condition, and not having a corresponding condition when returning to the foreground.

I'd appreciate it if you could take a look.