### PR TITLE
fix: support opacity properly

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -132,6 +132,8 @@ public final class ExoPlayerView extends FrameLayout implements AdViewProvider {
             }
         } else {
             view = new TextureView(context);
+            // Support opacity properly:
+            ((TextureView) view).setOpaque(false);
         }
         view.setLayoutParams(layoutParams);
 


### PR DESCRIPTION
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

#### Update the documentation

/

#### Update the changelog

/

#### Provide an example of how to test the change

In the example app set the styles of a video component to opacity: 0.5. The whole video component should now be 50% visible. Without that change, only the video content would have 50% transparency while the video view itself would be a back background.

#### Focus the PR on only one area
✅

#### Describe the changes

Texture views are by default opaque. To enable styling the opacity of a video when using texture view we have to disable opaqueness.
