### PR TITLE
refactor(android): replace deprecated SYSTEM_UI flag with WindowInsetController

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -25,6 +25,9 @@ import android.widget.ImageButton;
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 import androidx.media3.common.AudioAttributes;
 import androidx.media3.common.C;
 import androidx.media3.common.Format;
@@ -102,6 +105,7 @@ import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.google.ads.interactivemedia.v3.api.AdEvent;
 import com.google.common.collect.ImmutableList;
@@ -1969,34 +1973,27 @@ public class ReactExoplayerView extends FrameLayout implements
         }
 
         Window window = activity.getWindow();
-        View decorView = window.getDecorView();
-        int uiOptions;
+        WindowInsetsControllerCompat controller = new WindowInsetsControllerCompat(window, window.getDecorView());
         if (isFullscreen) {
-            if (Util.SDK_INT >= 19) { // 4.4+
-                uiOptions = SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                        | SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                        | SYSTEM_UI_FLAG_FULLSCREEN;
-            } else {
-                uiOptions = SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                        | SYSTEM_UI_FLAG_FULLSCREEN;
-            }
             eventEmitter.fullscreenWillPresent();
             if (controls && fullScreenPlayerView != null) {
                 fullScreenPlayerView.show();
             }
-            post(() -> {
-                decorView.setSystemUiVisibility(uiOptions);
+            UiThreadUtil.runOnUiThread(() -> {
+                WindowCompat.setDecorFitsSystemWindows(window, false);
+                controller.hide(WindowInsetsCompat.Type.systemBars());
+                controller.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
                 eventEmitter.fullscreenDidPresent();
             });
         } else {
-            uiOptions = View.SYSTEM_UI_FLAG_VISIBLE;
             eventEmitter.fullscreenWillDismiss();
             if (controls && fullScreenPlayerView != null) {
                 fullScreenPlayerView.dismiss();
                 reLayout(exoPlayerView);
             }
-            post(() -> {
-                decorView.setSystemUiVisibility(uiOptions);
+            UiThreadUtil.runOnUiThread(() -> {
+                WindowCompat.setDecorFitsSystemWindows(window, true);
+                controller.show(WindowInsetsCompat.Type.systemBars());
                 eventEmitter.fullscreenDidDismiss();
             });
         }


### PR DESCRIPTION
#### Update the changelog
refactor(android): replace deprecated SYSTEM_UI flag with WindowInsetController

#### Provide an example of how to test the change
- `WindowInsetController` was introduced from Android 30, so it should be tested separately on SDK30 and below SDK30.

```tsx
  const [full, toggleFull] = useReducer(v => !v, true);
  const videoRef = useRef<ElementRef<typeof Video>>(null);
  return (
    <>
      <Button
        title="toggle fullscreen"
        onPress={() => {
          if (full) {
            videoRef.current?.dismissFullscreenPlayer();
          } else {
            videoRef.current?.presentFullscreenPlayer();
          }
          toggleFull();
        }}
      />
      <Video
        ref={videoRef}
        style={{width: '100%', height: 300, backgroundColor: 'black'}}
        source={{
          uri: 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-en.ism/.mpd',
        }}
        selectedTextTrack={{
          type: SelectedTrackType.INDEX,
          value: 0,
        }}
        fullscreen={full}
        controls={false}
        debug={{enable: true, thread: true}}
      />
    </>
  );
```

#### Describe the changes
- Replace deprecated SYSTEM_UI flag with WindowInsetController
- Use androidx package for backward compatibility