### PR TITLE
fix(android): fix leak caused by removing lifecycle listener too early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 
+# [6.0.0-beta.1](https://github.com/react-native-video/react-native-video/compare/v6.0.0-beta.0...v6.0.0-beta.1) (WIP)
+* **android:** fix leak caused by removing lifecycle listener too early ([#3380](https://github.com/react-native-video/react-native-video/pull/3380))
 
 # [6.0.0-beta.0](https://github.com/react-native-video/react-native-video/compare/v6.0.0-alpha.11...v6.0.0-beta.0) (2023-11-18)
 
@@ -56,7 +58,7 @@
 - iOS: Fix audio session category when not using the audioOutput prop
 - iOS: implement onPlaybackStateChanged callback [#3307](https://github.com/react-native-video/react-native-video/pull/3307)
 - iOS: remove false calls at onPlaybackRateChange [#3306](https://github.com/react-native-video/react-native-video/pull/3306)
-- iOS: audio does not work with headphones [#3284](https://github.com/react-native-video/react-native-video/pull/3284) 
+- iOS: audio does not work with headphones [#3284](https://github.com/react-native-video/react-native-video/pull/3284)
 - iOS: Resuming video ad after closing the in-app browser on iOS [#3275](https://github.com/react-native-video/react-native-video/pull/3275)
 - iOS, Android: expose playback functions to ref [#3245](https://github.com/react-native-video/react-native-video/pull/3245)
 - tvOS: fix build: [#3276](https://github.com/react-native-video/react-native-video/pull/3276)

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -349,6 +349,7 @@ public class ReactExoplayerView extends FrameLayout implements
     @Override
     public void onHostDestroy() {
         stopPlayback();
+        themedReactContext.removeLifecycleEventListener(this);
     }
 
     public void cleanUpResources() {
@@ -881,7 +882,6 @@ public class ReactExoplayerView extends FrameLayout implements
         }
         adsLoader = null;
         progressHandler.removeMessages(SHOW_PROGRESS);
-        themedReactContext.removeLifecycleEventListener(this);
         audioBecomingNoisyReceiver.removeListener();
         bandwidthMeter.removeEventListener(this);
 


### PR DESCRIPTION
This PR fixes some cases where the lifecycle event listeners are removed before it receives `onHostDestroy`, causing the app to not release the resource when some other methods such as `setBufferConfig`.

### Possible leak scenario
1. `<Video />` mounts. `ReactExoplayerView` is created.
2. `bufferConfig` prop is changed, calling the `ReactExoplayerViewManager.setBufferConfig`, `ReactExoplayerView.setBufferConfig`, `ReactExoplayerView.releasePlayer` in order.
3. `releasePlayer` removes the activity lifecycle listener, causing it to not receive `onHostDestroy` properly.
4. After activity is destroyed, the view doesn't know it's destroyed due to the listener removal, causing it to hold the resources that should be handled by `releasePlayer`.