### PR TITLE
feat(ios): update the way to get `keyWindow`

### DIFF
--- a/ios/Video/Features/RCTVideoUtils.swift
+++ b/ios/Video/Features/RCTVideoUtils.swift
@@ -348,6 +348,7 @@ enum RCTVideoUtils {
 
         return nil
     }
+
     static func getCurrentWindow() -> UIWindow? {
         if #available(iOS 13.0, tvOS 13, *) {
             return UIApplication.shared.connectedScenes
@@ -359,5 +360,4 @@ enum RCTVideoUtils {
             #endif
         }
     }
-
 }

--- a/ios/Video/Features/RCTVideoUtils.swift
+++ b/ios/Video/Features/RCTVideoUtils.swift
@@ -348,4 +348,16 @@ enum RCTVideoUtils {
 
         return nil
     }
+    static func getCurrentWindow() -> UIWindow? {
+        if #available(iOS 13.0, tvOS 13, *) {
+            return UIApplication.shared.connectedScenes
+                .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+                .last { $0.isKeyWindow }
+        } else {
+            #if !os(visionOS)
+                return UIApplication.shared.keyWindow
+            #endif
+        }
+    }
+
 }

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -792,7 +792,8 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             // Find the nearest view controller
             var viewController: UIViewController! = self.firstAvailableUIViewController()
             if viewController == nil {
-                let keyWindow: UIWindow! = UIApplication.shared.keyWindow
+                guard let keyWindow = RCTVideoUtils.getCurrentWindow() else { return }
+
                 viewController = keyWindow.rootViewController
                 if !viewController.children.isEmpty {
                     viewController = viewController.children.last
@@ -1291,9 +1292,12 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     func handleViewControllerOverlayViewFrameChange(overlayView _: UIView, change: NSKeyValueObservedChange<CGRect>) {
         let oldRect = change.oldValue
         let newRect = change.newValue
+
+        guard let bounds = RCTVideoUtils.getCurrentWindow()?.bounds else { return }
+
         if !oldRect!.equalTo(newRect!) {
             // https://github.com/react-native-video/react-native-video/issues/3085#issuecomment-1557293391
-            if newRect!.equalTo(UIScreen.main.bounds) {
+            if newRect!.equalTo(bounds) {
                 RCTLog("in fullscreen")
                 if !_fullscreenUncontrolPlayerPresented {
                     _fullscreenUncontrolPlayerPresented = true
@@ -1311,7 +1315,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                 }
             }
 
-            self.reactViewController().view.frame = UIScreen.main.bounds
+            self.reactViewController().view.frame = bounds
             self.reactViewController().view.setNeedsLayout()
         }
     }

--- a/ios/Video/RCTVideoPlayerViewController.swift
+++ b/ios/Video/RCTVideoPlayerViewController.swift
@@ -35,8 +35,13 @@ class RCTVideoPlayerViewController: AVPlayerViewController {
                 return .portrait
             } else {
                 // default case
-                let orientation = UIApplication.shared.statusBarOrientation
-                return orientation
+                if #available(iOS 13, tvOS 13, *) {
+                    return RCTVideoUtils.getCurrentWindow()?.windowScene?.interfaceOrientation ?? .unknown
+                } else {
+                    #if !os(visionOS)
+                        return UIApplication.shared.statusBarOrientation
+                    #endif
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
Part of https://github.com/react-native-video/react-native-video/pull/3425
Move `keyWindow` "getter" to utils in order to support visionOS and use newer API

# Test plan
- [x] Tested in example app
- [x] CI passed