### PR TITLE
Fix/fairplay different key per asset

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -267,15 +267,15 @@ export default class Video extends Component {
         const getLicensePromise = Promise.resolve(getLicenseOverride); // Handles both scenarios, getLicenseOverride being a promise and not.
         getLicensePromise.then((result => {
           if (result !== undefined) {
-            NativeModules.VideoManager.setLicenseResult(result,  data.contentId, findNodeHandle(this._root));
+            NativeModules.VideoManager.setLicenseResult(result,  data.licenseUrl, findNodeHandle(this._root));
           } else {
-            NativeModules.VideoManager.setLicenseError && NativeModules.VideoManager.setLicenseError('Empty license result',  data.contentId, findNodeHandle(this._root));
+            NativeModules.VideoManager.setLicenseError && NativeModules.VideoManager.setLicenseError('Empty license result',  data.licenseUrl, findNodeHandle(this._root));
           }
         })).catch((error) => {
-          NativeModules.VideoManager.setLicenseError && NativeModules.VideoManager.setLicenseError(error, data.contentId, findNodeHandle(this._root));
+          NativeModules.VideoManager.setLicenseError && NativeModules.VideoManager.setLicenseError(error, data.licenseUrl, findNodeHandle(this._root));
         });
       } else {
-        NativeModules.VideoManager.setLicenseError && NativeModules.VideoManager.setLicenseError('No spc received', data.contentId, findNodeHandle(this._root));
+        NativeModules.VideoManager.setLicenseError && NativeModules.VideoManager.setLicenseError('No spc received', data.licenseUrl, findNodeHandle(this._root));
       }
     }
   }

--- a/Video.js
+++ b/Video.js
@@ -267,15 +267,15 @@ export default class Video extends Component {
         const getLicensePromise = Promise.resolve(getLicenseOverride); // Handles both scenarios, getLicenseOverride being a promise and not.
         getLicensePromise.then((result => {
           if (result !== undefined) {
-            NativeModules.VideoManager.setLicenseResult(result, findNodeHandle(this._root));
+            NativeModules.VideoManager.setLicenseResult(result,  data.contentId, findNodeHandle(this._root));
           } else {
-            NativeModules.VideoManager.setLicenseError && NativeModules.VideoManager.setLicenseError('Empty license result', findNodeHandle(this._root));
+            NativeModules.VideoManager.setLicenseError && NativeModules.VideoManager.setLicenseError('Empty license result',  data.contentId, findNodeHandle(this._root));
           }
         })).catch((error) => {
-          NativeModules.VideoManager.setLicenseError && NativeModules.VideoManager.setLicenseError(error, findNodeHandle(this._root));
+          NativeModules.VideoManager.setLicenseError && NativeModules.VideoManager.setLicenseError(error, data.contentId, findNodeHandle(this._root));
         });
       } else {
-        NativeModules.VideoManager.setLicenseError && NativeModules.VideoManager.setLicenseError('No spc received', findNodeHandle(this._root));
+        NativeModules.VideoManager.setLicenseError && NativeModules.VideoManager.setLicenseError('No spc received', data.contentId, findNodeHandle(this._root));
       }
     }
   }

--- a/docs/DRM.md
+++ b/docs/DRM.md
@@ -31,13 +31,16 @@ Platforms: iOS
 
 ### `getLicense`
 
