### PR TITLE
BREAKING fix: revert drm type definition change

### DIFF
--- a/examples/basic/src/VideoPlayer.tsx
+++ b/examples/basic/src/VideoPlayer.tsx
@@ -32,6 +32,7 @@ import Video, {
   VideoRef,
   ResizeMode,
   SelectedTrack,
+  DRMType,
 } from 'react-native-video';
 import ToggleControl from './ToggleControl';
 import MultiValueControl, {
@@ -144,6 +145,24 @@ class VideoPlayer extends Component {
       adTagUrl:
         'https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpremidpostoptimizedpodbumper&ciu_szs=300x250&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&cmsid=496&vid=short_onecue&correlator=',
       uri: 'http://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4',
+    },
+    {
+      description: 'WV: Secure SD & HD (cbcs,MP4,H264)',
+      uri: 'https://storage.googleapis.com/wvmedia/cbcs/h264/tears/tears_aes_cbcs.mpd',
+      drm: {
+        type: DRMType.WIDEVINE,
+        licenseServer:
+          'https://proxy.uat.widevine.com/proxy?provider=widevine_test',
+      },
+    },
+    {
+      description: 'Secure UHD (cenc)',
+      uri: 'https://storage.googleapis.com/wvmedia/cenc/h264/tears/tears_uhd.mpd',
+      drm: {
+        type: DRMType.WIDEVINE,
+        licenseServer:
+          'https://proxy.uat.widevine.com/proxy?provider=widevine_test',
+      },
     },
   ];
 
@@ -716,6 +735,7 @@ class VideoPlayer extends Component {
           }}
           source={this.srcList[this.state.srcListId]}
           adTagUrl={this.srcList[this.state.srcListId]?.adTagUrl}
+          drm={this.srcList[this.state.srcListId]?.drm}
           style={viewStyle}
           rate={this.state.rate}
           paused={this.state.paused}

--- a/src/VideoNativeComponent.ts
+++ b/src/VideoNativeComponent.ts
@@ -50,7 +50,7 @@ export type Filter =
   | 'CIPhotoEffectTransfer'
   | 'CISepiaTone';
 
-export type DrmType = 'widevine' | 'playready' | 'clearkey' | 'fairplay';
+export type DRMType = 'widevine' | 'playready' | 'clearkey' | 'fairplay';
 
 type DebugConfig = Readonly<{
   enable?: boolean;
@@ -58,7 +58,7 @@ type DebugConfig = Readonly<{
 }>;
 
 type Drm = Readonly<{
-  type?: DrmType;
+  type?: DRMType;
   licenseServer?: string;
   headers?: Headers;
   contentId?: string; // ios

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -33,7 +33,7 @@ export type DebugConfig = Readonly<{
   thread?: boolean;
 }>;
 
-export enum DrmType {
+export enum DRMType {
   WIDEVINE = 'widevine',
   PLAYREADY = 'playready',
   CLEARKEY = 'clearkey',
@@ -41,7 +41,7 @@ export enum DrmType {
 }
 
 export type Drm = Readonly<{
-  type?: DrmType;
+  type?: DRMType;
   licenseServer?: string;
   headers?: Headers;
   contentId?: string; // ios


### PR DESCRIPTION
evert drm type definition change 
on 5.2 : DRMType
on 6.0: DrmType

--> rollback to DRMType

I also add drmized content in android sample

Will address ticket: https://github.com/react-native-video/react-native-video/issues/3404