### PR TITLE
fix(iOS): correct release volume change observer

### DIFF
--- a/ios/Video/Features/RCTPlayerObserver.swift
+++ b/ios/Video/Features/RCTPlayerObserver.swift
@@ -140,6 +140,7 @@ class RCTPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate, AVPla
     func removePlayerObservers() {
         _playerRateChangeObserver?.invalidate()
         _playerExternalPlaybackActiveObserver?.invalidate()
+        _playerVolumeChangeObserver?.invalidate()
     }
 
     func addPlayerItemObservers() {


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
in version 6.0.0, _playerVolumeChangeObserver is not invalidate when player deinit, leading to multithreading crashes on iOS. This problem occurred specifically when a video was added to a flatlist, continuously created and destroyed.
