### PR TITLE
fix(ReactVideoProps): add accessibility & testID in typing

### DIFF
--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -1,6 +1,6 @@
 import type {ISO639_1} from './language';
 import type {ReactVideoEvents} from './events';
-import type {StyleProp, ViewStyle} from 'react-native';
+import type {AccessibilityProps, StyleProp, ViewStyle} from 'react-native';
 import type VideoResizeMode from './ResizeMode';
 import type FilterType from './FilterType';
 
@@ -170,7 +170,7 @@ export enum PosterResizeModeType {
   STRETCH = 'stretch',
 }
 
-export interface ReactVideoProps extends ReactVideoEvents {
+export interface ReactVideoProps extends ReactVideoEvents, AccessibilityProps {
   source?: ReactVideoSource;
   drm?: Drm;
   style?: StyleProp<ViewStyle>;
@@ -215,6 +215,7 @@ export interface ReactVideoProps extends ReactVideoEvents {
   selectedVideoTrack?: SelectedVideoTrack; // android
   subtitleStyle?: SubtitleStyle; // android
   textTracks?: TextTracks;
+  testID?: string;
   trackId?: string; // Android
   useTextureView?: boolean; // Android
   useSecureView?: boolean; // Android


### PR DESCRIPTION
### Change Description 
Fixes https://github.com/react-native-video/react-native-video/issues/3427

As suggested, ReactVideoProps now extends AccessibilityProps. 
The testID has been added on its own, as in [ViewPropsTypes in React Native](https://github.com/facebook/react-native/blob/dae4a11e901696f7c205e19df6f0b306319be43a/packages/react-native/Libraries/Components/View/ViewPropTypes.d.ts#L250)!

### Test plan
I tested this on my project ; we have now : 
- No TS error when adding testID or accessibility props in a Video
```typescript
import Video, { ReactVideoProps } from 'react-native-video';

export const TF1Video = (props: ReactVideoProps) => {
  return (
    <Video
      accessibilityHint="A React Native Video" // ✅ ts okay
      accessibilityLabel="A good React Native Video label" // ✅ ts okay
      testID="rn-video" // ✅ ts okay
      {...props}
    />
  );
};

``` 
- Autocompletion 
<img width="808" alt="image" src="https://github.com/react-native-video/react-native-video/assets/67843879/d9748ff9-b119-4773-94c2-51180391f8e5">

- We still have `screen.getByLabelText('"A good React Native Video label')` working using RNTL
- We still have all props appearing in spnashots :
```
exports[`React Native Video renders correctly`] = `
  <RCTVideo
    accessibilityHint="A React Native Video"
    accessibilityLabel="A good label"
    {...}
    testID="rn-video"
  />
```

### Checks 
[ x ] No need for doc update
[  ] Changelog modified -> no but is it this still needed?

