### PR TITLE
feat: implement capture method

### DIFF
--- a/android/src/main/java/com/brentvatne/common/toolbox/CaptureUtil.kt
+++ b/android/src/main/java/com/brentvatne/common/toolbox/CaptureUtil.kt
@@ -16,7 +16,6 @@ import com.facebook.react.bridge.ReactApplicationContext
 import java.io.IOException
 import java.io.OutputStream
 
-
 object CaptureUtil {
     @JvmStatic
     fun capture(reactContext: ReactApplicationContext, view: View) {

--- a/android/src/main/java/com/brentvatne/common/toolbox/CaptureUtil.kt
+++ b/android/src/main/java/com/brentvatne/common/toolbox/CaptureUtil.kt
@@ -1,0 +1,93 @@
+package com.brentvatne.common.toolbox
+
+import android.content.ContentValues
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.provider.MediaStore
+import android.view.PixelCopy
+import android.view.SurfaceView
+import android.view.TextureView
+import android.view.View
+import androidx.media3.common.util.Util
+import com.facebook.react.bridge.ReactApplicationContext
+import java.io.IOException
+import java.io.OutputStream
+
+
+object CaptureUtil {
+    @JvmStatic
+    fun capture(reactContext: ReactApplicationContext, view: View) {
+        val bitmap: Bitmap?
+        if (view is TextureView) {
+            bitmap = view.bitmap
+            try {
+                saveImageToStream(bitmap, reactContext)
+            } catch (e: IOException) {
+                throw e
+            }
+        } else if (Util.SDK_INT >= 24 && view is SurfaceView) {
+            bitmap = Bitmap.createBitmap(view.getWidth(), view.getHeight(), Bitmap.Config.ARGB_8888)
+            PixelCopy.request(view, bitmap, { copyResult: Int ->
+                if (copyResult == PixelCopy.SUCCESS) {
+                    try {
+                        saveImageToStream(bitmap, reactContext)
+                    } catch (e: IOException) {
+                        e.printStackTrace()
+                    }
+                }
+            }, Handler(Looper.getMainLooper()))
+        } else {
+            // https://stackoverflow.com/questions/27817577/android-take-screenshot-of-surface-view-shows-black-screen/27824250#27824250
+            throw RuntimeException("SurfaceView couldn't support capture under SDK 24")
+        }
+    }
+
+    private fun saveImageToStream(bitmap: Bitmap?, reactContext: ReactApplicationContext) {
+        val isUnderQ = Build.VERSION.SDK_INT < Build.VERSION_CODES.Q
+        val values = contentValues()
+        val resolver = reactContext.contentResolver
+        var stream: OutputStream? = null
+        var uri: Uri? = null
+        try {
+            if (!isUnderQ) {
+                values.put(MediaStore.MediaColumns.IS_PENDING, 1)
+            }
+            val imageCollection = MediaStore.Images.Media.getContentUri(if (isUnderQ) MediaStore.VOLUME_EXTERNAL else MediaStore.VOLUME_EXTERNAL_PRIMARY)
+            uri = resolver.insert(imageCollection, values)
+            if (uri == null) {
+                throw IOException("Failed to create new MediaStore record.")
+            }
+            stream = resolver.openOutputStream(uri)
+            if (stream == null) {
+                throw IOException("Failed to get output stream.")
+            }
+            if (!bitmap!!.compress(Bitmap.CompressFormat.PNG, 100, stream)) {
+                throw IOException("Failed to save bitmap.")
+            }
+            if (!isUnderQ) {
+                values.clear()
+                values.put(MediaStore.MediaColumns.IS_PENDING, 0)
+                resolver.update(uri, values, null, null)
+            }
+        } catch (e: IOException) {
+            if (uri != null) {
+                // Don't leave an orphan entry in the MediaStore
+                resolver.delete(uri, null, null)
+            }
+            throw e
+        } finally {
+            stream?.close()
+        }
+    }
+
+    private fun contentValues(): ContentValues {
+        val values = ContentValues()
+        values.put(MediaStore.MediaColumns.MIME_TYPE, "image/png")
+        values.put(MediaStore.MediaColumns.DATE_ADDED, System.currentTimeMillis() / 1000)
+        values.put(MediaStore.MediaColumns.DATE_TAKEN, System.currentTimeMillis())
+        return values
+    }
+}

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1817,6 +1817,10 @@ public class ReactExoplayerView extends FrameLayout implements
         return groupIndex;
     }
 
+    public ExoPlayerView getExoPlayerView() {
+        return this.exoPlayerView;
+    }
+
     public void setSelectedVideoTrack(String type, Dynamic value) {
         videoTrackType = type;
         videoTrackValue = value;

--- a/android/src/main/java/com/brentvatne/react/VideoManagerModule.java
+++ b/android/src/main/java/com/brentvatne/react/VideoManagerModule.java
@@ -5,7 +5,6 @@ import android.view.View;
 import androidx.annotation.NonNull;
 
 import com.brentvatne.common.toolbox.CaptureUtil;
-import com.brentvatne.common.toolbox.DebugLog;
 import com.brentvatne.exoplayer.ExoPlayerView;
 import com.brentvatne.exoplayer.ReactExoplayerView;
 import com.facebook.react.bridge.Promise;
@@ -13,8 +12,6 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.uimanager.UIManagerModule;
-
-import java.util.Objects;
 
 public class VideoManagerModule extends ReactContextBaseJavaModule {
     private static final String REACT_CLASS = "VideoManager";
@@ -51,7 +48,7 @@ public class VideoManagerModule extends ReactContextBaseJavaModule {
                 if (view instanceof ReactExoplayerView) {
                     try {
                         ReactExoplayerView videoView = (ReactExoplayerView) view;
-                        ExoPlayerView exoPlayerView = videoView.exoPlayerView;
+                        ExoPlayerView exoPlayerView = videoView.getExoPlayerView();
                         CaptureUtil.capture(context, exoPlayerView);
                         promise.resolve(null);
                     } catch (Exception e) {

--- a/android/src/main/java/com/brentvatne/react/VideoManagerModule.java
+++ b/android/src/main/java/com/brentvatne/react/VideoManagerModule.java
@@ -49,7 +49,7 @@ public class VideoManagerModule extends ReactContextBaseJavaModule {
                     try {
                         ReactExoplayerView videoView = (ReactExoplayerView) view;
                         ExoPlayerView exoPlayerView = videoView.getExoPlayerView();
-                        CaptureUtil.capture(context, exoPlayerView);
+                        CaptureUtil.capture(context, exoPlayerView.getVideoSurfaceView());
                         promise.resolve(null);
                     } catch (Exception e) {
                         promise.reject("CAPTURE_ERROR", e);

--- a/android/src/main/java/com/brentvatne/react/VideoManagerModule.java
+++ b/android/src/main/java/com/brentvatne/react/VideoManagerModule.java
@@ -4,11 +4,17 @@ import android.view.View;
 
 import androidx.annotation.NonNull;
 
+import com.brentvatne.common.toolbox.CaptureUtil;
+import com.brentvatne.common.toolbox.DebugLog;
+import com.brentvatne.exoplayer.ExoPlayerView;
 import com.brentvatne.exoplayer.ReactExoplayerView;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.uimanager.UIManagerModule;
+
+import java.util.Objects;
 
 public class VideoManagerModule extends ReactContextBaseJavaModule {
     private static final String REACT_CLASS = "VideoManager";
@@ -34,5 +40,25 @@ public class VideoManagerModule extends ReactContextBaseJavaModule {
                 videoView.setPausedModifier(paused);
             }
         });
+    }
+
+    @ReactMethod
+    public void capture(int reactTag, Promise promise) {
+        final ReactApplicationContext context = getReactApplicationContext();
+        final UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
+        uiManager.prependUIBlock(manager -> {
+                View view = manager.resolveView(reactTag);
+                if (view instanceof ReactExoplayerView) {
+                    try {
+                        ReactExoplayerView videoView = (ReactExoplayerView) view;
+                        ExoPlayerView exoPlayerView = videoView.exoPlayerView;
+                        CaptureUtil.capture(context, exoPlayerView);
+                        promise.resolve(null);
+                    } catch (Exception e) {
+                        promise.reject("CAPTURE_ERROR", e);
+                    }
+                }
+            }
+        );
     }
 }

--- a/docs/pages/component/methods.mdx
+++ b/docs/pages/component/methods.mdx
@@ -76,8 +76,7 @@ Notes:
 
 - this method can not be used with encrypted video contents (with DRM)
 - On Android API level 23 and below capture couldn't support Android `SurfaceView`. if you use SurfaceView, method will be throw an error (`useSurfaceView`, `useSecureView` and `drm` props are internally use SurfaceView).
-- For Android API level 29+ you will need to request the [WRITE_EXTERNAL_STORAGE permission](https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE) manually using either the built-in react-native `PermissionsAndroid` APIs or a related module such as `react-native-permissions`
-- Also you have to define below code within your `AndroidManifest.xml` file
+- On Android API level 28 and below you will need to request the [WRITE_EXTERNAL_STORAGE permission](https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE) manually using either the built-in react-native `PermissionsAndroid` APIs or a related module such as `react-native-permissions`. also you have to define below code within your `AndroidManifest.xml` file
 
 ```xml
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/docs/pages/component/methods.mdx
+++ b/docs/pages/component/methods.mdx
@@ -74,6 +74,8 @@ Save current frame as a PNG file. Returns promise.
 
 Notes:
 
+- this method can not be used with encrypted video contents (with DRM)
+- On Android API level 23 and below capture couldn't support Android `SurfaceView`. if you use SurfaceView, method will be throw an error (`useSurfaceView`, `useSecureView` and `drm` props are internally use SurfaceView).
 - For Android API level 29+ you will need to request the [WRITE_EXTERNAL_STORAGE permission](https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE) manually using either the built-in react-native `PermissionsAndroid` APIs or a related module such as `react-native-permissions`
 - Also you have to define below code within your `AndroidManifest.xml` file
 

--- a/docs/pages/component/methods.mdx
+++ b/docs/pages/component/methods.mdx
@@ -64,6 +64,23 @@ Future:
 - Will support more formats in the future through options
 - Will support custom directory and file name through options
 
+### `capture`
+
+<PlatformsList types={['iOS', 'Android']} />
+
+`capture(): Promise<void>`
+
+Save current frame as a PNG file. Returns promise.
+
+Notes:
+
+- For Android API level 29+ you will need to request the [WRITE_EXTERNAL_STORAGE permission](https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE) manually using either the built-in react-native `PermissionsAndroid` APIs or a related module such as `react-native-permissions`
+- Also you have to define below code within your `AndroidManifest.xml` file
+
+```xml
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+```
+
 ### `restoreUserInterfaceForPictureInPictureStopCompleted`
 
 <PlatformsList types={['iOS']} />

--- a/docs/pages/component/methods.mdx
+++ b/docs/pages/component/methods.mdx
@@ -83,6 +83,13 @@ Notes:
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 ```
 
+- In order to save photos on iOS, user must accept permission to save photos. To enable this permission, you need to add the following to your `info.plist`
+
+```xml
+<key>NSPhotoLibraryAddUsageDescription</key>
+<string>YOUR TEXT</string>
+```
+
 ### `restoreUserInterfaceForPictureInPictureStopCompleted`
 
 <PlatformsList types={['iOS']} />

--- a/docs/pages/component/methods.mdx
+++ b/docs/pages/component/methods.mdx
@@ -83,7 +83,7 @@ Notes:
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 ```
 
-- In order to save photos on iOS, user must accept permission to save photos. To enable this permission, you need to add the following to your `info.plist`
+- In order to save photos on iOS, user must accept permission to save photos. To enable this permission, you need to add the following to your `Info.plist` file.
 
 ```xml
 <key>NSPhotoLibraryAddUsageDescription</key>

--- a/ios/Video/Features/RCTVideoCapture.swift
+++ b/ios/Video/Features/RCTVideoCapture.swift
@@ -1,0 +1,50 @@
+import AVFoundation
+
+enum CaptureError: Error {
+    case emptyPlayerItem
+    case emptyPlayerItemOutput
+    case emptyBuffer
+    case emptyImg
+    case emtpyPngData
+    case emptyTmpDir
+}
+
+enum RCTVideoCapture {
+
+    static func capture(
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock,
+        playerItem: AVPlayerItem?,
+        playerOutput: AVPlayerItemVideoOutput?
+    ) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let playerItem = try playerItem ?? { throw CaptureError.emptyPlayerItem }()
+                let playerOutput = try playerOutput ?? { throw CaptureError.emptyPlayerItemOutput }()
+
+                let currentTime = playerItem.currentTime()
+                let settings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
+                let output = AVPlayerItemVideoOutput.init(pixelBufferAttributes: settings)
+                let buffer = try playerOutput.copyPixelBuffer(forItemTime: currentTime, itemTimeForDisplay: nil) ?? { throw CaptureError.emptyBuffer }()
+                
+                let ciImage = CIImage(cvPixelBuffer: buffer)
+                let ctx = CIContext.init(options: nil)
+                let width = CVPixelBufferGetWidth(buffer)
+                let height = CVPixelBufferGetHeight(buffer)
+                let rect = CGRectMake(0, 0, CGFloat(width), CGFloat(height))
+                let videoImage = try ctx.createCGImage(ciImage, from: rect) ?? { throw CaptureError.emptyImg }()
+                
+                let image = UIImage.init(cgImage: videoImage)
+                UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
+                let data = try image.pngData() ?? { throw CaptureError.emtpyPngData }()
+                
+                let tmpDir = try RCTTempFilePath("png", nil) ?? { throw CaptureError.emptyTmpDir }()
+
+                try data.write(to: URL(fileURLWithPath: tmpDir))
+                resolve(nil)
+            } catch {
+                reject("RCTVideoCapture Error", "Capture failed: \(error)", nil)
+            }
+        }
+    }
+}

--- a/ios/Video/Features/RCTVideoCapture.swift
+++ b/ios/Video/Features/RCTVideoCapture.swift
@@ -52,7 +52,7 @@ enum RCTVideoCapture {
         }
     }
 
-    static private func checkPhotoAddPermission() throws {
+    private static func checkPhotoAddPermission() throws {
         var status: PHAuthorizationStatus?
         if #available(iOS 14, *) {
             status = PHPhotoLibrary.authorizationStatus(for: .addOnly)
@@ -60,10 +60,10 @@ enum RCTVideoCapture {
             status = PHPhotoLibrary.authorizationStatus()
         }
         switch status {
-            case .restricted, .denied:
-                throw CaptureError.permissionDenied
-            default:
-                return;
+        case .restricted, .denied:
+            throw CaptureError.permissionDenied
+        default:
+            return
         }
     }
 }

--- a/ios/Video/Features/RCTVideoCapture.swift
+++ b/ios/Video/Features/RCTVideoCapture.swift
@@ -1,5 +1,7 @@
 import AVFoundation
 
+// MARK: - CaptureError
+
 enum CaptureError: Error {
     case emptyPlayerItem
     case emptyPlayerItemOutput
@@ -9,8 +11,9 @@ enum CaptureError: Error {
     case emptyTmpDir
 }
 
-enum RCTVideoCapture {
+// MARK: - RCTVideoCapture
 
+enum RCTVideoCapture {
     static func capture(
         resolve: @escaping RCTPromiseResolveBlock,
         reject: @escaping RCTPromiseRejectBlock,
@@ -24,20 +27,20 @@ enum RCTVideoCapture {
 
                 let currentTime = playerItem.currentTime()
                 let settings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
-                let output = AVPlayerItemVideoOutput.init(pixelBufferAttributes: settings)
+                let output = AVPlayerItemVideoOutput(pixelBufferAttributes: settings)
                 let buffer = try playerOutput.copyPixelBuffer(forItemTime: currentTime, itemTimeForDisplay: nil) ?? { throw CaptureError.emptyBuffer }()
-                
+
                 let ciImage = CIImage(cvPixelBuffer: buffer)
-                let ctx = CIContext.init(options: nil)
+                let ctx = CIContext(options: nil)
                 let width = CVPixelBufferGetWidth(buffer)
                 let height = CVPixelBufferGetHeight(buffer)
-                let rect = CGRectMake(0, 0, CGFloat(width), CGFloat(height))
+                let rect = CGRect(x: 0, y: 0, width: CGFloat(width), height: CGFloat(height))
                 let videoImage = try ctx.createCGImage(ciImage, from: rect) ?? { throw CaptureError.emptyImg }()
-                
-                let image = UIImage.init(cgImage: videoImage)
+
+                let image = UIImage(cgImage: videoImage)
                 UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
                 let data = try image.pngData() ?? { throw CaptureError.emtpyPngData }()
-                
+
                 let tmpDir = try RCTTempFilePath("png", nil) ?? { throw CaptureError.emptyTmpDir }()
 
                 try data.write(to: URL(fileURLWithPath: tmpDir))

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -68,7 +68,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     private var _presentingViewController: UIViewController?
     private var _pictureInPictureEnabled = false
     private var _startPosition: Float64 = -1
-    private var _playerOutput:AVPlayerItemVideoOutput?
+    private var _playerOutput: AVPlayerItemVideoOutput?
 
     /* IMA Ads */
     private var _adTagUrl: String?
@@ -368,7 +368,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
                     // for capture
                     let settings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
-                    self._playerOutput = AVPlayerItemVideoOutput.init(pixelBufferAttributes: settings)
+                    self._playerOutput = AVPlayerItemVideoOutput(pixelBufferAttributes: settings)
 
                     self._playerObserver.playerItem = self._playerItem
                     self.setPreferredForwardBufferDuration(self._preferredForwardBufferDuration)
@@ -1384,7 +1384,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     }
 
     @objc
-    func capture(resolve: @escaping RCTPromiseResolveBlock, reject:@escaping RCTPromiseRejectBlock) {
+    func capture(resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         RCTVideoCapture.capture(resolve: resolve, reject: reject, playerItem: _playerItem, playerOutput: _playerOutput)
     }
 

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -84,4 +84,6 @@ RCT_EXTERN_METHOD(presentFullscreenPlayer : (nonnull NSNumber*)reactTag)
 
 RCT_EXTERN_METHOD(dismissFullscreenPlayer : (nonnull NSNumber*)reactTag)
 
+RCT_EXTERN_METHOD(capture : (nonnull NSNumber *)reactTag resolver : (RCTPromiseResolveBlock)resolve rejecter : (RCTPromiseRejectBlock)reject)
+
 @end

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -84,6 +84,6 @@ RCT_EXTERN_METHOD(presentFullscreenPlayer : (nonnull NSNumber*)reactTag)
 
 RCT_EXTERN_METHOD(dismissFullscreenPlayer : (nonnull NSNumber*)reactTag)
 
-RCT_EXTERN_METHOD(capture : (nonnull NSNumber *)reactTag resolver : (RCTPromiseResolveBlock)resolve rejecter : (RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(capture : (nonnull NSNumber*)reactTag resolver : (RCTPromiseResolveBlock)resolve rejecter : (RCTPromiseRejectBlock)reject)
 
 @end

--- a/ios/Video/RCTVideoManager.swift
+++ b/ios/Video/RCTVideoManager.swift
@@ -84,6 +84,18 @@ class RCTVideoManager: RCTViewManager {
         }
     }
 
+    @objc(capture:resolver:rejecter:)
+    func capture(_ reactTag: NSNumber, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        bridge.uiManager.prependUIBlock { _, viewRegistry in
+            let view = viewRegistry?[reactTag]
+            if !(view is RCTVideo) {
+                RCTLogError("Invalid view returned from registry, expecting RCTVideo, got: %@", String(describing: view))
+            } else if let view = view as? RCTVideo {
+                view.capture(resolve: resolve, reject: reject)
+            }
+        }
+    }
+
     override class func requiresMainQueueSetup() -> Bool {
         return true
     }

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -55,6 +55,7 @@ export interface VideoRef {
     restore: boolean,
   ) => void;
   save: (options: object) => Promise<VideoSaveData>;
+  capture: () => Promise<void>;
 }
 
 const Video = forwardRef<VideoRef, ReactVideoProps>(
@@ -263,6 +264,10 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
 
     const resume = useCallback(() => {
       return VideoManager.setPlayerPauseState(false, getReactTag(nativeRef));
+    }, []);
+
+    const capture = useCallback(() => {
+      return VideoManager.capture(getReactTag(nativeRef));
     }, []);
 
     const restoreUserInterfaceForPictureInPictureStopCompleted = useCallback(
@@ -485,6 +490,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         presentFullscreenPlayer,
         dismissFullscreenPlayer,
         save,
+        capture,
         pause,
         resume,
         restoreUserInterfaceForPictureInPictureStopCompleted,
@@ -494,6 +500,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         presentFullscreenPlayer,
         dismissFullscreenPlayer,
         save,
+        capture,
         pause,
         resume,
         restoreUserInterfaceForPictureInPictureStopCompleted,

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -267,8 +267,11 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
     }, []);
 
     const capture = useCallback(() => {
-      return VideoManager.capture(getReactTag(nativeRef));
-    }, []);
+      if (drm) {
+        throw Error('"capture" method can not be called with "drm" prop');
+      }
+      return VideoManager.capture?.(getReactTag(nativeRef));
+    }, [drm]);
 
     const restoreUserInterfaceForPictureInPictureStopCompleted = useCallback(
       (restored: boolean) => {

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -535,6 +535,7 @@ export type VideoSaveData = {
 
 export interface VideoManagerType {
   save: (option: object, reactTag: number) => Promise<VideoSaveData>;
+  capture: (reactTag: number) => Promise<void>;
   setPlayerPauseState: (paused: boolean, reactTag: number) => Promise<void>;
   setLicenseResult: (
     result: string,


### PR DESCRIPTION
## Summary
Implement capture method

### Motivation
Actually this feature(save image file) doesn't related player feature, but it is so much hard to implement within JS side or other native module. so I create this PR.
(If it doesn't fit your development plan, please close it.)

### Changes
add method named `capture`

## Test plan
just call `await videoRef.current.capture()` without below props
- useSurfaceView
- useSecureView
- drm

and check below setup
- https://github.com/react-native-video/react-native-video/pull/3577/files#diff-aa8251da49a770bf1cb8679474b0eb22feff34b6eb7d4104bb838299ea2f2999R67-R91