-`licenseServer` and `headers` will be ignored. You will obtain as argument the `SPC` (as ASCII string, you will probably need to convert it to base 64) obtained from your `contentId` + the provided certificate via `[loadingRequest streamingContentKeyRequestDataForApp:certificateData contentIdentifier:contentIdData options:nil error:&spcError];`.
-  You should return on this method a `CKC` in Base64, either by just returning it or returning a `Promise` that resolves with the `CKC`.
+`licenseServer` and `headers` will be ignored. You will obtain as argument the `SPC` (as ASCII string, you will probably need to convert it to base 64) obtained from your `contentId` + the provided certificate via `[loadingRequest streamingContentKeyRequestDataForApp:certificateData contentIdentifier:contentIdData options:nil error:&spcError];`. 
+
+Also, you will receive the `contentId` and a `licenseUrl` URL defined as `loadingRequest.request.URL.absoluteString ` or as the `licenseServer` prop if it's passed.
+  
+You should return on this method a `CKC` in Base64, either by just returning it or returning a `Promise` that resolves with the `CKC`.
 
 With this prop you can override the license acquisition flow, as an example:
 
 ```js
-getLicense: (spcString) => {
+getLicense: (spcString, contentId, licenseUrl) => {
   const base64spc = Base64.encode(spcString);
   const formData = new FormData();
   formData.append('spc', base64spc);

--- a/ios/Video/Features/RCTResourceLoaderDelegate.swift
+++ b/ios/Video/Features/RCTResourceLoaderDelegate.swift
@@ -66,6 +66,7 @@ class RCTResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URLSes
         let dataRequest: AVAssetResourceLoadingDataRequest! = loadingRequest?.dataRequest
         dataRequest.respond(with: respondData)
         loadingRequest!.finishLoading()
+        _loadingRequests.removeValue(forKey: contentId)
     }
     
     func setLicenseResultError(_ error:String!,_ contentId: String!) {
@@ -86,7 +87,7 @@ class RCTResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URLSes
         }
 
         loadingRequest!.finishLoading(with: error)
-
+        _loadingRequests.removeValue(forKey: contentId)
         _onVideoError?([
             "error": [
                 "code": NSNumber(value: error.code),

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1030,12 +1030,12 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         )
     }
 
-    func setLicenseResult(_ license:String!, _ contentId: String!) {
-        _resouceLoaderDelegate?.setLicenseResult(license, contentId)
+    func setLicenseResult(_ license:String!, _ licenseUrl: String!) {
+        _resouceLoaderDelegate?.setLicenseResult(license, licenseUrl)
     }
 
-    func setLicenseResultError(_ error:String!, _ contentId: String!) {
-        _resouceLoaderDelegate?.setLicenseResultError(error, contentId)
+    func setLicenseResultError(_ error:String!, _ licenseUrl: String!) {
+        _resouceLoaderDelegate?.setLicenseResultError(error, licenseUrl)
     }
 
     func dismissFullscreenPlayer(_ error:String!) {

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1030,12 +1030,12 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         )
     }
 
-    func setLicenseResult(_ license:String!) {
-        _resouceLoaderDelegate?.setLicenseResult(license)
+    func setLicenseResult(_ license:String!, _ contentId: String!) {
+        _resouceLoaderDelegate?.setLicenseResult(license, contentId)
     }
 
-    func setLicenseResultError(_ error:String!) {
-        _resouceLoaderDelegate?.setLicenseResultError(error)
+    func setLicenseResultError(_ error:String!, _ contentId: String!) {
+        _resouceLoaderDelegate?.setLicenseResultError(error, contentId)
     }
 
     func dismissFullscreenPlayer(_ error:String!) {

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -69,10 +69,12 @@ RCT_EXTERN_METHOD(save:(NSDictionary *)options
         rejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(setLicenseResult:(NSString *)license
+         contentId:(NSString *)contentId
          reactTag:(nonnull NSNumber *)reactTag)
 
-RCT_EXTERN_METHOD(setLicenseResultError(NSString *)error
-                 reactTag:(nonnull NSNumber *)reactTag)
+RCT_EXTERN_METHOD(setLicenseResultError:(NSString *)error
+         contentId:(NSString *)contentId
+         reactTag:(nonnull NSNumber *)reactTag)
 
 RCT_EXTERN_METHOD(presentFullscreenPlayer
                  reactTag:(nonnull NSNumber *)reactTag)

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -69,11 +69,11 @@ RCT_EXTERN_METHOD(save:(NSDictionary *)options
         rejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(setLicenseResult:(NSString *)license
-         contentId:(NSString *)contentId
+         licenseUrl:(NSString *)licenseUrl
          reactTag:(nonnull NSNumber *)reactTag)
 
 RCT_EXTERN_METHOD(setLicenseResultError:(NSString *)error
-         contentId:(NSString *)contentId
+         licenseUrl:(NSString *)licenseUrl
          reactTag:(nonnull NSNumber *)reactTag)
 
 RCT_EXTERN_METHOD(presentFullscreenPlayer

--- a/ios/Video/RCTVideoManager.swift
+++ b/ios/Video/RCTVideoManager.swift
@@ -24,26 +24,26 @@ class RCTVideoManager: RCTViewManager {
         })
     }
     
-    @objc(setLicenseResult:contentId:reactTag:)
-    func setLicenseResult(license: NSString, contentId:NSString, reactTag: NSNumber) -> Void {
+    @objc(setLicenseResult:licenseUrl:reactTag:)
+    func setLicenseResult(license: NSString, licenseUrl:NSString, reactTag: NSNumber) -> Void {
         bridge.uiManager.prependUIBlock({_ , viewRegistry in
             let view = viewRegistry?[reactTag]
             if !(view is RCTVideo) {
                 RCTLogError("Invalid view returned from registry, expecting RCTVideo, got: %@", String(describing: view))
             } else if let view = view as? RCTVideo {
-                view.setLicenseResult(license as String, contentId as String)
+                view.setLicenseResult(license as String, licenseUrl as String)
             }
         })
     }
     
-    @objc(setLicenseResultError:contentId:reactTag:)
-    func setLicenseResultError(error: NSString, contentId:NSString, reactTag: NSNumber) -> Void {
+    @objc(setLicenseResultError:licenseUrl:reactTag:)
+    func setLicenseResultError(error: NSString, licenseUrl:NSString, reactTag: NSNumber) -> Void {
         bridge.uiManager.prependUIBlock({_ , viewRegistry in
             let view = viewRegistry?[reactTag]
             if !(view is RCTVideo) {
                 RCTLogError("Invalid view returned from registry, expecting RCTVideo, got: %@", String(describing: view))
             } else if let view = view as? RCTVideo {
-                view.setLicenseResultError(error as String, contentId as String)
+                view.setLicenseResultError(error as String, licenseUrl as String)
             }
         })
     }

--- a/ios/Video/RCTVideoManager.swift
+++ b/ios/Video/RCTVideoManager.swift
@@ -24,26 +24,26 @@ class RCTVideoManager: RCTViewManager {
         })
     }
     
-    @objc(setLicenseResult:reactTag:)
-    func setLicenseResult(license: NSString, reactTag: NSNumber) -> Void {
+    @objc(setLicenseResult:contentId:reactTag:)
+    func setLicenseResult(license: NSString, contentId:NSString, reactTag: NSNumber) -> Void {
         bridge.uiManager.prependUIBlock({_ , viewRegistry in
             let view = viewRegistry?[reactTag]
             if !(view is RCTVideo) {
                 RCTLogError("Invalid view returned from registry, expecting RCTVideo, got: %@", String(describing: view))
             } else if let view = view as? RCTVideo {
-                view.setLicenseResult(license as String)
+                view.setLicenseResult(license as String, contentId as String)
             }
         })
     }
     
-    @objc(setLicenseResultError:reactTag:)
-    func setLicenseResultError(error: NSString, reactTag: NSNumber) -> Void {
+    @objc(setLicenseResultError:contentId:reactTag:)
+    func setLicenseResultError(error: NSString, contentId:NSString, reactTag: NSNumber) -> Void {
         bridge.uiManager.prependUIBlock({_ , viewRegistry in
             let view = viewRegistry?[reactTag]
             if !(view is RCTVideo) {
                 RCTLogError("Invalid view returned from registry, expecting RCTVideo, got: %@", String(describing: view))
             } else if let view = view as? RCTVideo {
-                view.setLicenseResultError(error as String)
+                view.setLicenseResultError(error as String, contentId as String)
             }
         })
     }


### PR DESCRIPTION
# Summary
As described in #3227, when a content has mutliple asset and each asset has different key, for example, skd://{key}/AUDIO for audio playlist, skd://{key}/HD and skd://{key}/SD for video playlist, the content is not being played.

# Problem found

In `ios/Video/Features/RCTResourceLoaderDelegate.swift`, for every `contentId` the function `handleDrm()` is called. For every call, the `_loadingRequest` object was set to the current call, so the reference to the previous `_loadingRequest` is lost. Also, when the `license` is retrieved from the `getLicense` function, the `setLicenseResult` is called, and sets the current `_loadingRequest` to finished, event though it was already finished.

# Solution description

We replaced the `_loadingRequest` object to a dictionary of `AVAssetResourceLoadingRequest` with key the `contentId` of the request. So, when the license is resolved, it looks for the request in the dictionary and finishes it with the corresponding value. Then, it removes it from the dictionary.

In order to get that working, we had to add the parameter `contentId` to the native functions `setLicenseResult` and `setLicenseResultError`. Also, we had to pass the `contentId` as `loadingRequest.request.url?.absoluteString,` in `_onGetLicense` inside `handleDRM`, so, the getLicense function now receives the full request url and not only the request's host.


# Video Sample

You can test the problem and solution with the following content:

URL: https://cdnw1-stg.zetatv.com.uy/testzapp/bigbuckbunny/playlist.m3u8
licenseServer: https://pm-stg.zetatv.com.uy:8443/api/fairplay/get_license/fbdd541b-0036-4b4c-afef-351b7627ba81/
certificateUrl: https://pm-stg.zetatv.com.uy:8443/fairplay/cert.crt

## Requirements for testing

The onGetLicense function defined on the video component should be the following:

```[javascript]
import { Base64 } from "js-base64";
getLicense: async (spc, skd) => {
          return fetch(licenseServer, {
            method: "POST",
            headers: {
              "Content-Type": "application/octet-stream",
              keyId: skd,
            },
            body: Base64.toUint8Array(spc),
          })
            .then((response) => response.blob())
            .then(async (response) => {
              const base_64 = await blobToBase64(response);
              return base_64.split(",")[1];
            })
            .catch((error) => {
              console.error("Error", error);
            });
        },
      },
```

