### PR TITLE
fix(iOS): currentPlaybackTime in ms and not seconds

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -282,7 +282,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                 "currentTime": NSNumber(value: Float(currentTimeSecs)),
                 "playableDuration": RCTVideoUtils.calculatePlayableDuration(_player, withSource: _source),
                 "atValue": NSNumber(value: currentTime?.value ?? .zero),
-                "currentPlaybackTime": NSNumber(value: NSNumber(value: floor(currentPlaybackTime?.timeIntervalSince1970 ?? 0 * 1000)).int64Value),
+                "currentPlaybackTime": NSNumber(value: NSNumber(value: Double(currentPlaybackTime?.timeIntervalSince1970 ?? 0 * 1000)).int64Value),
                 "target": reactTag,
                 "seekableDuration": RCTVideoUtils.calculateSeekableDuration(_player),
             ])


### PR DESCRIPTION
#### Provide an example of how to test the change
If we cast the `timeIntervalSince1970` to a number before we multiply it by 1000 we are losing the milliseconds.

<img width="1058" alt="Screenshot 2024-01-12 at 22 08 22" src="https://github.com/react-native-video/react-native-video/assets/38230596/4d6bf8d4-2574-483b-b40b-e186db9ddf93">

#### Describe the changes
Replacing the `floor` by casting it to a `Double`

Fixing #3471 