### PR TITLE
fix(android): remove lifecycle listener after component unmount

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -361,6 +361,7 @@ public class ReactExoplayerView extends FrameLayout implements
 
     public void cleanUpResources() {
         stopPlayback();
+        themedReactContext.removeLifecycleEventListener(this);
     }
 
     //BandwidthMeter.EventListener implementation


### PR DESCRIPTION
#### Update the changelog
- fix(android): remove lifecycle listener after component unmount (resolve issue #3488)

#### Provide an example of how to test the change
- already described via issue #3488

#### Describe the changes
- remove lifecycle listener after component unmount