### PR TITLE
chore(android): fix react native 0.73 support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -70,9 +70,16 @@ android {
     compileSdkVersion safeExtGet('compileSdkVersion', 31)
     buildToolsVersion safeExtGet('buildToolsVersion', '30.0.2')
 
-    compileOptions {
-        targetCompatibility JavaVersion.VERSION_1_8
-        sourceCompatibility JavaVersion.VERSION_1_8
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    if (agpVersion.tokenize('.')[0].toInteger() < 8) {
+      compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+      }
+
+      kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_11.majorVersion
+      }
     }
 
     defaultConfig {
@@ -85,6 +92,10 @@ android {
         ndk {
             abiFilters(*reactNativeArchitectures())
         }
+    }
+
+    buildFeatures {
+        buildConfig true
     }
 
     packagingOptions {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -91,11 +91,6 @@ android {
         exclude "**/libreact_render*.so"
     }
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     buildDir 'buildOutput_' + configStringPath
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,11 +24,20 @@ def getExtOrDefault(name, defaultValue) {
 }
 
 def isNewArchitectureEnabled() {
-    // To opt-in for the New Architecture, you can either:
-    // - Set `newArchEnabled` to true inside the `gradle.properties` file
-    // - Invoke gradle with `-newArchEnabled=true`
-    // - Set an environment variable `ORG_GRADLE_PROJECT_newArchEnabled=true`
-    return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
+    return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
+}
+
+def supportsNamespace() {
+  def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
+  def major = parsed[0].toInteger()
+  def minor = parsed[1].toInteger()
+
+  // Namespace support was added in 7.3.0
+  if (major == 7 && minor >= 3) {
+    return true
+  }
+
+  return major >= 8
 }
 
 def useExoplayerIMA = safeExtGet("RNVUseExoplayerIMA", false)
@@ -48,7 +57,16 @@ if (isNewArchitectureEnabled()) {
 }
 
 android {
-    namespace 'com.brentvatne.react'
+    if (supportsNamespace()) {
+      namespace 'com.brentvatne.react'
+
+      sourceSets {
+        main {
+          manifest.srcFile "src/main/AndroidManifestNew.xml"
+        }
+      }
+    }
+
     compileSdkVersion safeExtGet('compileSdkVersion', 31)
     buildToolsVersion safeExtGet('buildToolsVersion', '30.0.2')
 

--- a/android/src/main/AndroidManifestNew.xml
+++ b/android/src/main/AndroidManifestNew.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>


### PR DESCRIPTION
## Summary 
Fixes support for react native `0.73`. More information you can find here:
- https://github.com/react-native-community/discussions-and-proposals/issues/671

## Test plan
- [x] Example app should compile and run