### PR TITLE
feat(android): update `isCodecSupported` to return enum

### DIFF
--- a/API.md
+++ b/API.md
@@ -1684,8 +1684,9 @@ parameters:
 - **width**, **height**: resolution to query
 
 Possible results:
--   **true** - codec supported
--   **false** - codec is not supported
+-   **`hardware`** - codec is supported by hardware
+-   **`software`** - codec is supported by software only
+-   **`unsupported`** - codec is not supported
 
 Example:
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next
 - Windows: fix build error from over-specified SDK version [#3246](https://github.com/react-native-video/react-native-video/pull/3246)
 - Windows: fix `onError` not being raised [#3247](https://github.com/react-native-video/react-native-video/pull/3247)
-- Android: update isCodecSupported to return enum [#3254](https://github.com/react-native-video/react-native-video/pull/3254)
+- **BREAKING CHANGE**❗️Android: update isCodecSupported to return enum [#3254](https://github.com/react-native-video/react-native-video/pull/3254)
 
 ### Version 6.0.0-alpha.8
 - All: Playing audio over earpiece [#2887](https://github.com/react-native-video/react-native-video/issues/2887)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 - Windows: fix build error from over-specified SDK version [#3246](https://github.com/react-native-video/react-native-video/pull/3246)
 - Windows: fix `onError` not being raised [#3247](https://github.com/react-native-video/react-native-video/pull/3247)
+- Android: update isCodecSupported to return enum [#3254](https://github.com/react-native-video/react-native-video/pull/3254)
 
 ### Version 6.0.0-alpha.8
 - All: Playing audio over earpiece [#2887](https://github.com/react-native-video/react-native-video/issues/2887)

--- a/android/src/main/java/com/brentvatne/react/VideoDecoderPropertiesModule.java
+++ b/android/src/main/java/com/brentvatne/react/VideoDecoderPropertiesModule.java
@@ -1,6 +1,7 @@
 package com.brentvatne.react;
 
 import android.annotation.SuppressLint;
+import android.media.MediaCodecInfo;
 import android.media.MediaCodecList;
 import android.media.MediaDrm;
 import android.media.MediaFormat;
@@ -79,18 +80,36 @@ public class VideoDecoderPropertiesModule extends ReactContextBaseJavaModule {
     @SuppressLint("ObsoleteSdkInt")
     @ReactMethod
     public void isCodecSupported(String mimeType, int width, int height, Promise p) {
-        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.LOLLIPOP) {
-            p.resolve(false);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            p.resolve("unsupported");
             return;
         }
+
         MediaCodecList mRegularCodecs = new MediaCodecList(MediaCodecList.REGULAR_CODECS);
         MediaFormat format = MediaFormat.createVideoFormat(mimeType, width, height);
         String codecName = mRegularCodecs.findDecoderForFormat(format);
+
         if (codecName == null) {
-            p.resolve(false);
-        } else {
-            p.resolve(true);
+            p.resolve("unsupported");
+            return;
         }
+
+        // Fallback for android < 10
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            p.resolve("software");
+            return;
+        }
+
+        boolean isHardwareAccelerated = false;
+
+        for (MediaCodecInfo codecInfo : mRegularCodecs.getCodecInfos()) {
+            if (codecInfo.getName().equalsIgnoreCase(codecName)) {
+                isHardwareAccelerated = codecInfo.isHardwareAccelerated();
+                break;
+            }
+        }
+
+        p.resolve(isHardwareAccelerated ? "software" : "hardware");
     }
 
 

--- a/examples/basic/src/VideoPlayer.android.tsx
+++ b/examples/basic/src/VideoPlayer.android.tsx
@@ -86,25 +86,23 @@ class VideoPlayer extends Component {
 
   popupInfo = () => {
     VideoDecoderProperties.getWidevineLevel().then((widevineLevel: number) => {
-      VideoDecoderProperties.isHEVCSupported().then((hevcSupported: boolean) => {
+      VideoDecoderProperties.isHEVCSupported().then((hevc: string) => {
         VideoDecoderProperties.isCodecSupported('video/avc', 1920, 1080).then(
-          (avcSupported: boolean) => {
+          (avc: string) => {
             this.toast(
               true,
               'Widevine level: ' +
               widevineLevel +
               '\n hevc: ' +
-              (hevcSupported ? '' : 'NOT') +
-              'supported' +
+              hevc +
               '\n avc: ' +
-              (avcSupported ? '' : 'NOT') +
-              'supported',
-            )
+              avc,
+            );
           },
-        )
-      })
-    })
-  }
+        );
+      });
+    });
+  };
 
   onLoad = (data: any) => {
     this.setState({ duration: data.duration, loading: false, });


### PR DESCRIPTION
### Breaking change❗️
## Summary
Update android function `isCodecSupported` to return enum to let developer know if codec is supported by hardware, to avoid CPU decoding (look here #2998). 

For iOS there will be separate PR  
## Test plan
- [x] `isCodecSupported` should work and return an enum
- [x] Example app should work

