### PR TITLE
fix(android): add explicitly dependancy to androidx.activity

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -143,7 +143,8 @@ repositories {
 
 def media3_version = safeExtGet('media3Version')
 def kotlin_version = safeExtGet('kotlinVersion')
-def androidxCode_version = safeExtGet('androidxCoreVersion')
+def androidxCore_version = safeExtGet('androidxCoreVersion')
+def androidxActivity_version = safeExtGet('androidxActivityVersion')
 
 dependencies {
     // For < 0.71, this will be from the local maven repo
@@ -151,7 +152,8 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"
 
-    implementation "androidx.core:core:$androidxCode_version"
+    implementation "androidx.core:core:$androidxCore_version"
+    implementation "androidx.activity:activity-ktx:$androidxActivity_version"
 
     // For media playback using ExoPlayer
     implementation "androidx.media3:media3-exoplayer:$media3_version"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -7,3 +7,4 @@ RNVideo_buildToolsVersion=30.0.2
 RNVideo_media3Version=1.1.1
 RNVideo_RNVUseExoplayerIMA=false
 RNVideo_androidxCoreVersion=1.9.0
+RNVideo_androidxActivityVersion=1.7.0


### PR DESCRIPTION
Add explicitly dependancy to androidx.activity
Will address: https://github.com/react-native-video/react-native-video/issues/3392
