### PR TITLE
feat(android): bump media3 version from v1.1.1 to v1.2.0

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -4,5 +4,5 @@ RNVideo_targetSdkVersion=31
 RNVideo_compileSdkVersion=31
 RNVideo_ndkversion=21.4.7075529
 RNVideo_buildToolsVersion=30.0.2
-RNVideo_media3Version=1.1.1
+RNVideo_media3Version=1.2.0
 RNVideo_RNVUseExoplayerIMA=false

--- a/android/lint.xml
+++ b/android/lint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<lint>
+  <issue id="UnsafeOptInUsageError">
+    <ignore regexp='\(markerClass = androidx\.media3\.common\.util\.UnstableApi\.class\)' />
+  </issue>
+</lint>


### PR DESCRIPTION
#### Update the changelog
feat(android): bump media3 version from v1.1.1 to v1.2.0

#### Describe the changes
- bump media3 version from v1.1.1 to v1.2.0
  - v1.2.0's breaking change has no effect on this project
  - https://developer.android.com/jetpack/androidx/releases/media3#version_120_3
- add android lint file for ignore UnstableApi lint error
  - https://developer.android.com/guide/topics/media/media3/getting-started/migration-guide#handle_unstable_api_lint_errors
  - https://developer.android.com/reference/androidx/media3/common/util/UnstableApi#opting-in-to-use-unstable-apis
