### PR TITLE
fix: remove false calls at `onPlaybackRateChange`

### DIFF
--- a/ios/Video/Features/RCTPlayerObserver.swift
+++ b/ios/Video/Features/RCTPlayerObserver.swift
@@ -94,7 +94,7 @@ class RCTPlayerObserver: NSObject {
             return
         }
         
-        _playerRateChangeObserver = player.observe(\.rate, changeHandler: _handlers.handlePlaybackRateChange)
+        _playerRateChangeObserver = player.observe(\.rate, options: [.old], changeHandler: _handlers.handlePlaybackRateChange)
         _playerExternalPlaybackActiveObserver = player.observe(\.isExternalPlaybackActive, changeHandler: _handlers.handleExternalPlaybackActiveChange)
     }
     

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1221,6 +1221,10 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     func handlePlaybackRateChange(player: AVPlayer, change: NSKeyValueObservedChange<Float>) {
         guard let _player = _player else { return }
         
+        if(player.rate == change.oldValue && change.oldValue != nil) {
+            return
+        }
+        
         onPlaybackRateChange?(["playbackRate": NSNumber(value: _player.rate),
                                "target": reactTag as Any])
         


### PR DESCRIPTION
## Summary
Don't emit event `onPlaybackRateChange` if value is same as in previous call - like on android

## Test plan
- [x] run example & check if callback is working correctly 