### PR TITLE
[Android] use explicit not-exported flag for AudioBecomingNoisyReceiver

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -62,7 +62,6 @@ dependencies {
         exclude group: 'com.android.support'
     }
 
-    // All support libs must use the same version
     implementation "androidx.annotation:annotation:1.7.0"
     implementation "androidx.core:core:1.12.0"
     implementation "androidx.media:media:1.6.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,9 +63,9 @@ dependencies {
     }
 
     implementation "androidx.annotation:annotation:1.7.0"
-    implementation "androidx.core:core:1.12.0"
+    implementation "androidx.core:core:1.9.0"
     implementation "androidx.media:media:1.6.0"
-    implementation "androidx.activity:activity:1.8.0"
+    implementation "androidx.activity:activity:1.6.0"
 
     implementation('com.google.android.exoplayer:extension-okhttp:2.18.1') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,10 +63,10 @@ dependencies {
     }
 
     // All support libs must use the same version
-    implementation "androidx.annotation:annotation:1.1.0"
-    implementation "androidx.core:core:1.1.0"
-    implementation "androidx.media:media:1.1.0"
-    implementation "androidx.activity:activity:1.4.0"
+    implementation "androidx.annotation:annotation:1.7.0"
+    implementation "androidx.core:core:1.12.0"
+    implementation "androidx.media:media:1.6.0"
+    implementation "androidx.activity:activity:1.8.0"
 
     implementation('com.google.android.exoplayer:extension-okhttp:2.18.1') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'

--- a/android/src/main/java/com/brentvatne/receiver/AudioBecomingNoisyReceiver.java
+++ b/android/src/main/java/com/brentvatne/receiver/AudioBecomingNoisyReceiver.java
@@ -2,6 +2,7 @@ package com.brentvatne.receiver;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
+import androidx.core.content.ContextCompat;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.media.AudioManager;
@@ -25,7 +26,7 @@ public class AudioBecomingNoisyReceiver extends BroadcastReceiver {
     public void setListener(BecomingNoisyListener listener) {
         this.listener = listener;
         IntentFilter intentFilter = new IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY);
-        context.registerReceiver(this, intentFilter);
+        ContextCompat.registerReceiver(context, this, intentFilter, ContextCompat.RECEIVER_NOT_EXPORTED);
     }
 
     public void removeListener() {


### PR DESCRIPTION
Add `RECEIVER_NOT_EXPORTED` flag support to `AudioBecomingNoisyReceiver` for Android 14 support. See
https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported for details.

Without this fix, apps using this dependency and targeting SDK 34 will crash when we attempt to register this receiver:

```
SecurityException: {package name here}: One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts
```