### PR TITLE
Fix(ios): another video caching fix

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -14,7 +14,7 @@
     },
     "hooks": {
         "before:init": [
-            "rm -Rf lib", 
+            "rm -Rf lib tsconfig.tsbuildinfo",
             "yarn install --frozen-lockfile --non-interactive --production=false", 
             "yarn run lint", 
             "yarn run build"

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -80,7 +80,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     private var _resouceLoaderDelegate: RCTResourceLoaderDelegate?
     private var _playerObserver: RCTPlayerObserver = RCTPlayerObserver()
 
-#if canImport(RCTVideoCache)
+#if USE_VIDEO_CACHING
     private let _videoCache:RCTVideoCachingHandler = RCTVideoCachingHandler()
 #endif
 
@@ -174,7 +174,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             object: nil
         )
         _playerObserver._handlers = self
-#if canImport(RCTVideoCache)
+#if USE_VIDEO_CACHING
         _videoCache.playerItemPrepareText = playerItemPrepareText
 #endif
     }
@@ -316,11 +316,11 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                         throw NSError(domain: "", code: 0, userInfo: nil)
                     }
 
-    #if canImport(RCTVideoCache)
+#if USE_VIDEO_CACHING
                     if self._videoCache.shouldCache(source:source, textTracks:self._textTracks) {
                         return self._videoCache.playerItemForSourceUsingCache(uri: source.uri, assetOptions:assetOptions)
                     }
-    #endif
+#endif
 
                     if self._drm != nil || self._localSourceEncryptionKeyScheme != nil {
                         self._resouceLoaderDelegate = RCTResourceLoaderDelegate(

--- a/ios/VideoCaching/RCTVideoCachingHandler.swift
+++ b/ios/VideoCaching/RCTVideoCachingHandler.swift
@@ -77,8 +77,8 @@ class RCTVideoCachingHandler: NSObject, DVAssetLoaderDelegatesDelegate {
     
     // MARK: - DVAssetLoaderDelegate
     
-    func dvAssetLoaderDelegate(loaderDelegate:DVAssetLoaderDelegate!, didLoadData data:NSData!, forURL url:NSURL!) {
-        _videoCache.storeItem(data as Data?, forUri:url.absoluteString, withCallback:{ (success:Bool) in
+    func dvAssetLoaderDelegate(_ loaderDelegate: DVAssetLoaderDelegate!, didLoad data: Data!, for url: URL!) {
+            _videoCache.storeItem(data as Data?, forUri:url.absoluteString, withCallback:{ (success:Bool) in
             DebugLog("Cache data stored successfully 🎉")
         })
     }

--- a/react-native-video.podspec
+++ b/react-native-video.podspec
@@ -32,7 +32,10 @@ Pod::Spec.new do |s|
       Pod::UI.puts "RNVideo: enable Video caching"
       ss.dependency "SPTPersistentCache", "~> 1.1.0"
       ss.dependency "DVAssetLoaderDelegate", "~> 0.3.1"
-      ss.source_files = "ios/Video/**/*.{h,m,swift}" "ios/VideoCaching/**/*.{h,m,swift}"
+      ss.source_files = "ios/*/**/*.{h,m,swift}"
+      ss.pod_target_xcconfig = {
+        'OTHER_SWIFT_FLAGS' => '$(inherited) -D USE_VIDEO_CACHING'
+      }
     end
   end
 


### PR DESCRIPTION
Add fix propose by @chayin in: https://github.com/react-native-video/react-native-video/issues/3346
Linked to original issue: https://github.com/react-native-video/react-native-video/issues/3217

* fix podspec for video caching
* fix conditionnal include usage
* fix dvAssetLoaderDelegate  prototype issue

I was able to build and run with video caching.
I see VideoCaching log displayed
save() api still not working on my side
