### PR TITLE
fix: added nodeModulesPath on metro.config.js of basic example app

### DIFF
--- a/examples/basic/metro.config.js
+++ b/examples/basic/metro.config.js
@@ -43,6 +43,10 @@ const config = {
       acc[name] = path.join(__dirname, 'node_modules', name);
       return acc;
     }, {}),
+    nodeModulesPaths: [
+      path.resolve(path.join(__dirname, './node_modules')),
+      path.resolve(path.join(__dirname, '../../node_modules'))
+    ],
     transformer: {
       getTransformOptions: async () => ({
         transform: {


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
I couldn't run example basic app.
I've got this error on metro CLI when I run example basic app.
`error: Error: Unable to resolve module @babel/runtime/helpers/interopRequireDefault`

I figured out why I got this error.
I think it's because of metro config.
So I've implemented `nodeModulesPaths` on metro.config.js

### Motivation

### Changes
* example/basic/metro.config.js - nodeModulesPaths

## Test plan