### PR TITLE
Feat: Add ios support for accessing WebVTT Subtitle Content 

### DIFF
--- a/docs/pages/component/events.md
+++ b/docs/pages/component/events.md
@@ -493,7 +493,24 @@ Example:
 }
 ```
 
-Platforms: Android
+### `onSubtitleTracks`
+Callback function that is called when subtitles are available. This provides the actual subtitle content.
+
+Payload:
+
+Property | Type | Description
+--- | --- | ---
+`subtitleTracks` | `string` | The subtitles text content in a compatible format.
+
+
+Example:
+```javascript
+{
+  subtitleTracks: "This blade has a dark past.",
+}
+```
+
+Platforms: iOS
 
 ### `onVideoTracks`
 Callback function that is called when video tracks change

--- a/docs/pages/component/events.md
+++ b/docs/pages/component/events.md
@@ -493,8 +493,8 @@ Example:
 }
 ```
 
-### `onSubtitleTracks`
-Callback function that is called when subtitles are available. This provides the actual subtitle content.
+### `onTextTrackDataChanged`
+Callback function that is called when new subtitle data is available. It provides the actual subtitle content for the current selected text track, if available (mainly WebVTT). 
 
 Payload:
 

--- a/examples/basic/src/VideoPlayer.tsx
+++ b/examples/basic/src/VideoPlayer.tsx
@@ -33,7 +33,7 @@ import Video, {
   ResizeMode,
   SelectedTrack,
   DRMType,
-  OnSubtitleTracksData,
+  OnTextTrackDataChangedData,
   SelectedTrackType,
 } from 'react-native-video';
 import ToggleControl from './ToggleControl';
@@ -124,7 +124,7 @@ class VideoPlayer extends Component {
 
   srcIosList = [
     {
-      description: 'example to get subtitles',
+      description: 'sintel with subtitles',
       uri: 'https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
     },
   ];
@@ -255,7 +255,7 @@ class VideoPlayer extends Component {
     }
   };
 
