### PR TITLE
fix(android): re-layout controls after fullscreen dismiss

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -387,7 +387,7 @@ public class ReactExoplayerView extends FrameLayout implements
      */
     private void togglePlayerControlVisibility() {
         if (player == null) return;
-        reLayout(playerControlView);
+        reLayoutControls();
         if (playerControlView.isVisible()) {
             playerControlView.hide();
         } else {
@@ -498,6 +498,11 @@ public class ReactExoplayerView extends FrameLayout implements
         view.measure(MeasureSpec.makeMeasureSpec(getMeasuredWidth(), MeasureSpec.EXACTLY),
                 MeasureSpec.makeMeasureSpec(getMeasuredHeight(), MeasureSpec.EXACTLY));
         view.layout(view.getLeft(), view.getTop(), view.getMeasuredWidth(), view.getMeasuredHeight());
+    }
+
+    private void reLayoutControls() {
+        reLayout(exoPlayerView);
+        reLayout(playerControlView);
     }
 
     private class RNVLoadControl extends DefaultLoadControl {
@@ -725,7 +730,8 @@ public class ReactExoplayerView extends FrameLayout implements
         player.prepare();
         playerNeedsSource = false;
 
-        reLayout(exoPlayerView);
+        reLayoutControls();
+
         eventEmitter.loadStart();
         loadVideoStarted = true;
 
@@ -1994,8 +2000,7 @@ public class ReactExoplayerView extends FrameLayout implements
             eventEmitter.fullscreenWillDismiss();
             if (controls && fullScreenPlayerView != null) {
                 fullScreenPlayerView.dismiss();
-                reLayout(exoPlayerView);
-                reLayout(playerControlView);
+                reLayoutControls();
             }
             UiThreadUtil.runOnUiThread(() -> {
                 WindowCompat.setDecorFitsSystemWindows(window, true);

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1995,6 +1995,7 @@ public class ReactExoplayerView extends FrameLayout implements
             if (controls && fullScreenPlayerView != null) {
                 fullScreenPlayerView.dismiss();
                 reLayout(exoPlayerView);
+                reLayout(playerControlView);
             }
             UiThreadUtil.runOnUiThread(() -> {
                 WindowCompat.setDecorFitsSystemWindows(window, true);


### PR DESCRIPTION
## Summary
re layout controls view after exit from fullscreen to update controls positions and weird bug when controls are out of video

fixes #3377

## Test plan
- [x] Tested in example
- [x] App build in CI