### PR TITLE
fix(ios): fix pip memory leak

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -140,7 +140,14 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         _eventDispatcher = eventDispatcher
 
         #if os(iOS)
-            _pip = RCTPictureInPicture(self._onPictureInPictureStatusChanged, self._onRestoreUserInterfaceForPictureInPictureStop)
+            _pip = RCTPictureInPicture(
+                { [weak self] in
+                    self?._onPictureInPictureStatusChanged()
+                },
+                { [weak self] in
+                    self?._onRestoreUserInterfaceForPictureInPictureStop()
+                }
+            )
         #endif
 
         NotificationCenter.default.addObserver(
@@ -193,6 +200,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     deinit {
         NotificationCenter.default.removeObserver(self)
         self.removePlayerLayer()
+        _pip = nil
         _playerObserver.clearPlayer()
     }
 

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -140,14 +140,11 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         _eventDispatcher = eventDispatcher
 
         #if os(iOS)
-            _pip = RCTPictureInPicture(
-                { [weak self] in
-                    self?._onPictureInPictureStatusChanged()
-                },
-                { [weak self] in
-                    self?._onRestoreUserInterfaceForPictureInPictureStop()
-                }
-            )
+            _pip = RCTPictureInPicture({ [weak self] in
+                self?._onPictureInPictureStatusChanged()
+            }, { [weak self] in
+                self?._onRestoreUserInterfaceForPictureInPictureStop()
+            })
         #endif
 
         NotificationCenter.default.addObserver(


### PR DESCRIPTION
## Summary
Fix memory leak caused by pip (`RCTPictureInPicture`).
Seems like RCTPictureInPicture hold strong reference to RCTVideo. With this change I was able to call `deinit` on component unmount

should fix #3505 #3399

## Test Plan
- [x] Tested in example