### PR TITLE
fix(android): remove pausePlayback when audio focus loss event

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -925,8 +925,6 @@ public class ReactExoplayerView extends FrameLayout implements
                 case AudioManager.AUDIOFOCUS_LOSS:
                     view.hasAudioFocus = false;
                     view.eventEmitter.audioFocusChanged(false);
-                    // FIXME this pause can cause issue if content doesn't have pause capability (can happen on live channel)
-                    view.pausePlayback();
                     view.audioManager.abandonAudioFocus(this);
                     break;
                 case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:


### PR DESCRIPTION
#### Update the documentation
fix(android): remove pausePlayback when audio focus loss event

#### Update the changelog
fix(android): remove pausePlayback when audio focus loss event

#### Describe the changes
pausePlayback is added within PR #1897  (commit [1ab82f7](https://github.com/react-native-video/react-native-video/pull/1897/commits/1ab82f773d57efb9310e04faa8b94da8c1efbda8))
but, it makes unintended pauses can be happen with below flow
source ready(auto play) -> pause -> play
