### PR TITLE
fix(ios): fix startPosition, cropStart and cropEnd to handle float values correctly

### DIFF
--- a/ios/Video/DataStructures/VideoSource.swift
+++ b/ios/Video/DataStructures/VideoSource.swift
@@ -5,7 +5,7 @@ struct VideoSource {
     let isAsset: Bool
     let shouldCache: Bool
     let requestHeaders: [String: Any]?
-    let startPosition: Int64?
+    let startPosition: Float64?
     let cropStart: Int64?
     let cropEnd: Int64?
     // Custom Metadata
@@ -51,9 +51,9 @@ struct VideoSource {
         } else {
             self.requestHeaders = nil
         }
-        self.startPosition = json["startPosition"] as? Int64
-        self.cropStart = json["cropStart"] as? Int64
-        self.cropEnd = json["cropEnd"] as? Int64
+        self.startPosition = json["startPosition"] as? Float64
+        self.cropStart = (json["cropStart"] as? Float64).flatMap { Int64(round($0)) }
+        self.cropEnd = (json["cropEnd"] as? Float64).flatMap { Int64(round($0)) }
         self.title = json["title"] as? String
         self.subtitle = json["subtitle"] as? String
         self.description = json["description"] as? String

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -741,13 +741,13 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     }
 
     func setPlaybackRange(_ item: AVPlayerItem!, withCropStart cropStart: Int64?, withCropEnd cropEnd: Int64?) {
-        if let cropStart = cropStart {
+        if let cropStart {
             let start = CMTimeMake(value: cropStart, timescale: 1000)
             item.reversePlaybackEndTime = start
             _pendingSeekTime = Float(CMTimeGetSeconds(start))
             _pendingSeek = true
         }
-        if let cropEnd = cropEnd {
+        if let cropEnd {
             item.forwardPlaybackEndTime = CMTimeMake(value: cropEnd, timescale: 1000)
         }
     }

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -367,7 +367,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                     }
 
                     if let startPosition = self._source?.startPosition {
-                        self._startPosition = Float64(startPosition) / 1000
+                        self._startPosition = startPosition / 1000
                     }
 
                     #if USE_VIDEO_CACHING

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -398,7 +398,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                     self._playerItem = playerItem
                     self._playerObserver.playerItem = self._playerItem
                     self.setPreferredForwardBufferDuration(self._preferredForwardBufferDuration)
-                    self.setPlaybackRange(playerItem, withVideoStart: self._source?.cropStart, withVideoEnd: self._source?.cropEnd)
+                    self.setPlaybackRange(playerItem, withCropStart: self._source?.cropStart, withCropEnd: self._source?.cropEnd)
                     self.setFilter(self._filterName)
                     if let maxBitRate = self._maxBitRate {
                         self._playerItem?.preferredPeakBitRate = Double(maxBitRate)
@@ -740,15 +740,15 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         }
     }
 
-    func setPlaybackRange(_ item: AVPlayerItem!, withVideoStart videoStart: Int64?, withVideoEnd videoEnd: Int64?) {
-        if videoStart != nil {
-            let start = CMTimeMake(value: videoStart!, timescale: 1000)
+    func setPlaybackRange(_ item: AVPlayerItem!, withCropStart cropStart: Int64?, withCropEnd cropEnd: Int64?) {
+        if let cropStart = cropStart {
+            let start = CMTimeMake(value: cropStart, timescale: 1000)
             item.reversePlaybackEndTime = start
             _pendingSeekTime = Float(CMTimeGetSeconds(start))
             _pendingSeek = true
         }
-        if videoEnd != nil {
-            item.forwardPlaybackEndTime = CMTimeMake(value: videoEnd!, timescale: 1000)
+        if let cropEnd = cropEnd {
+            item.forwardPlaybackEndTime = CMTimeMake(value: cropEnd, timescale: 1000)
         }
     }
 


### PR DESCRIPTION
## Summary
fix startPosition, cropStart and cropEnd to handle float values correctly

### Motivation

### Changes
startPosition, cropStart, and cropEnd now accept float values and work correctly

## Test plan