### PR TITLE
chore(ci): fix CI caching

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -20,12 +20,12 @@ runs:
       uses: actions/cache@v3
       with:
         path: |
-          **/node_modules
+          ${{ inputs.working-directory }}/node_modules
           .yarn/install-state.gz
-        key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}-${{ hashFiles('**/package.json', '!node_modules/**') }}
+        key: ${{ runner.os }}-yarn-${{ inputs.working-directory }}-${{ hashFiles('yarn.lock') }}-${{ hashFiles('**/package.json', '!node_modules/**') }}
         restore-keys: |
-          ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          ${{ runner.os }}-yarn-
+          ${{ runner.os }}-yarn-${{ inputs.working-directory }}-${{ hashFiles('yarn.lock') }}-
+          ${{ runner.os }}-yarn-${{ inputs.working-directory }}
     - name: Install dependencies
       working-directory: ${{ inputs.working-directory }}
       if: steps.yarn-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
Fix CI caching

### Motivation
Because this repo is not mono repo there was bug with `node_modules` mismatch where `example` was using `root` `node_modules` and vice versa

fixes #3580 

### Changes
Add `working directory` to cache key

## Test plan
- [x] Tested in fork