### PR TITLE
feat: refactor resize prop handler

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -121,12 +121,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
 
     @Override
     public @Nullable Map<String, Object> getExportedViewConstants() {
-        return MapBuilder.<String, Object>of(
-                "ScaleNone", Integer.toString(ResizeMode.RESIZE_MODE_FIT),
-                "ScaleAspectFit", Integer.toString(ResizeMode.RESIZE_MODE_FIT),
-                "ScaleToFill", Integer.toString(ResizeMode.RESIZE_MODE_FILL),
-                "ScaleAspectFill", Integer.toString(ResizeMode.RESIZE_MODE_CENTER_CROP)
-        );
+        return MapBuilder.of();
     }
 
     @ReactProp(name = PROP_DRM)
@@ -212,8 +207,19 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
 
 
     @ReactProp(name = PROP_RESIZE_MODE)
-    public void setResizeMode(final ReactExoplayerView videoView, final String resizeModeOrdinalString) {
-        videoView.setResizeModeModifier(convertToIntDef(resizeModeOrdinalString));
+    public void setResizeMode(final ReactExoplayerView videoView, final String resizeMode) {
+        switch (resizeMode) {
+            case "cover":
+                videoView.setResizeModeModifier(ResizeMode.RESIZE_MODE_CENTER_CROP);
+                break;
+            case "stretch":
+                videoView.setResizeModeModifier(ResizeMode.RESIZE_MODE_FILL);
+                break;
+            default:
+                // Handle also for "none" or "contain"
+                videoView.setResizeModeModifier(ResizeMode.RESIZE_MODE_FIT);
+                break;
+        }
     }
 
     @ReactProp(name = PROP_REPEAT, defaultBoolean = false)
@@ -429,13 +435,5 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
                 || lowerCaseUri.startsWith("content://")
                 || lowerCaseUri.startsWith("file://")
                 || lowerCaseUri.startsWith("asset://");
-    }
-
-    private @ResizeMode.Mode int convertToIntDef(String resizeModeOrdinalString) {
-        if (!TextUtils.isEmpty(resizeModeOrdinalString)) {
-            int resizeModeOrdinal = Integer.parseInt(resizeModeOrdinalString);
-            return ResizeMode.toResizeMode(resizeModeOrdinal);
-        }
-        return ResizeMode.RESIZE_MODE_FIT;
     }
 }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -119,11 +119,6 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
         return builder.build();
     }
 
-    @Override
-    public @Nullable Map<String, Object> getExportedViewConstants() {
-        return MapBuilder.of();
-    }
-
     @ReactProp(name = PROP_DRM)
     public void setDRM(final ReactExoplayerView videoView, @Nullable ReadableMap drm) {
         if (drm != null && drm.hasKey(PROP_DRM_TYPE)) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -204,6 +204,10 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_RESIZE_MODE)
     public void setResizeMode(final ReactExoplayerView videoView, final String resizeMode) {
         switch (resizeMode) {
+            case "none":
+            case "contain":
+                videoView.setResizeModeModifier(ResizeMode.RESIZE_MODE_FIT);
+                break;
             case "cover":
                 videoView.setResizeModeModifier(ResizeMode.RESIZE_MODE_CENTER_CROP);
                 break;
@@ -211,7 +215,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
                 videoView.setResizeModeModifier(ResizeMode.RESIZE_MODE_FILL);
                 break;
             default:
-                // Handle also for "none" or "contain"
+                DebugLog.w("ExoPlayer Warning", "Unsupported resize mode: " + resizeMode + " - falling back to fit");
                 videoView.setResizeModeModifier(ResizeMode.RESIZE_MODE_FIT);
                 break;
         }

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -56,7 +56,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     private var _playWhenInactive:Bool = false
     private var _ignoreSilentSwitch:String! = "inherit" // inherit, ignore, obey
     private var _mixWithOthers:String! = "inherit" // inherit, mix, duck
-    private var _resizeMode:String! = "AVLayerVideoGravityResizeAspectFill"
+    private var _resizeMode:String! = "cover"
     private var _fullscreen:Bool = false
     private var _fullscreenAutorotate:Bool = true
     private var _fullscreenOrientation:String! = "all"
@@ -429,12 +429,32 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     // MARK: - Prop setters
 
     @objc
-    func setResizeMode(_ mode: String?) {
-        if _controls {
-            _playerViewController?.videoGravity = AVLayerVideoGravity(rawValue: mode ?? "")
-        } else {
-            _playerLayer?.videoGravity = AVLayerVideoGravity(rawValue: mode ?? "")
+    func setResizeMode(_ mode: String) {
+        var resizeMode: AVLayerVideoGravity = .resizeAspect
+        
+        switch mode {
+        case "contain":
+            resizeMode = .resizeAspect
+            break
+        case "none":
+            resizeMode = .resizeAspect
+            break
+        case "cover":
+            resizeMode = .resizeAspectFill
+            break
+        case "stretch":
+            resizeMode = .resize
+            break
+        default:
+            resizeMode = .resizeAspect
         }
+        
+        if _controls {
+            _playerViewController?.videoGravity = resizeMode
+        } else {
+            _playerLayer?.videoGravity = resizeMode
+        }
+        
         _resizeMode = mode
     }
 

--- a/ios/Video/RCTVideoManager.swift
+++ b/ios/Video/RCTVideoManager.swift
@@ -85,12 +85,7 @@ class RCTVideoManager: RCTViewManager {
     }
 
     override func constantsToExport() -> [AnyHashable : Any]? {
-        return [
-            "ScaleNone": AVLayerVideoGravity.resizeAspect,
-            "ScaleToFill": AVLayerVideoGravity.resize,
-            "ScaleAspectFit": AVLayerVideoGravity.resizeAspect,
-            "ScaleAspectFill": AVLayerVideoGravity.resizeAspectFill
-        ]
+        return [:]
     }
 
     override class func requiresMainQueueSetup() -> Bool {

--- a/ios/Video/RCTVideoManager.swift
+++ b/ios/Video/RCTVideoManager.swift
@@ -84,10 +84,6 @@ class RCTVideoManager: RCTViewManager {
         })
     }
 
-    override func constantsToExport() -> [AnyHashable : Any]? {
-        return [:]
-    }
-
     override class func requiresMainQueueSetup() -> Bool {
         return true
     }

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -8,9 +8,8 @@ import React, {
   type ComponentRef,
 } from 'react';
 import {View, StyleSheet, Image, Platform} from 'react-native';
-import NativeVideoComponent, {RCTVideoConstants} from './VideoNativeComponent';
+import NativeVideoComponent from './VideoNativeComponent';
 import type {
-  NativeVideoResizeMode,
   OnAudioFocusChangedData,
   OnAudioTracksData,
   OnPlaybackStateChangedData,
@@ -149,19 +148,6 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         customImageUri: resolvedSource.customImageUri,
       };
     }, [source]);
