### PR TITLE
fix(ios): fix missing bridge in bridgeless mode

### DIFF
--- a/ios/Video/RCTVideoManager.swift
+++ b/ios/Video/RCTVideoManager.swift
@@ -4,7 +4,7 @@ import React
 @objc(RCTVideoManager)
 class RCTVideoManager: RCTViewManager {
     override func view() -> UIView {
-        return RCTVideo(eventDispatcher: bridge.eventDispatcher() as! RCTEventDispatcher)
+        return RCTVideo(eventDispatcher: (RCTBridge.current().eventDispatcher() as! RCTEventDispatcher))
     }
 
     func methodQueue() -> DispatchQueue {


### PR DESCRIPTION
## Summary
Added support for bridge less mode (for now via interop layer as we don't have fabric yet)

### Motivation
In bridgeless mode there are some changes of accessing "bridge", this PR fix the old method where bridge was null

## Test plan
- [x] `basic` example with old arch
- [x] `basic` example with new arch + bridgeless mode