### PR TITLE
fix(android): ensure adTagUrl can be reset

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -198,6 +198,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_AD_TAG_URL)
     public void setAdTagUrl(final ReactExoplayerView videoView, final String uriString) {
         if (TextUtils.isEmpty(uriString)) {
+            videoView.setAdTagUrl(null);
             return;
         }
 


### PR DESCRIPTION
In sample app, once we play the ads sample, next video playback will still use the ads even if it is not requested.
I just improve handling of setAdTagUrl to allow setting value to null.

Can be tested with basic sample app