### PR TITLE
fix: update onError definition to match implementation

### DIFF
--- a/src/VideoNativeComponent.ts
+++ b/src/VideoNativeComponent.ts
@@ -241,11 +241,21 @@ export type OnReceiveAdEventData = Readonly<{
 }>;
 
 export type OnVideoErrorData = Readonly<{
-  errorString: string;
-  errorException: string;
-  errorStackTrace: string;
-  errorCode: string;
-  error: string;
+  error: OnVideoErrorDataDetails;
+  target?: number; // ios
+}>;
+
+export type OnVideoErrorDataDetails = Readonly<{
+  errorString?: string; // android
+  errorException?: string; // android
+  errorStackTrace?: string; // android
+  errorCode?: string; // android
+  error?: string; // ios
+  code?: number; // ios
+  localizedDescription?: string; // ios
+  localizedFailureReason?: string; // ios
+  localizedRecoverySuggestion?: string; // ios
+  domain?: string; // ios
 }>;
 
 export type OnAudioFocusChangedData = Readonly<{

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -118,13 +118,22 @@ export type OnReceiveAdEventData = Readonly<{
 }>;
 
 export type OnVideoErrorData = Readonly<{
-  errorString: string;
-  errorException: string;
-  errorStackTrace: string;
-  errorCode: string;
-  error: string;
+  error: OnVideoErrorDataDetails;
+  target?: number; // ios
 }>;
 
+export type OnVideoErrorDataDetails = Readonly<{
+  errorString?: string; // android
+  errorException?: string; // android
+  errorStackTrace?: string; // android
+  errorCode?: string; // android
+  error?: string; // ios
+  code?: number; // ios
+  localizedDescription?: string; // ios
+  localizedFailureReason?: string; // ios
+  localizedRecoverySuggestion?: string; // ios
+  domain?: string; // ios
+}>;
 export type OnAudioFocusChangedData = Readonly<{
   hasAudioFocus: boolean;
 }>;


### PR DESCRIPTION
Fix onError typescript definition.
It now match native implementation, but this clearly need to be refactored and unified between platforms
Should address: https://github.com/react-native-video/react-native-video/issues/3345