### PR TITLE
fix: add allowsExternalPlayback missing on ReactVideoProps

### DIFF
--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -221,4 +221,5 @@ export interface ReactVideoProps extends ReactVideoEvents {
   volume?: number;
   localSourceEncryptionKeyScheme?: string;
   debug?: DebugConfig;
+  allowsExternalPlayback?: boolean; // iOS
 }


### PR DESCRIPTION
Fixes:  #3396
