### PR TITLE
fix(ios): revert ios url encoding as this breaks encoded urls

### DIFF
--- a/ios/Video/Features/RCTVideoUtils.swift
+++ b/ios/Video/Features/RCTVideoUtils.swift
@@ -307,7 +307,7 @@ enum RCTVideoUtils {
         var asset: AVURLAsset!
         let bundlePath = Bundle.main.path(forResource: source.uri, ofType: source.type) ?? ""
         let url = source.isNetwork || source.isAsset
-            ? URL(string: source.uri?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")
+            ? URL(string: source.uri ?? "")
             : URL(fileURLWithPath: bundlePath)
         let assetOptions: NSMutableDictionary! = NSMutableDictionary()
 


### PR DESCRIPTION
Fixes the url encoding issues mentioned in https://github.com/react-native-video/react-native-video/issues/3430.

Possibly we could add a further comment/node to prevent this to happen again