### PR TITLE
Revert "fix: remove pausePlayback when audio focus loss event (#3496)"

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -931,6 +931,8 @@ public class ReactExoplayerView extends FrameLayout implements
                 case AudioManager.AUDIOFOCUS_LOSS:
                     view.hasAudioFocus = false;
                     view.eventEmitter.audioFocusChanged(false);
+                    // FIXME this pause can cause issue if content doesn't have pause capability (can happen on live channel)
+                    view.pausePlayback();
                     view.audioManager.abandonAudioFocus(this);
                     break;
                 case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:


### PR DESCRIPTION
This reverts commit b1ab0f24a3efbcc3be49005060f50b34a117664e.

It causes regression in case of incoming call.
initial PR: https://github.com/react-native-video/react-native-video/pull/3496

New Pr to be created