### PR TITLE
fix : onAttachedToWindow can call multiple times.

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -317,7 +317,9 @@ public class ReactExoplayerView extends FrameLayout implements
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        initializePlayer();
+        if(player == null) {
+            initializePlayer();
+        }
     }
 
     @Override


### PR DESCRIPTION
Related issue: #3022

Summary : 

When onAttachedToWindow in ReactExoplayerView.java is called multiple times, the video component blacks out and the error occurs

Fix : 

in ReactExolayerView.java
When onAttachedToWindow called multiple times, player initialize function call only one time.