### PR TITLE
fix(ios): fix PIP not working when video isn’t filling the entire screen in width

### DIFF
--- a/ios/Video/Features/RCTPictureInPicture.swift
+++ b/ios/Video/Features/RCTPictureInPicture.swift
@@ -47,6 +47,9 @@ class RCTPictureInPicture: NSObject, AVPictureInPictureControllerDelegate {
     func setupPipController(_ playerLayer: AVPlayerLayer?) {
         // Create new controller passing reference to the AVPlayerLayer
         _pipController = AVPictureInPictureController(playerLayer:playerLayer!)
+        if #available(iOS 14.2, *) {
+            _pipController?.canStartPictureInPictureAutomaticallyFromInline = true
+        }
         _pipController?.delegate = self
     }
     


### PR DESCRIPTION
#### Update the changelog
fix(ios): fix PIP not working when video isn’t filling the entire screen in width

#### Provide an example of how to test the change
```
      <Video
        style={{width: '50%', height: 400, backgroundColor: 'black'}}
        source={{
          uri: 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8',
        }}
        controls
        pictureInPicture
        playWhenInactive
        playInBackground={false}
      />
```

#### Describe the changes
- fix PIP not working when a video isn’t filling the entire screen in width
- Set `canStartPictureInPictureAutomaticallyFromInline` to `true`
- FYI) https://developer.apple.com/documentation/avkit/adopting_picture_in_picture_in_a_standard_player#2948600
- FYI) https://developer.apple.com/documentation/avkit/avpictureinpicturecontroller/3689454-canstartpictureinpictureautomati/
