### PR TITLE
fix: Fix types for `ReactVideoSource` to also allow `require(..)` sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@
 ## Next
 - Android, iOS: add onVolumeChange event #3322
 
-
 ### Version 6.0.0-alpha.9
 - All: add built-in typescript support [#3266](https://github.com/react-native-video/react-native-video/pull/3266)
 - All: update documentation generation [#3296](https://github.com/react-native-video/react-native-video/pull/3296)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@
 
 ## Next
 - Android, iOS: add onVolumeChange event #3322
-- Fix types for ReactVideoSource to also allow require(..) sources
 
 
 ### Version 6.0.0-alpha.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 
 ## Next
 - Android, iOS: add onVolumeChange event #3322
+- Fix types for ReactVideoSource to also allow require(..) sources
+
 
 ### Version 6.0.0-alpha.9
 - All: add built-in typescript support [#3266](https://github.com/react-native-video/react-native-video/pull/3266)

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -6,22 +6,24 @@ import type FilterType from './FilterType';
 
 export type Headers = Record<string, string>;
 
-export type ReactVideoSource = Readonly<{
-  uri?: string;
-  isNetwork?: boolean;
-  isAsset?: boolean;
-  shouldCache?: boolean;
-  type?: string;
-  mainVer?: number;
-  patchVer?: number;
-  headers?: Headers;
-  startTime?: number;
-  endTime?: number;
-  title?: string;
-  subtitle?: string;
-  description?: string;
-  customImageUri?: string;
-}>;
+export type ReactVideoSource =
+  | Readonly<{
+      uri?: string
+      isNetwork?: boolean
+      isAsset?: boolean
+      shouldCache?: boolean
+      type?: string
+      mainVer?: number
+      patchVer?: number
+      headers?: Headers
+      startTime?: number
+      endTime?: number
+      title?: string
+      subtitle?: string
+      description?: string
+      customImageUri?: string
+    }>
+  | NodeRequire;
 
 export type DebugConfig = Readonly<{
   enable?: boolean;

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -8,20 +8,20 @@ export type Headers = Record<string, string>;
 
 export type ReactVideoSource =
   | Readonly<{
-      uri?: string
-      isNetwork?: boolean
-      isAsset?: boolean
-      shouldCache?: boolean
-      type?: string
-      mainVer?: number
-      patchVer?: number
-      headers?: Headers
-      startTime?: number
-      endTime?: number
-      title?: string
-      subtitle?: string
-      description?: string
-      customImageUri?: string
+      uri?: string;
+      isNetwork?: boolean;
+      isAsset?: boolean;
+      shouldCache?: boolean;
+      type?: string;
+      mainVer?: number;
+      patchVer?: number;
+      headers?: Headers;
+      startTime?: number;
+      endTime?: number;
+      title?: string;
+      subtitle?: string;
+      description?: string;
+      customImageUri?: string;
     }>
   | NodeRequire;
 


### PR DESCRIPTION

We need to be careful here to not use `any`, so I used `NodeRequire` - which is afaik present in all React Native environments as a type.
