### PR TITLE
feat: implement opacity to control visibility of subtitles

### DIFF
--- a/android/src/main/java/com/brentvatne/common/api/SubtitleStyle.kt
+++ b/android/src/main/java/com/brentvatne/common/api/SubtitleStyle.kt
@@ -19,7 +19,7 @@ class SubtitleStyle private constructor() {
         private set
     var opacity = 1
         private set
-        
+
     companion object {
         private const val PROP_FONT_SIZE_TRACK = "fontSize"
         private const val PROP_PADDING_BOTTOM = "paddingBottom"

--- a/android/src/main/java/com/brentvatne/common/api/SubtitleStyle.kt
+++ b/android/src/main/java/com/brentvatne/common/api/SubtitleStyle.kt
@@ -17,7 +17,7 @@ class SubtitleStyle private constructor() {
         private set
     var paddingBottom = 0
         private set
-    var opacity = 1
+    var opacity = 1f
         private set
 
     companion object {
@@ -36,7 +36,7 @@ class SubtitleStyle private constructor() {
             subtitleStyle.paddingTop = ReactBridgeUtils.safeGetInt(src, PROP_PADDING_TOP, 0)
             subtitleStyle.paddingLeft = ReactBridgeUtils.safeGetInt(src, PROP_PADDING_LEFT, 0)
             subtitleStyle.paddingRight = ReactBridgeUtils.safeGetInt(src, PROP_PADDING_RIGHT, 0)
-            subtitleStyle.opacity = ReactBridgeUtils.safeGetInt(src, PROP_OPACITY, 1)
+            subtitleStyle.opacity = ReactBridgeUtils.safeGetFloat(src, PROP_OPACITY, 1f)
             return subtitleStyle
         }
     }

--- a/android/src/main/java/com/brentvatne/common/api/SubtitleStyle.kt
+++ b/android/src/main/java/com/brentvatne/common/api/SubtitleStyle.kt
@@ -17,13 +17,16 @@ class SubtitleStyle private constructor() {
         private set
     var paddingBottom = 0
         private set
-
+    var opacity = 1
+        private set
+        
     companion object {
         private const val PROP_FONT_SIZE_TRACK = "fontSize"
         private const val PROP_PADDING_BOTTOM = "paddingBottom"
         private const val PROP_PADDING_TOP = "paddingTop"
         private const val PROP_PADDING_LEFT = "paddingLeft"
         private const val PROP_PADDING_RIGHT = "paddingRight"
+        private const val PROP_OPACITY = "opacity"
 
         @JvmStatic
         fun parse(src: ReadableMap?): SubtitleStyle {
@@ -33,6 +36,7 @@ class SubtitleStyle private constructor() {
             subtitleStyle.paddingTop = ReactBridgeUtils.safeGetInt(src, PROP_PADDING_TOP, 0)
             subtitleStyle.paddingLeft = ReactBridgeUtils.safeGetInt(src, PROP_PADDING_LEFT, 0)
             subtitleStyle.paddingRight = ReactBridgeUtils.safeGetInt(src, PROP_PADDING_RIGHT, 0)
+            subtitleStyle.opacity = ReactBridgeUtils.safeGetInt(src, PROP_OPACITY, 1)
             return subtitleStyle
         }
     }

--- a/android/src/main/java/com/brentvatne/common/toolbox/ReactBridgeUtils.kt
+++ b/android/src/main/java/com/brentvatne/common/toolbox/ReactBridgeUtils.kt
@@ -66,6 +66,14 @@ object ReactBridgeUtils {
         return safeGetDouble(map, key, 0.0)
     }
 
+    @JvmStatic fun safeGetFloat(map: ReadableMap?, key: String?, fallback: Float): Float {
+        return if (map != null && map.hasKey(key!!) && !map.isNull(key)) map.getDouble(key).toFloat() else fallback
+    }
+
+    @JvmStatic fun safeGetFloat(map: ReadableMap?, key: String?): Float {
+        return safeGetFloat(map, key, 0.0f)
+    }
+
     /**
      * toStringMap converts a [ReadableMap] into a HashMap.
      *

--- a/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -117,7 +117,12 @@ public final class ExoPlayerView extends FrameLayout implements AdViewProvider {
             subtitleLayout.setFixedTextSize(TypedValue.COMPLEX_UNIT_SP, style.getFontSize());
         }
         subtitleLayout.setPadding(style.getPaddingLeft(), style.getPaddingTop(), style.getPaddingRight(), style.getPaddingBottom());
-        subtitleLayout.setVisibility(style.getOpacity() == 0 ? View.GONE : View.VISIBLE);
+        if (style.getOpacity() != 0) {
+            subtitleLayout.setAlpha(style.getOpacity());
+        } else {
+            subtitleLayout.setVisibility(View.GONE);
+        }
+
     }
 
     public void setShutterColor(Integer color) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -117,6 +117,7 @@ public final class ExoPlayerView extends FrameLayout implements AdViewProvider {
             subtitleLayout.setFixedTextSize(TypedValue.COMPLEX_UNIT_SP, style.getFontSize());
         }
         subtitleLayout.setPadding(style.getPaddingLeft(), style.getPaddingTop(), style.getPaddingRight(), style.getPaddingBottom());
+        subtitleLayout.setVisibility(style.getOpacity() == 0 ? View.GONE : View.VISIBLE);
     }
 
     public void setShutterColor(Integer color) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -119,6 +119,7 @@ public final class ExoPlayerView extends FrameLayout implements AdViewProvider {
         subtitleLayout.setPadding(style.getPaddingLeft(), style.getPaddingTop(), style.getPaddingRight(), style.getPaddingBottom());
         if (style.getOpacity() != 0) {
             subtitleLayout.setAlpha(style.getOpacity());
+            subtitleLayout.setVisibility(View.VISIBLE);
         } else {
             subtitleLayout.setVisibility(View.GONE);
         }

--- a/docs/pages/component/events.mdx
+++ b/docs/pages/component/events.mdx
@@ -534,6 +534,8 @@ Example:
 }
 ```
 
+For details on how to control the visibility of subtitles, see the [subtitleStyle](./props.mdx#subtitleStyle) section.
+
 ### `onVideoTracks`
 
 <PlatformsList types={['Android']} />

--- a/docs/pages/component/props.mdx
+++ b/docs/pages/component/props.mdx
@@ -739,11 +739,12 @@ source={{
 | paddingBottom | Adjust the bottom padding of the subtitles. Default: 0                  | Android   |
 | paddingLeft   | Adjust the left padding of the subtitles. Default: 0                    | Android   |
 | paddingRight  | Adjust the right padding of the subtitles. Default: 0                   | Android   |
+| opacity       | Adjust the visibility of subtitles. `0` will not render the subtitles, while `1` will make them fully visible. Default: 1. | Android   |
 
 Example:
 
 ```javascript
-subtitleStyle={{ paddingBottom: 50, fontSize: 20 }}
+subtitleStyle={{ paddingBottom: 50, fontSize: 20, opacity: 0 }}
 ```
 
 ### `textTracks`

--- a/docs/pages/component/props.mdx
+++ b/docs/pages/component/props.mdx
@@ -739,7 +739,7 @@ source={{
 | paddingBottom | Adjust the bottom padding of the subtitles. Default: 0                  | Android   |
 | paddingLeft   | Adjust the left padding of the subtitles. Default: 0                    | Android   |
 | paddingRight  | Adjust the right padding of the subtitles. Default: 0                   | Android   |
-| opacity       | Adjust the visibility of subtitles. `0` will not render the subtitles, while `1` will make them fully visible. Default: 1. | Android   |
+| opacity | Adjust the visibility of subtitles with 0 hiding and 1 fully showing them. Android supports float values between 0 and 1 for varying opacity levels, whereas iOS supports only 0 or 1. Default: 1. | Android, iOS |
 
 Example:
 

--- a/ios/Video/DataStructures/SubtitleStyle.swift
+++ b/ios/Video/DataStructures/SubtitleStyle.swift
@@ -1,0 +1,17 @@
+struct SubtitleStyle {
+    // Extend with more style properties as needed.
+    private(set) var opacity: CGFloat
+
+    enum SubtitleStyleKeys {
+        static let opacity = "opacity"
+    }
+
+    init(opacity: CGFloat = 1) {
+        self.opacity = opacity
+    }
+
+    static func parse(from dictionary: [String: Any]?) -> SubtitleStyle {
+        let opacity = dictionary?[SubtitleStyleKeys.opacity] as? CGFloat ?? 1
+        return SubtitleStyle(opacity: opacity)
+    }
+}

--- a/ios/Video/Features/RCTPlayerObserver.swift
+++ b/ios/Video/Features/RCTPlayerObserver.swift
@@ -46,9 +46,9 @@ class RCTPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate, AVPla
             }
         }
     }
-    
+
     var subtitleStyle: SubtitleStyle?
-    
+
     var playerItem: AVPlayerItem? {
         willSet {
             removePlayerItemObservers()

--- a/ios/Video/Features/RCTPlayerObserver.swift
+++ b/ios/Video/Features/RCTPlayerObserver.swift
@@ -46,7 +46,9 @@ class RCTPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate, AVPla
             }
         }
     }
-
+    
+    var subtitleStyle: SubtitleStyle?
+    
     var playerItem: AVPlayerItem? {
         willSet {
             removePlayerItemObservers()
@@ -63,6 +65,7 @@ class RCTPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate, AVPla
             playerItem.add(legibleOutput)
             metadataOutput.setDelegate(self, queue: .main)
             legibleOutput.setDelegate(self, queue: .main)
+            legibleOutput.suppressesPlayerRendering = subtitleStyle?.opacity == 0 ? true : false
         }
     }
 

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -952,7 +952,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         _playerLayer = nil
         _playerObserver.playerLayer = nil
     }
-    
+
     @objc
     func setSubtitleStyle(_ style: [String: Any]) {
         let subtitleStyle = SubtitleStyle.parse(from: style)

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -952,6 +952,12 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         _playerLayer = nil
         _playerObserver.playerLayer = nil
     }
+    
+    @objc
+    func setSubtitleStyle(_ style: [String: Any]) {
+        let subtitleStyle = SubtitleStyle.parse(from: style)
+        _playerObserver.subtitleStyle = subtitleStyle
+    }
 
     // MARK: - RCTVideoPlayerViewControllerDelegate
 

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -37,7 +37,7 @@ RCT_EXPORT_VIEW_PROPERTY(filterEnabled, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(progressUpdateInterval, float);
 RCT_EXPORT_VIEW_PROPERTY(restoreUserInterfaceForPIPStopCompletionHandler, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(localSourceEncryptionKeyScheme, NSString);
-
+RCT_EXPORT_VIEW_PROPERTY(subtitleStyle, NSDictionary);
 /* Should support: onLoadStart, onLoad, and onError to stay consistent with Image */
 RCT_EXPORT_VIEW_PROPERTY(onVideoLoadStart, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoLoad, RCTDirectEventBlock);

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -118,7 +118,7 @@ type SubtitleStyle = Readonly<{
   paddingBottom?: WithDefault<Float, 0>;
   paddingLeft?: WithDefault<Float, 0>;
   paddingRight?: WithDefault<Float, 0>;
-  opacity?: WithDefault<0 | 1, 1>;
+  opacity?: WithDefault<Float, 1>;
 }>;
 
 export type OnLoadData = Readonly<{

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -118,6 +118,7 @@ type SubtitleStyle = Readonly<{
   paddingBottom?: WithDefault<Float, 0>;
   paddingLeft?: WithDefault<Float, 0>;
   paddingRight?: WithDefault<Float, 0>;
+  opacity?: WithDefault<0 | 1, 1>;
 }>;
 
 export type OnLoadData = Readonly<{

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -101,7 +101,7 @@ export type SubtitleStyle = {
   paddingBottom?: number;
   paddingLeft?: number;
   paddingRight?: number;
-  opacity?: 0 | 1;
+  opacity?: number;
 };
 
 export enum TextTracksType {

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -101,6 +101,7 @@ export type SubtitleStyle = {
   paddingBottom?: number;
   paddingLeft?: number;
   paddingRight?: number;
+  opacity?: number;
 };
 
 export enum TextTracksType {

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -101,7 +101,7 @@ export type SubtitleStyle = {
   paddingBottom?: number;
   paddingLeft?: number;
   paddingRight?: number;
-  opacity?: number;
+  opacity?: 0 | 1;
 };
 
 export enum TextTracksType {


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
Add ability to control subtitle visibility while still maintaining ability of selecting a text track.
### Motivation
see https://github.com/react-native-video/react-native-video/issues/3579
### Changes
Updated `subtitleStyle` to include an `opacity` property; which, can control the visibility of subtitles.

Updated documentation for the new property and provided a link `onTextTrackDataChanged` -> `subtitleStyles` to clarify intent on how to control visibility of subtitles.

## Test plan

✅ Tested on example app:

![image](https://github.com/react-native-video/react-native-video/assets/75731066/d4c68474-7c98-49a4-8096-15aeb702ed83)

Simply set the following props:

```ts
          selectedTextTrack={{
            type: SelectedTrackType.LANGUAGE,
            value: 'en',
          }}
          subtitleStyle={{
            opacity: 0,
          }}
```

Then observe that the `subtitleTracks` log from `onTextTrackDataChanged` and _do not_ display them :)

Subtitles displayed as expected when set to 1:

![image](https://github.com/react-native-video/react-native-video/assets/75731066/afc69a88-73ea-4db6-a041-5f209107a92e)

If not explicitly set, they will be displayed:

![image](https://github.com/react-native-video/react-native-video/assets/75731066/58a0ba5a-f432-4eae-9334-1b6f4e3e48e5)

Type safe, must be 0 or 1
![image](https://github.com/react-native-video/react-native-video/assets/75731066/95817173-bc12-44d3-b9f8-010ed13db0a1)
