### PR TITLE
fix(android): fixes where Android's muted prop behavior differs from iOS

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -646,6 +646,7 @@ public class ReactExoplayerView extends FrameLayout implements
                     .setMediaSourceFactory(mediaSourceFactory)
                     .build();
         player.addListener(self);
+        player.setVolume(muted ? 0.f : audioVolume * 1);
         exoPlayerView.setPlayer(player);
         if (adsLoader != null) {
             adsLoader.setPlayer(player);


### PR DESCRIPTION
#### Update the changelog
fix(android): fixes where Android's muted prop behavior differs from iOS

#### Provide an example of how to test the change
```typescript
      <Video
        source={{
          uri: 'any valid url',
        }}
        muted
      />
```

#### Describe the changes
When Video Component mount with muted prop, it's behavior is different on Android and iOS
- iOS
play with no sound
- Android
play with sound

This PR makes Android behave like iOS