### PR TITLE
fix: ensure save doesn't crash on android

### DIFF
--- a/examples/basic/src/VideoPlayer.tsx
+++ b/examples/basic/src/VideoPlayer.tsx
@@ -644,20 +644,22 @@ class VideoPlayer extends Component {
                   onPress={this.onResizeModeSelected}
                   selected={this.state.resizeMode}
                 />
-                <ToggleControl
-                  isSelected={this.state.paused}
-                  onPress={() => {
-                    this.video
-                      ?.save({})
-                      .then(response => {
-                        console.log('Downloaded URI', response);
-                      })
-                      .catch(error => {
-                        console.log('error during save ', error);
-                      });
-                  }}
-                  text="save"
-                />
+                {Platform.OS === 'ios' ? (
+                  <ToggleControl
+                    isSelected={this.state.paused}
+                    onPress={() => {
+                      this.video
+                        ?.save({})
+                        ?.then(response => {
+                          console.log('Downloaded URI', response);
+                        })
+                        .catch(error => {
+                          console.log('error during save ', error);
+                        });
+                    }}
+                    text="save"
+                  />
+                ) : null}
               </View>
               {this.renderSeekBar()}
               <View style={styles.generalControls}>

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -243,7 +243,8 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
     }, [setIsFullscreen]);
 
     const save = useCallback((options: object) => {
-      return VideoManager.save(options, getReactTag(nativeRef));
+      // VideoManager.save can be null on android & windows
+      return VideoManager.save?.(options, getReactTag(nativeRef));
     }, []);
 
     const pause = useCallback(() => {


### PR DESCRIPTION
RNV: Fix possible crash on android & windows when save api is called.
Sample: remove save button on android