### PR TITLE
fix(ios): remove extra dismissFullscreenPlayer declaration

### DIFF
--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -81,6 +81,4 @@ RCT_EXTERN_METHOD(presentFullscreenPlayer : (nonnull NSNumber*)reactTag)
 
 RCT_EXTERN_METHOD(dismissFullscreenPlayer : (nonnull NSNumber*)reactTag)
 
-RCT_EXTERN_METHOD(dismissFullscreenPlayer reactTag : (nonnull NSNumber*)reactTag)
-
 @end


### PR DESCRIPTION
Remove extra declaration that was missed here: https://github.com/react-native-video/react-native-video/pull/3338#discussion_r1451773495
