### PR TITLE
fix: harmonize IMAAdEventType between iOS and Android

### DIFF
--- a/ios/Video/Features/RCTIMAAdsManager.swift
+++ b/ios/Video/Features/RCTIMAAdsManager.swift
@@ -160,7 +160,7 @@ class RCTIMAAdsManager: NSObject, IMAAdsLoaderDelegate, IMAAdsManagerDelegate, I
                 result = "CLICK";
                 break;
             case .COMPLETE:
-                result = "COMPLETE";
+                result = "COMPLETED";
                 break;
             case .CUEPOINTS_CHANGED:
                 result = "CUEPOINTS_CHANGED";


### PR DESCRIPTION
To test this PR, you have to enable ads in your project, see:
https://react-native-video.github.io/react-native-video/component/props#adtagurl (it appears the link needs to be fixed too) and iOS and Android parts of https://react-native-video.github.io/react-native-video/installation

- On iOS, add this to your Podfile:
```Podfile
$RNVideoUseGoogleIMA = true
```

- On Android, add this to `buildScript.ext` section of your `android/build.gradle` file:
```gradle
        RNVUseExoplayerIMA = true
```

Then, when an ad completes, you should receive the event `COMPLETED` instead of `COMPLETE` on your [onReceiveAdEvent](https://react-native-video.github.io/react-native-video/component/events#onreceiveadevent) listener on iOS (should already be the case before this PR on Android)