### PR TITLE
fix: add missing shutterColor type

### DIFF
--- a/docs/pages/component/props.md
+++ b/docs/pages/component/props.md
@@ -47,7 +47,7 @@ This page shows the list of available properties to configure player
 | [selectedAudioTrack](#selectedaudiotrack)                                           | Android, iOS, visionOS    |
 | [selectedTextTrack](#selectedtexttrack)                                             | Android, iOS  visionOS    |
 | [selectedVideoTrack](#selectedvideotrack)                                           | Android                   |
-| [shutterColor](#shutterColor)                                                       | Android                   |
+| [shutterColor](#shuttercolor)                                                       | Android                   |
 | [source](#source)                                                                   | All                       |
 | [subtitleStyle](#subtitlestyle)                                                     | Android                   |
 | [textTracks](#texttracks)                                                           | Android, iOS, visionOS    |

--- a/src/VideoNativeComponent.ts
+++ b/src/VideoNativeComponent.ts
@@ -314,6 +314,7 @@ export interface VideoNativeProps extends ViewProps {
   reportBandwidth?: boolean; //Android
   selectedVideoTrack?: SelectedVideoTrack; // android
   subtitleStyle?: SubtitleStyle; // android
+  shutterColor?: string; // Android
   trackId?: string; // Android
   useTextureView?: boolean; // Android
   useSecureView?: boolean; // Android

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -221,6 +221,7 @@ export interface ReactVideoProps extends ReactVideoEvents, ViewProps {
   selectedTextTrack?: SelectedTrack;
   selectedVideoTrack?: SelectedVideoTrack; // android
   subtitleStyle?: SubtitleStyle; // android
+  shutterColor?: string; // Android
   textTracks?: TextTracks;
   testID?: string;
   trackId?: string; // Android


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
Add missing type for shutterColor

Fixes: https://github.com/react-native-video/react-native-video/issues/3550