-
-    const _resizeMode: NativeVideoResizeMode = useMemo(() => {
-      switch (resizeMode) {
-        case 'contain':
-          return RCTVideoConstants.ScaleAspectFit;
-        case 'cover':
-          return RCTVideoConstants.ScaleAspectFill;
-        case 'stretch':
-          return RCTVideoConstants.ScaleToFill;
-        default:
-          return RCTVideoConstants.ScaleNone;
-      }
-    }, [resizeMode]);
 
     const _drm = useMemo(() => {
       if (!drm) {
@@ -476,7 +462,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           src={src}
           drm={_drm}
           style={StyleSheet.absoluteFill}
-          resizeMode={_resizeMode}
+          resizeMode={resizeMode}
           fullscreen={isFullscreen}
           restoreUserInterfaceForPIPStopCompletionHandler={
             _restoreUserInterfaceForPIPStopCompletionHandler

--- a/src/VideoNativeComponent.ts
+++ b/src/VideoNativeComponent.ts
@@ -233,15 +233,13 @@ export type OnVideoErrorData = Readonly<{
 export type OnAudioFocusChangedData = Readonly<{
   hasFocus: boolean;
 }>;
-
-export type NativeVideoResizeMode = unknown;
 export interface VideoNativeProps extends ViewProps {
   src?: VideoSrc;
   drm?: Drm;
   adTagUrl?: string;
   allowsExternalPlayback?: boolean; // ios, true
   maxBitRate?: number;
-  resizeMode?: NativeVideoResizeMode;
+  resizeMode?: 'none' | 'cover' | 'contain' | 'stretch';
   repeat?: boolean;
   automaticallyWaitsToMinimizeStalling?: boolean;
   textTracks?: TextTracks;
@@ -365,12 +363,7 @@ export interface VideoDecoderPropertiesType {
 }
 
 export type VideoViewManagerConfig = {
-  Constants: {
-    ScaleNone: unknown;
-    ScaleToFill: unknown;
-    ScaleAspectFit: unknown;
-    ScaleAspectFill: unknown;
-  };
+  Constants: Record<string, never>;
   Commands: {[key: string]: number};
 };
 

--- a/src/VideoNativeComponent.ts
+++ b/src/VideoNativeComponent.ts
@@ -4,7 +4,6 @@ import type {
   ViewProps,
 } from 'react-native';
 import {NativeModules, requireNativeComponent} from 'react-native';
-import {getViewManagerConfig} from './utils';
 
 // -------- There are types for native component (future codegen) --------
 // if you are looking for types for react component, see src/types/video.ts
@@ -362,17 +361,9 @@ export interface VideoDecoderPropertiesType {
   isHEVCSupported: () => Promise<'unsupported' | 'hardware' | 'software'>;
 }
 
-export type VideoViewManagerConfig = {
-  Constants: Record<string, never>;
-  Commands: {[key: string]: number};
-};
-
 export const VideoManager = NativeModules.VideoManager as VideoManagerType;
 export const VideoDecoderProperties =
   NativeModules.VideoDecoderProperties as VideoDecoderPropertiesType;
-export const RCTVideoConstants = (
-  getViewManagerConfig('RCTVideo') as VideoViewManagerConfig
-).Constants;
 
 export default requireNativeComponent<VideoNativeProps>(
   'RCTVideo',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import type {Component, RefObject, ComponentClass} from 'react';
-import {Image, UIManager, findNodeHandle} from 'react-native';
+import {Image, findNodeHandle} from 'react-native';
 import type {ImageSourcePropType} from 'react-native';
 import type {ReactVideoSource} from './types/video';
 
@@ -34,12 +34,4 @@ export function getReactTag(
   }
 
   return reactTag;
-}
-
-export function getViewManagerConfig(name: string) {
-  if ('getViewManagerConfig' in UIManager) {
-    return UIManager.getViewManagerConfig(name);
-  }
-
-  return UIManager[name];
 }


### PR DESCRIPTION
**This is internal change only, and does not affect users**
## Summary
Map JS values to native equivalents and remove old exported values. With this we have clear type and same JS values for platforms

## Test Plan
- [x] `resize` prop work in example app
