### PR TITLE
fix(ios): ensure playback stopped in background

### DIFF
--- a/.github/workflows/test-build-docs.yml
+++ b/.github/workflows/test-build-docs.yml
@@ -1,5 +1,5 @@
 
-name: test build docs
+name: Test Docs build
 on:
   workflow_dispatch:
   pull_request:
@@ -8,7 +8,7 @@ on:
       - 'docs/**'
 
 jobs:
-  deploy-docs:
+  build-docs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/docs/pages/component/props.mdx
+++ b/docs/pages/component/props.mdx
@@ -622,11 +622,20 @@ The docs for this prop are incomplete and will be updated as each option is inve
 
 Example:
 
+Pass directly the asset to play (deprecated)
+
 ```javascript
 const sintel = require('./sintel.mp4');
+source={ sintel };
+```
 
+Or by using an uri (starting from 6.0.0-beta.6)
+
+```javascript
+const sintel = require('./sintel.mp4');
 source={{ uri: sintel }}
 ```
+
 
 #### URI string
 

--- a/docs/pages/component/props.mdx
+++ b/docs/pages/component/props.mdx
@@ -625,7 +625,7 @@ Example:
 ```javascript
 const sintel = require('./sintel.mp4');
 
-source = {sintel};
+source={{ uri: sintel }}
 ```
 
 #### URI string

--- a/examples/basic/src/VideoPlayer.tsx
+++ b/examples/basic/src/VideoPlayer.tsx
@@ -97,7 +97,10 @@ class VideoPlayer extends Component {
   seekerWidth = 0;
 
   srcAllPlatformList = [
-    require('./broadchurch.mp4'),
+    {
+      description: 'local file',
+      uri: require('./broadchurch.mp4'),
+    },
     {
       description: '(hls|live) red bull tv',
       uri: 'https://rbmn-live.akamaized.net/hls/live/590964/BoRB-AT/master_928.m3u8',

--- a/examples/basic/tsconfig.json
+++ b/examples/basic/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@react-native/typescript-config/tsconfig.json",
   "compilerOptions": {
     "paths": {
-      "react-native-video": ["../../src/index"]
+      "react-native-video": ["../../src/index"],
+      "react": ["./node_modules/@types/react"]
     }
   },
   "include": ["src", "**/*.js"],

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -13,7 +13,6 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     private var _player: AVPlayer?
     private var _playerItem: AVPlayerItem?
     private var _source: VideoSource?
-    private var _playerBufferEmpty = true
     private var _playerLayer: AVPlayerLayer?
     private var _chapters: [Chapter]?
 
@@ -1118,6 +1117,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     }
 
     func handleReadyForDisplay(changeObject _: Any, change _: NSKeyValueObservedChange<Bool>) {
+        onVideoBuffer?(["isBuffering": false, "target": reactTag as Any])
         onReadyForDisplay?([
             "target": reactTag,
         ])
@@ -1248,16 +1248,11 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     }
 
     func handlePlaybackBufferKeyEmpty(playerItem _: AVPlayerItem, change _: NSKeyValueObservedChange<Bool>) {
-        _playerBufferEmpty = true
         onVideoBuffer?(["isBuffering": true, "target": reactTag as Any])
     }
 
     // Continue playing (or not if paused) after being paused due to hitting an unbuffered zone.
     func handlePlaybackLikelyToKeepUp(playerItem _: AVPlayerItem, change _: NSKeyValueObservedChange<Bool>) {
-        if (!(_controls || _fullscreenPlayerPresented) || _playerBufferEmpty) && ((_playerItem?.isPlaybackLikelyToKeepUp) == true) {
-            setPaused(_paused)
-        }
-        _playerBufferEmpty = false
         onVideoBuffer?(["isBuffering": false, "target": reactTag as Any])
     }
 
@@ -1368,7 +1363,6 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             item.seek(to: _source?.cropStart != nil ? CMTime(value: _source!.cropStart!, timescale: 1000) : CMTime.zero, completionHandler: nil)
             self.applyModifiers()
         } else {
-            self.setPaused(true)
             _playerObserver.removePlayerTimeObserver()
         }
     }

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -29,7 +29,9 @@ export type ReactVideoSourceProperties = {
 };
 
 export type ReactVideoSource = Readonly<