-  onSubtitleTracks = (data: OnSubtitleTracksData) => {
+  onTextTrackDataChanged = (data: OnTextTrackDataChangedData) => {
     console.log(`Subtitles: ${JSON.stringify(data, null, 2)}`);
   };
 
@@ -760,7 +760,7 @@ class VideoPlayer extends Component {
           onLoad={this.onLoad}
           onAudioTracks={this.onAudioTracks}
           onTextTracks={this.onTextTracks}
-          onSubtitleTracks={this.onSubtitleTracks}
+          onTextTrackDataChanged={this.onTextTrackDataChanged}
           onProgress={this.onProgress}
           onEnd={this.onEnd}
           progressUpdateInterval={1000}

--- a/examples/basic/src/VideoPlayer.tsx
+++ b/examples/basic/src/VideoPlayer.tsx
@@ -33,6 +33,8 @@ import Video, {
   ResizeMode,
   SelectedTrack,
   DRMType,
+  OnSubtitleTracksData,
+  SelectedTrackType,
 } from 'react-native-video';
 import ToggleControl from './ToggleControl';
 import MultiValueControl, {
@@ -120,7 +122,12 @@ class VideoPlayer extends Component {
     },
   ];
 
-  srcIosList = [];
+  srcIosList = [
+    {
+      description: 'example to get subtitles',
+      uri: 'https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
+    },
+  ];
 
   srcAndroidList = [
     {
@@ -231,7 +238,7 @@ class VideoPlayer extends Component {
 
   onTextTracks = (data: OnTextTracksData) => {
     const selectedTrack = data.textTracks?.find((x: TextTrack) => {
-      return x.selected;
+      return x?.selected;
     });
 
     this.setState({
@@ -246,6 +253,10 @@ class VideoPlayer extends Component {
         },
       });
     }
+  };
+
+  onSubtitleTracks = (data: OnSubtitleTracksData) => {
+    console.log(`Subtitles: ${JSON.stringify(data, null, 2)}`);
   };
 
   onAspectRatio = (data: OnVideoAspectRatioData) => {
@@ -749,6 +760,7 @@ class VideoPlayer extends Component {
           onLoad={this.onLoad}
           onAudioTracks={this.onAudioTracks}
           onTextTracks={this.onTextTracks}
+          onSubtitleTracks={this.onSubtitleTracks}
           onProgress={this.onProgress}
           onEnd={this.onEnd}
           progressUpdateInterval={1000}

--- a/ios/Video/Features/RCTPlayerObserver.swift
+++ b/ios/Video/Features/RCTPlayerObserver.swift
@@ -26,11 +26,12 @@ protocol RCTPlayerObserverHandler: RCTPlayerObserverHandlerObjc {
     func handleExternalPlaybackActiveChange(player: AVPlayer, change: NSKeyValueObservedChange<Bool>)
     func handleViewControllerOverlayViewFrameChange(overlayView: UIView, change: NSKeyValueObservedChange<CGRect>)
     func handleTracksChange(playerItem: AVPlayerItem, change: NSKeyValueObservedChange<[AVPlayerItemTrack]>)
+    func handleLegibleOutput(strings: [NSAttributedString])
 }
 
 // MARK: - RCTPlayerObserver
 
-class RCTPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate {
+class RCTPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate, AVPlayerItemLegibleOutputPushDelegate {
     weak var _handlers: RCTPlayerObserverHandler?
 
     var player: AVPlayer? {
@@ -57,9 +58,11 @@ class RCTPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate {
 
             // handle timedMetadata
             let metadataOutput = AVPlayerItemMetadataOutput()
+            let legibleOutput = AVPlayerItemLegibleOutput()
             playerItem.add(metadataOutput)
+            playerItem.add(legibleOutput)
             metadataOutput.setDelegate(self, queue: .main)
-        }
+            legibleOutput.setDelegate(self, queue: .main)        }
     }
 
     var playerViewController: AVPlayerViewController? {
@@ -111,6 +114,11 @@ class RCTPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate {
         for metadataGroup in groups {
             _handlers.handleTimeMetadataChange(timedMetadata: metadataGroup.items)
         }
+    }
+    
+    func legibleOutput(_: AVPlayerItemLegibleOutput, didOutputAttributedStrings strings: [NSAttributedString], nativeSampleBuffers _: [Any], forItemTime _: CMTime) {
+        guard let _handlers else { return }
+        _handlers.handleLegibleOutput(strings: strings)
     }
 
     func addPlayerObservers() {

--- a/ios/Video/Features/RCTPlayerObserver.swift
+++ b/ios/Video/Features/RCTPlayerObserver.swift
@@ -62,7 +62,8 @@ class RCTPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate, AVPla
             playerItem.add(metadataOutput)
             playerItem.add(legibleOutput)
             metadataOutput.setDelegate(self, queue: .main)
-            legibleOutput.setDelegate(self, queue: .main)        }
+            legibleOutput.setDelegate(self, queue: .main)
+        }
     }
 
     var playerViewController: AVPlayerViewController? {
@@ -115,8 +116,11 @@ class RCTPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate, AVPla
             _handlers.handleTimeMetadataChange(timedMetadata: metadataGroup.items)
         }
     }
-    
-    func legibleOutput(_: AVPlayerItemLegibleOutput, didOutputAttributedStrings strings: [NSAttributedString], nativeSampleBuffers _: [Any], forItemTime _: CMTime) {
+
+    func legibleOutput(_: AVPlayerItemLegibleOutput,
+                       didOutputAttributedStrings strings: [NSAttributedString],
+                       nativeSampleBuffers _: [Any],
+                       forItemTime _: CMTime) {
         guard let _handlers else { return }
         _handlers.handleLegibleOutput(strings: strings)
     }

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -118,7 +118,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     @objc var onReceiveAdEvent: RCTDirectEventBlock?
     @objc var onTextTracks: RCTDirectEventBlock?
     @objc var onAudioTracks: RCTDirectEventBlock?
-    @objc var onSubtitleTracks: RCTDirectEventBlock?
+    @objc var onTextTrackDataChanged: RCTDirectEventBlock?
 
     @objc
     func _onPictureInPictureStatusChanged() {
@@ -1390,7 +1390,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     func handleLegibleOutput(strings: [NSAttributedString]) {
         if let subtitles = strings.first {
-            self.onSubtitleTracks?(["subtitleTracks": subtitles.string])
+            self.onTextTrackDataChanged?(["subtitleTracks": subtitles.string])
         }
     }
 }

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -118,6 +118,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     @objc var onReceiveAdEvent: RCTDirectEventBlock?
     @objc var onTextTracks: RCTDirectEventBlock?
     @objc var onAudioTracks: RCTDirectEventBlock?
+    @objc var onSubtitleTracks: RCTDirectEventBlock?
 
     @objc
     func _onPictureInPictureStatusChanged() {
@@ -1385,5 +1386,18 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             self.onTextTracks?(["textTracks": textTracks])
             self.onAudioTracks?(["audioTracks": audioTracks])
         }
+    }
+    
+    func handleLegibleOutput(strings: [NSAttributedString]) {
+        let subtitles = strings.map { subtitle in
+            Dictionary(subtitle.string
+                .split(separator: "\n")
+                .compactMap { line -> (String, String)? in
+                    let parts = line.split(separator: "=", maxSplits: 1).map(String.init)
+                    return parts.count == 2 ? (parts[0], parts[1]) : nil
+                }, uniquingKeysWith: { _, last in last })
+        }
+
+        self.onSubtitleTracks?(["subtitleTracks": subtitles])
     }
 }

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1387,7 +1387,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             self.onAudioTracks?(["audioTracks": audioTracks])
         }
     }
-    
+
     func handleLegibleOutput(strings: [NSAttributedString]) {
         if let subtitles = strings.first {
             self.onSubtitleTracks?(["subtitleTracks": subtitles.string])

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1389,15 +1389,8 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     }
     
     func handleLegibleOutput(strings: [NSAttributedString]) {
-        let subtitles = strings.map { subtitle in
-            Dictionary(subtitle.string
-                .split(separator: "\n")
-                .compactMap { line -> (String, String)? in
-                    let parts = line.split(separator: "=", maxSplits: 1).map(String.init)
-                    return parts.count == 2 ? (parts[0], parts[1]) : nil
-                }, uniquingKeysWith: { _, last in last })
+        if let subtitles = strings.first {
+            self.onSubtitleTracks?(["subtitleTracks": subtitles.string])
         }
-
-        self.onSubtitleTracks?(["subtitleTracks": subtitles])
     }
 }

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -66,6 +66,7 @@ RCT_EXPORT_VIEW_PROPERTY(onRestoreUserInterfaceForPictureInPictureStop, RCTDirec
 RCT_EXPORT_VIEW_PROPERTY(onReceiveAdEvent, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onTextTracks, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onAudioTracks, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onSubtitleTracks, RCTDirectEventBlock);
 
 RCT_EXTERN_METHOD(save
                   : (NSDictionary*)options reactTag

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -66,7 +66,7 @@ RCT_EXPORT_VIEW_PROPERTY(onRestoreUserInterfaceForPictureInPictureStop, RCTDirec
 RCT_EXPORT_VIEW_PROPERTY(onReceiveAdEvent, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onTextTracks, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onAudioTracks, RCTDirectEventBlock);
-RCT_EXPORT_VIEW_PROPERTY(onSubtitleTracks, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onTextTrackDataChanged, RCTDirectEventBlock);
 
 RCT_EXTERN_METHOD(save
                   : (NSDictionary*)options reactTag

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -336,8 +336,12 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
     );
 
     const _onTextTrackDataChanged = useCallback(
-      (e: NativeSyntheticEvent<OnTextTrackDataChangedData>) => {
-        onTextTrackDataChanged?.(e.nativeEvent);
+      (
+        e: NativeSyntheticEvent<OnTextTrackDataChangedData & {target?: number}>,
+      ) => {
+        const {...eventData} = e.nativeEvent;
+        delete eventData.target;
+        onTextTrackDataChanged?.(eventData as OnTextTrackDataChangedData);
       },
       [onTextTrackDataChanged],
     );

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -29,7 +29,7 @@ import type {
   OnProgressData,
   OnReceiveAdEventData,
   OnSeekData,
-  OnSubtitleTracksData,
+  OnTextTrackDataChangedData,
   OnTextTracksData,
   OnTimedMetadataData,
   OnVideoAspectRatioData,
@@ -94,7 +94,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       onTimedMetadata,
       onAudioTracks,
       onTextTracks,
-      onSubtitleTracks,
+      onTextTrackDataChanged,
       onVideoTracks,
       onAspectRatio,
       ...rest
@@ -335,11 +335,11 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       [onTextTracks],
     );
 
-    const _onSubtitleTracks = useCallback(
-      (e: NativeSyntheticEvent<OnSubtitleTracksData>) => {
-        onSubtitleTracks?.(e.nativeEvent);
+    const _onTextTrackDataChanged = useCallback(
+      (e: NativeSyntheticEvent<OnTextTrackDataChangedData>) => {
+        onTextTrackDataChanged?.(e.nativeEvent);
       },
-      [onSubtitleTracks],
+      [onTextTrackDataChanged],
     );
 
     const _onVideoTracks = useCallback(
@@ -518,7 +518,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           onTimedMetadata={_onTimedMetadata}
           onAudioTracks={_onAudioTracks}
           onTextTracks={_onTextTracks}
-          onSubtitleTracks={_onSubtitleTracks}
+          onTextTrackDataChanged={_onTextTrackDataChanged}
           onVideoTracks={_onVideoTracks}
           onVideoFullscreenPlayerDidDismiss={onFullscreenPlayerDidDismiss}
           onVideoFullscreenPlayerDidPresent={onFullscreenPlayerDidPresent}

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -29,6 +29,7 @@ import type {
   OnProgressData,
   OnReceiveAdEventData,
   OnSeekData,
+  OnSubtitleTracksData,
   OnTextTracksData,
   OnTimedMetadataData,
   OnVideoAspectRatioData,
@@ -93,6 +94,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       onTimedMetadata,
       onAudioTracks,
       onTextTracks,
+      onSubtitleTracks,
       onVideoTracks,
       onAspectRatio,
       ...rest
@@ -333,6 +335,13 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       [onTextTracks],
     );
 
+    const _onSubtitleTracks = useCallback(
+      (e: NativeSyntheticEvent<OnSubtitleTracksData>) => {
+        onSubtitleTracks?.(e.nativeEvent);
+      },
+      [onSubtitleTracks],
+    );
+
     const _onVideoTracks = useCallback(
       (e: NativeSyntheticEvent<OnVideoTracksData>) => {
         onVideoTracks?.(e.nativeEvent);
@@ -509,6 +518,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           onTimedMetadata={_onTimedMetadata}
           onAudioTracks={_onAudioTracks}
           onTextTracks={_onTextTracks}
+          onSubtitleTracks={_onSubtitleTracks}
           onVideoTracks={_onVideoTracks}
           onVideoFullscreenPlayerDidDismiss={onFullscreenPlayerDidDismiss}
           onVideoFullscreenPlayerDidPresent={onFullscreenPlayerDidPresent}

--- a/src/VideoNativeComponent.ts
+++ b/src/VideoNativeComponent.ts
@@ -10,7 +10,7 @@ import type Orientation from './types/Orientation';
 import type {
   AdEvent,
   EnumValues,
-  OnSubtitleTracksData,
+  OnTextTrackDataChangedData,
   OnTextTracksTypeData,
 } from './types';
 
@@ -371,7 +371,9 @@ export interface VideoNativeProps extends ViewProps {
   onTimedMetadata?: (event: NativeSyntheticEvent<OnTimedMetadataData>) => void; // ios, android
   onAudioTracks?: (event: NativeSyntheticEvent<OnAudioTracksData>) => void; // android
   onTextTracks?: (event: NativeSyntheticEvent<OnTextTracksData>) => void; // android
-  onSubtitleTracks?: (e: NativeSyntheticEvent<OnSubtitleTracksData>) => void; // iOS
+  onTextTrackDataChanged?: (
+    event: NativeSyntheticEvent<OnTextTrackDataChangedData>,
+  ) => void; // iOS
   onVideoTracks?: (event: NativeSyntheticEvent<OnVideoTracksData>) => void; // android
 }
 

--- a/src/VideoNativeComponent.ts
+++ b/src/VideoNativeComponent.ts
@@ -7,7 +7,12 @@ import {NativeModules, requireNativeComponent} from 'react-native';
 import type ResizeMode from './types/ResizeMode';
 import type FilterType from './types/FilterType';
 import type Orientation from './types/Orientation';
-import type {AdEvent, EnumValues, OnTextTracksTypeData} from './types';
+import type {
+  AdEvent,
+  EnumValues,
+  OnSubtitleTracksData,
+  OnTextTracksTypeData,
+} from './types';
 
 // -------- There are types for native component (future codegen) --------
 // if you are looking for types for react component, see src/types/video.ts
@@ -366,6 +371,7 @@ export interface VideoNativeProps extends ViewProps {
   onTimedMetadata?: (event: NativeSyntheticEvent<OnTimedMetadataData>) => void; // ios, android
   onAudioTracks?: (event: NativeSyntheticEvent<OnAudioTracksData>) => void; // android
   onTextTracks?: (event: NativeSyntheticEvent<OnTextTracksData>) => void; // android
+  onSubtitleTracks?: (e: NativeSyntheticEvent<OnSubtitleTracksData>) => void; // iOS
   onVideoTracks?: (event: NativeSyntheticEvent<OnVideoTracksData>) => void; // android
 }
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -79,6 +79,10 @@ export type OnTextTracksData = Readonly<{
   textTracks: ReadonlyArray<TextTrack>;
 }>;
 
+export type OnSubtitleTracksData = Readonly<{
+  subtitleTracks: string;
+}>;
+
 export type OnVideoTracksData = Readonly<{
   videoTracks: ReadonlyArray<
     Readonly<{
@@ -181,6 +185,7 @@ export interface ReactVideoEvents {
   onTimedMetadata?: (e: OnTimedMetadataData) => void; //Android, iOS
   onAudioTracks?: (e: OnAudioTracksData) => void; // Android
   onTextTracks?: (e: OnTextTracksData) => void; //Android
+  onSubtitleTracks?: (e: OnSubtitleTracksData) => void; // iOS
   onVideoTracks?: (e: OnVideoTracksData) => void; //Android
   onAspectRatio?: (e: OnVideoAspectRatioData) => void;
 }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -79,7 +79,7 @@ export type OnTextTracksData = Readonly<{
   textTracks: ReadonlyArray<TextTrack>;
 }>;
 
-export type OnSubtitleTracksData = Readonly<{
+export type OnTextTrackDataChangedData = Readonly<{
   subtitleTracks: string;
 }>;
 
@@ -185,7 +185,7 @@ export interface ReactVideoEvents {
   onTimedMetadata?: (e: OnTimedMetadataData) => void; //Android, iOS
   onAudioTracks?: (e: OnAudioTracksData) => void; // Android
   onTextTracks?: (e: OnTextTracksData) => void; //Android
-  onSubtitleTracks?: (e: OnSubtitleTracksData) => void; // iOS
+  onTextTrackDataChanged?: (e: OnTextTrackDataChangedData) => void; // iOS
   onVideoTracks?: (e: OnVideoTracksData) => void; //Android
   onAspectRatio?: (e: OnVideoAspectRatioData) => void;
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## 📝 Summary
This PR adds the capability to access and expose the content of subtitles within RN; but, currently only implements the `ios` portion. The core of this functionality leverages `AVFoundation framework's` `AVPlayerItemLegibleOutput`, enabling the app to intercept subtitle data as attributed strings during video playback. This data is subsequently passed to do the RN layer through the newly introduced event, `onSubtitleTracks`; thus, allowing components to reactively update based on this `subtitle` content.


### Motivation

Our motivation for integrating the onSubtitleTracks event handler with `react-native-video` is to enhance user engagement with HLS VODs of sports content. Utilizing WebVTT tracks, we aim to dynamically display game information like scores as overlays on the video, based on the playback position. This feature ensures viewers have access to contextual sports data as they navigate through the video, significantly improving their viewing experience by making it more informative and interactive. This implementation aligns with the capabilities of the WebVTT API, optimizing our app's use of text tracks for an enriched sports viewing experience. 

> The primary purpose of WebVTT files is to add text overlays to a `<video>`

[source](https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API)

### Changes

## 📲 iOS Implementation:
- `RCTPlayerObserver` class implements `AVPlayerItemLegibleOutputPushDelegate` to observe and handle subtitle tracks.
- Configured `legibleOutput` on the player item and set the current class as the delegate to manage legible output.
- Implemented the `legibleOutput` delegate method to capture subtitle data, processing it via the `handleLegibleOutput` method to extract and utilize subtitle strings.

## 🌉 RN Bridge:
- Added an @objc property `onSubtitleTracks` to facilitate event emission, enabling the RN layer to receive subtitle data.
- Implemented method `handleLegibleOutput` to handle attributed strings from subtitles, triggering the `onSubtitleTracks` event with the subtitle text for consumption within RN components.

## 🥳 RN Layer
- Exposed the `onSubtitleTracks` property. 

Example:

```ts
const App = () => {
  const handleSubtitleTracks = useCallback((e: OnSubtitleTracksData) => {
    console.log('Subtitles:', e.subtitleTracks);
  }, []);

  return (
    <Video
      source={{ uri: 'video-url.mp4' }} // Replace 'video-url.mp4' with your video source
      onSubtitleTracks={handleSubtitleTracks} // new event handler
      // Other props for the Video component
    />
  );
};
```

## 📄 Docs
- updated `events.md` to include a description aligned with current standards.


## Test plan

✅ Tested in example app with `uri` included in this PR

Set the tracks you want to use, for my demo I used the below; however, `SelectedTrackType.LANGUAGE` also works. For my actual use-case, we'll be using `TITLE` so I wanted to make sure that worked.

  - Apply following changes to test in example app:
  
  ```js
// VideoPlayer.tsx

      // selectedTextTrack={this.state.selectedTextTrack}
      selectedTextTrack={{
        type: SelectedTrackType.TITLE,
        value: 'English',
      }}
```
Comment out this line; due to `textTracks` being undefined, I believe it has to do with how `data.textTracks` is being set; but, I didn't want to address that on this PR as its a separate issue.

```js
// VideoPlayer.tsx
  {/* {this.state.textTracks.map(track => (
    <Picker.Item
      label={track.language}
      value={track.language}
      key={track.language}
    />
  ))} */}
```
Comment out this line for the app to build( I believe this is a known issue):
```js
// metro.config.js

// /(.*\/react-native-video\/node_modules\/.*)$/,
```

Demo of how it works:


https://github.com/react-native-video/react-native-video/assets/75731066/c5ec08dc-567d-4704-a1b1-a6f39121673f



