### PR TITLE
Resuming video ad after closing the in-app browser on iOS

### DIFF
--- a/API.md
+++ b/API.md
@@ -667,7 +667,7 @@ Determine whether the media should played as picture in picture.
 * **false (default)** - Don't not play as picture in picture
 * **true** - Play the media as picture in picture
 
-NOTE: Video ads cannot start when you are using the PIP on iOS (more info available at [Google IMA SDK Docs](https://developers.google.com/interactive-media-ads/docs/sdks/ios/client-side/picture_in_picture?hl=en#starting_ads)). If you are using custom controls, you must disable your PIP button when you receive the ```STARTED``` event from ```onReceiveAdEvent``` and show it again when you receive the ```ALL_ADS_COMPLETED``` event.
+NOTE: Video ads cannot start when you are using the PIP on iOS (more info available at [Google IMA SDK Docs](https://developers.google.com/interactive-media-ads/docs/sdks/ios/client-side/picture_in_picture?hl=en#starting_ads)). If you are using custom controls, you must hide your PIP button when you receive the ```STARTED``` event from ```onReceiveAdEvent``` and show it again when you receive the ```ALL_ADS_COMPLETED``` event.
 
 Platforms: iOS
 

--- a/ios/Video/Features/RCTIMAAdsManager.swift
+++ b/ios/Video/Features/RCTIMAAdsManager.swift
@@ -2,7 +2,7 @@
 import Foundation
 import GoogleInteractiveMediaAds
 
-class RCTIMAAdsManager: NSObject, IMAAdsLoaderDelegate, IMAAdsManagerDelegate {
+class RCTIMAAdsManager: NSObject, IMAAdsLoaderDelegate, IMAAdsManagerDelegate, IMALinkOpenerDelegate {
 
     private weak var _video: RCTVideo?
     private var _pipEnabled:() -> Bool
@@ -65,6 +65,7 @@ class RCTIMAAdsManager: NSObject, IMAAdsLoaderDelegate, IMAAdsManagerDelegate {
 
         // Create ads rendering settings and tell the SDK to use the in-app browser.
         let adsRenderingSettings: IMAAdsRenderingSettings = IMAAdsRenderingSettings();
+        adsRenderingSettings.linkOpenerDelegate = self;
         adsRenderingSettings.linkOpenerPresentingController = _video.reactViewController();
 
         adsManager.initialize(with: adsRenderingSettings)
@@ -123,6 +124,12 @@ class RCTIMAAdsManager: NSObject, IMAAdsLoaderDelegate, IMAAdsManagerDelegate {
         // Resume the content since the SDK is done playing ads (at least for now).
         _video?.setAdPlaying(false)
         _video?.setPaused(false)
+    }
+
+    // MARK: - IMALinkOpenerDelegate
+
+    func linkOpenerDidClose(inAppLink linkOpener: NSObject) {
+        adsManager?.resume()
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
Resuming video ad after closing the in-app browser on iOS.

Detected bug:

On iOS, when watching a video ad and tapping on "Learn More", the user is redirected to the in-app browser. Once the in-app browser is closed, the user automatically goes back to the App and the video ad is paused and there is nothing that can be done.

Bugfix in this PR:

Resuming video ad after closing the in-app browser.