-  ReactVideoSourceProperties | NodeRequire
+  Omit<ReactVideoSourceProperties, 'uri'> & {
+    uri?: string | NodeRequire;
+  }
 >;
 
 export type DebugConfig = Readonly<{

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,7 @@
 import type {Component, RefObject, ComponentClass} from 'react';
 import {Image, findNodeHandle} from 'react-native';
-import type {ImageSourcePropType} from 'react-native';
 import type {ReactVideoSource, ReactVideoSourceProperties} from './types/video';
 
-type Source = ImageSourcePropType | ReactVideoSource;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function generateHeaderForNative(obj?: Record<string, any>) {
@@ -13,12 +11,13 @@ export function generateHeaderForNative(obj?: Record<string, any>) {
   return Object.entries(obj).map(([key, value]) => ({key, value}));
 }
 
+type Source = ImageSourcePropType | ReactVideoSource;
 export function resolveAssetSourceForVideo(
-  source: Source,
+  source: ReactVideoSource,
 ): ReactVideoSourceProperties {
-  if (typeof source === 'number') {
+  if (typeof source.uri === 'number') {
     return {
-      uri: Image.resolveAssetSource(source).uri,
+      uri: Image.resolveAssetSource(source.uri).uri,
     };
   }
   return source as ReactVideoSourceProperties;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,12 +15,20 @@ type Source = ImageSourcePropType | ReactVideoSource;
 export function resolveAssetSourceForVideo(
   source: ReactVideoSource,
 ): ReactVideoSourceProperties {
+  // This is deprecated, but we need to support it for backward compatibility
+  if (typeof source === 'number') {
+    return {
+      uri: Image.resolveAssetSource(source).uri,
+    };
+  }
+
   if (typeof source.uri === 'number') {
     return {
       ...source,
       uri: Image.resolveAssetSource(source.uri).uri,
     };
   }
+
   return source as ReactVideoSourceProperties;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,7 @@ export function resolveAssetSourceForVideo(
 ): ReactVideoSourceProperties {
   if (typeof source.uri === 'number') {
     return {
+      ...source,
       uri: Image.resolveAssetSource(source.uri).uri,
     };
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,6 @@
 import type {Component, RefObject, ComponentClass} from 'react';
-import {Image, findNodeHandle} from 'react-native';
+import {Image, findNodeHandle, type ImageSourcePropType} from 'react-native';
 import type {ReactVideoSource, ReactVideoSourceProperties} from './types/video';
-
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function generateHeaderForNative(obj?: Record<string, any>) {
@@ -12,8 +11,9 @@ export function generateHeaderForNative(obj?: Record<string, any>) {
 }
 
 type Source = ImageSourcePropType | ReactVideoSource;
+
 export function resolveAssetSourceForVideo(
-  source: ReactVideoSource,
+  source: Source,
 ): ReactVideoSourceProperties {
   // This is deprecated, but we need to support it for backward compatibility
   if (typeof source === 'number') {
@@ -22,7 +22,7 @@ export function resolveAssetSourceForVideo(
     };
   }
 
-  if (typeof source.uri === 'number') {
+  if ('uri' in source && typeof source.uri === 'number') {
     return {
       ...source,
       uri: Image.resolveAssetSource(source.uri).uri,


### PR DESCRIPTION
## Summary

Fix: https://github.com/react-native-video/react-native-video/issues/3568 and https://github.com/react-native-video/react-native-video/issues/2954 

Do not pause playback in handlePlaybackLikelyToKeepUp and in seek call

start reviewing onBuffer event (not yet clean)

### Motivation
It doesn't make sens to pause the playback in that case. see apple documentation about this event: https://developer.apple.com/documentation/avfoundation/avplayeritem/1390348-playbacklikelytokeepup
Even if buffer is empty, we don't want to pause the playback, the player shall automatically resume it.

## Test plan
Tested with the sample.
I also ensure pip works fine