### PR TITLE
fix(ios): Do not crash when accessLog return nil

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1374,9 +1374,11 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     @objc
     func handleAVPlayerAccess(notification: NSNotification!) {
-        let accessLog: AVPlayerItemAccessLog! = (notification.object as! AVPlayerItem).accessLog()
-        let lastEvent: AVPlayerItemAccessLogEvent! = accessLog.events.last
+        guard let accessLog = (notification.object as? AVPlayerItem)?.accessLog() else {
+            return
+        }
 
+        guard let lastEvent = accessLog.events.last else { return }
         onVideoBandwidthUpdate?(["bitrate": lastEvent.observedBitrate, "target": reactTag])
     }
 


### PR DESCRIPTION
## Summary

accessLog method can return nil if no logging information are currently available (see https://developer.apple.com/documentation/avfoundation/avplayeritem/1388499-accesslog).



### Motivation

should fix https://github.com/react-native-video/react-native-video/issues/3424


### Changes

I handle the case where `accessLog` return `nil` & do not call onVideoBandwidthUpdate if it's `nil`. That should avoid some crash.

## Test plan

Sadly I can not reproduce the crash. I did not find a way to trigger `onVideoBandwidthUpdate`. Someone maybe can point me a way to reproduce this beahavior ?
