### PR TITLE
fix(android): ensure rate is never set to 0

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1902,6 +1902,8 @@ public class ReactExoplayerView extends FrameLayout implements
     }
 
     public void setRateModifier(float newRate) {
+        if (rate < 0) return;
+
         rate = newRate;
 
         if (player != null) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1902,7 +1902,10 @@ public class ReactExoplayerView extends FrameLayout implements
     }
 
     public void setRateModifier(float newRate) {
-        if (rate < 0) return;
+        if (newRate <= 0) {
+            DebugLog.w(TAG, "cannot set rate <= 0");
+            return;
+        }
 
         rate = newRate;
 

--- a/docs/pages/component/props.mdx
+++ b/docs/pages/component/props.mdx
@@ -434,8 +434,8 @@ Default: 250.0
 
 Speed at which the media should play.
 
-- **0.0** - Pauses the video
-- **1.0** - Play at normal speed
+- **0.0** - Pauses the video (iOS only)
+- **1.0** - Play at normal speed (default)
 - **Other values** - Slow down or speed up playback
 
 ### `repeat`

--- a/examples/basic/src/VideoPlayer.tsx
+++ b/examples/basic/src/VideoPlayer.tsx
@@ -638,11 +638,13 @@ class VideoPlayer extends Component {
                 />
               </View>
               <View style={styles.generalControls}>
+                {/* shall be replaced by slider */}
                 <MultiValueControl
-                  values={[0.25, 0.5, 1.0, 1.5, 2.0]}
+                  values={[0, 0.25, 0.5, 1.0, 1.5, 2.0]}
                   onPress={this.onRateSelected}
                   selected={this.state.rate}
                 />
+                {/* shall be replaced by slider */}
                 <MultiValueControl
                   values={[0.5, 1, 1.5]}
                   onPress={this.onVolumeSelected}


### PR DESCRIPTION
## Summary
- Add safety check to ensure rate is never set to 0 on android
- update and clarify documentation

### Motivation
Fix: https://github.com/react-native-video/react-native-video/issues/3071 

### Changes
- documentation update
- add safety check on android
- add 0 playback speed in sample to test easily

## Test plan
- press 0 playback speed in the sample