### PR TITLE
chore(ci): use `macos-14` for iOS builds

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -1,6 +1,7 @@
 name: Build iOS
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -19,7 +20,7 @@ on:
 jobs:
   build:
     name: Build iOS Example App
-    runs-on: macOS-latest
+    runs-on: macos-14 # This allow us to use Xcode 15.0.1 which is a lot faster - TODO change to "macos-latest" once it's out of beta
     defaults:
       run:
         working-directory: examples/basic/ios
@@ -62,13 +63,13 @@ jobs:
           -scheme videoplayer \
           -sdk iphonesimulator \
           -configuration Debug \
-          -destination 'platform=iOS Simulator,name=iPhone 11 Pro' \
+          -destination 'platform=iOS Simulator,name=iPhone 14' \
           build \
           CODE_SIGNING_ALLOWED=NO | xcpretty"
 
   build-with-ads:
     name: Build iOS Example App With Ads
-    runs-on: macOS-latest
+    runs-on: macos-14 # This allow us to use Xcode 15.0.1 which is a lot faster - TODO change to "macos-latest" once it's out of beta
     defaults:
       run:
         working-directory: examples/basic/ios
@@ -111,13 +112,13 @@ jobs:
           -scheme videoplayer \
           -sdk iphonesimulator \
           -configuration Debug \
-          -destination 'platform=iOS Simulator,name=iPhone 11 Pro' \
+          -destination 'platform=iOS Simulator,name=iPhone 14' \
           build \
           CODE_SIGNING_ALLOWED=NO | xcpretty"
 
   build-with-caching:
     name: Build iOS Example App With Caching
-    runs-on: macOS-latest
+    runs-on: macos-14 # This allow us to use Xcode 15.0.1 which is a lot faster - TODO change to "macos-latest" once it's out of beta
     defaults:
       run:
         working-directory: examples/basic/ios
@@ -160,6 +161,6 @@ jobs:
           -scheme videoplayer \
           -sdk iphonesimulator \
           -configuration Debug \
-          -destination 'platform=iOS Simulator,name=iPhone 11 Pro' \
+          -destination 'platform=iOS Simulator,name=iPhone 14' \
           build \
           CODE_SIGNING_ALLOWED=NO | xcpretty"

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - master
     paths:
       - '.github/workflows/build-ios.yml'
       - 'ios/**'

--- a/.github/workflows/check-ios.yml
+++ b/.github/workflows/check-ios.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           WORKING_DIRECTORY: ios
   Swift-Format:
-    runs-on: macOS-latest
+    runs-on: macos-14 # This allow us to use Xcode 15.0.1 which is a lot faster - TODO change to "macos-latest" once it's out of beta
     defaults:
       run:
         working-directory: ./ios


### PR DESCRIPTION
## Summary
With `macos-14` build are faster around 50%-65%

More Information about `macos-14` here - https://github.com/orgs/community/discussions/102846

## Test plan
I have tested it on fork