### PR TITLE
feat: add release-it

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,27 @@
+{
+    "git": {
+        "commitMessage": "chore: release v${version}",
+        "requireCleanWorkingDir": true,
+        "tagAnnotation": "Release v${version}",
+        "tagName": "v${version}"
+    },
+    
+    "plugins": {
+        "@release-it/conventional-changelog": {
+            "preset": "angular",
+            "infile": "CHANGELOG.md"
+        }
+    },
+    "hooks": {
+        "before:init": [
+            "rm -Rf lib", 
+            "yarn install --frozen-lockfile --non-interactive --production=false", 
+            "yarn run lint", 
+            "yarn run build"
+        ],
+        "after:release": "echo Successfully released ${name} v${version} from repository ${repo.repository}."
+    },
+    "npm": {
+        "skipChecks": false
+    }
+}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,11 @@
         "test": "echo no test available"
     },
     "files": [
+        ...
+        "!docs",
+        "!examples",
+        ...
+    ]
         "android",
         "ios",
         "windows",

--- a/package.json
+++ b/package.json
@@ -47,11 +47,6 @@
         "test": "echo no test available"
     },
     "files": [
-        ...
-        "!docs",
-        "!examples",
-        ...
-    ]
         "android",
         "ios",
         "windows",
@@ -62,6 +57,8 @@
         "!android/buildOutput_*",
         "!android/local.properties",
         "!ios/build",
-        "!**/*.tsbuildinfo"
+        "!**/*.tsbuildinfo",
+        "!docs",
+        "!examples"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     },
     "devDependencies": {
         "@react-native/eslint-config": "^0.72.2",
+        "@release-it/conventional-changelog": "^7.0.2",
         "@types/jest": "^28.1.2",
         "@types/react": "~18.0.0",
         "@types/react-native": "0.72.3",
@@ -28,6 +29,7 @@
         "react": "18.2.0",
         "react-native": "0.72.5",
         "react-native-windows": "^0.61.0-0",
+        "release-it": "^16.2.1",
         "typescript": "5.1.6"
     },
     "dependencies": {},
@@ -41,6 +43,7 @@
         "prepare": "yarn build",
         "xbasic": "yarn --cwd examples/basic",
         "docs": "yarn --cwd docs build",
+        "release": "release-it",
         "test": "echo no test available"
     },
     "files": [


### PR DESCRIPTION
Integrate release-it tool for new release management

Next version can be generated with:
npx release-it --preRelease=alpha

should address: https://github.com/react-native-video/react-native-video/issues/3333