### PR TITLE
feat(android): allow limit max video resolution to screen resolution

### DIFF
--- a/android/src/main/java/com/brentvatne/common/api/LimitMode.kt
+++ b/android/src/main/java/com/brentvatne/common/api/LimitMode.kt
@@ -1,0 +1,37 @@
+package com.brentvatne.common.api
+
+import androidx.annotation.StringDef
+
+internal object LimitMode {
+    /**
+     * Don't limit video resolution
+     */
+    const val DISABLED = "disabled"
+
+    /**
+     * Limit video resolution to screen resolution
+     */
+    const val SCREEN_SIZE = "screen"
+
+    /**
+     * Limit video resolution to video surface size
+     */
+    const val VIDEO_SURFACE = "videoSurface"
+
+    @JvmStatic
+    @Mode
+    fun toLimitMode(ordinal: String): String =
+        when (ordinal) {
+            SCREEN_SIZE -> SCREEN_SIZE
+            VIDEO_SURFACE -> VIDEO_SURFACE
+            else -> DISABLED
+        }
+
+    @Retention(AnnotationRetention.SOURCE)
+    @StringDef(
+        SCREEN_SIZE,
+        VIDEO_SURFACE,
+        DISABLED
+    )
+    annotation class Mode
+}

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -17,7 +17,6 @@ import android.os.Looper;
 import android.os.Message;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -624,7 +624,7 @@ public class ReactExoplayerView extends FrameLayout implements
         int backBufferMs = backBufferDurationMs;
 
         if(freeMemory < (self.enableBackBufferAvailableMemory * 1000 * 1000)) {
-            Log.w("LoadControl", "Available memory is less than required to enable back buffer, setting to 0ms!");
+            DebugLog.w("LoadControl", "Available memory is less than required to enable back buffer, setting to 0ms!");
             backBufferMs = 0;
         }
 

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -83,6 +83,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_FULLSCREEN = "fullscreen";
     private static final String PROP_USE_TEXTURE_VIEW = "useTextureView";
     private static final String PROP_SECURE_VIEW = "useSecureView";
+    private  static final String PROP_LIMIT_MAX_RESOLUTION = "limitMaxResolution";
     private static final String PROP_SELECTED_VIDEO_TRACK = "selectedVideoTrack";
     private static final String PROP_SELECTED_VIDEO_TRACK_TYPE = "type";
     private static final String PROP_SELECTED_VIDEO_TRACK_VALUE = "value";
@@ -389,6 +390,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_SECURE_VIEW, defaultBoolean = true)
     public void useSecureView(final ReactExoplayerView videoView, final boolean useSecureView) {
         videoView.useSecureView(useSecureView);
+    }
+
+    @ReactProp(name = PROP_LIMIT_MAX_RESOLUTION, defaultBoolean = false)
+    public void setLimitMaxResolution(final ReactExoplayerView videoView, final boolean limitMaxResolution) {
+        videoView.setLimitMaxResolution(limitMaxResolution);
     }
 
     @ReactProp(name = PROP_HIDE_SHUTTER_VIEW, defaultBoolean = false)

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -10,6 +10,7 @@ import androidx.media3.common.util.Util;
 import androidx.media3.datasource.RawResourceDataSource;
 import androidx.media3.exoplayer.DefaultLoadControl;
 
+import com.brentvatne.common.api.LimitMode;
 import com.brentvatne.common.api.ResizeMode;
 import com.brentvatne.common.api.SubtitleStyle;
 import com.brentvatne.common.react.VideoEventEmitter;
@@ -392,9 +393,9 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
         videoView.useSecureView(useSecureView);
     }
 
-    @ReactProp(name = PROP_LIMIT_MAX_RESOLUTION, defaultBoolean = false)
-    public void setLimitMaxResolution(final ReactExoplayerView videoView, final boolean limitMaxResolution) {
-        videoView.setLimitMaxResolution(limitMaxResolution);
+    @ReactProp(name = PROP_LIMIT_MAX_RESOLUTION)
+    public void setLimitMaxResolution(final ReactExoplayerView videoView, final String limitMode) {
+        videoView.setLimitMaxResolution(LimitMode.toLimitMode(limitMode));
     }
 
     @ReactProp(name = PROP_HIDE_SHUTTER_VIEW, defaultBoolean = false)

--- a/docs/pages/component/props.mdx
+++ b/docs/pages/component/props.mdx
@@ -287,10 +287,11 @@ Controls whether the ExoPlayer shutter view (black screen while loading) is enab
 
 <PlatformsList types={['Android']} />
 
-Controls whether to limit the available videotracks to not exceed device screen resolution. If enabled the video track list will be limited to resolutions that are smaller or equal to the screen resolution of the device (this also affects automatic video track selection).
+Controls whether to limit the available videotracks to not exceed device screen resolution or video surface. If enabled the video track list will be limited to resolutions that are smaller or equal to the screen resolution of the device (this also affects automatic video track selection).
 
-- **false (default)** - Don't limit the video track resolution.
-- **true** - Limit the video track resolution to the device screen resolution.
+- **disabled (default)** - Don't limit the video track resolution.
+- **screen** - Limit the video track resolution to the device screen resolution.
+- **videoSurface** - Limit the video track resoultion to the video surface.
 
 Example:
 ```

--- a/docs/pages/component/props.mdx
+++ b/docs/pages/component/props.mdx
@@ -283,6 +283,20 @@ Controls whether the ExoPlayer shutter view (black screen while loading) is enab
 - **false (default)** - Show shutter view
 - **true** - Hide shutter view
 
+### `limitMaxResolution`
+
+<PlatformsList types={['Android']} />
+
+Controls whether to limit the available videotracks to not exceed device screen resolution. If enabled the video track list will be limited to resolutions that are smaller or equal to the screen resolution of the device (this also affects automatic video track selection).
+
+- **false (default)** - Don't limit the video track resolution.
+- **true** - Limit the video track resolution to the device screen resolution.
+
+Example:
+```
+limitMaxResolutionToScreenSize={true}
+```
+
 ### `ignoreSilentSwitch`
 
 <PlatformsList types={['iOS', 'visionOS']} />

--- a/examples/basic/src/VideoPlayer.tsx
+++ b/examples/basic/src/VideoPlayer.tsx
@@ -756,6 +756,7 @@ class VideoPlayer extends Component {
           ref={(ref: VideoRef) => {
             this.video = ref;
           }}
+          limitMaxResolution="disabled"
           source={this.srcList[this.state.srcListId]}
           adTagUrl={this.srcList[this.state.srcListId]?.adTagUrl}
           drm={this.srcList[this.state.srcListId]?.drm}

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -497,7 +497,10 @@ export interface VideoNativeProps extends ViewProps {
   trackId?: string; // Android
   useTextureView?: boolean; // Android
   useSecureView?: boolean; // Android
-  limitMaxResolution?: boolean; // Android
+  limitMaxResolution?: WithDefault<
+    'screen' | 'videoArea' | 'disabled',
+    'disabled'
+  >; // Android
   onVideoLoad?: DirectEventHandler<OnLoadData>;
   onVideoLoadStart?: DirectEventHandler<OnLoadStartData>;
   onVideoAspectRatio?: DirectEventHandler<OnVideoAspectRatioData>;

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -497,6 +497,7 @@ export interface VideoNativeProps extends ViewProps {
   trackId?: string; // Android
   useTextureView?: boolean; // Android
   useSecureView?: boolean; // Android
+  limitMaxResolution?: boolean; // Android
   onVideoLoad?: DirectEventHandler<OnLoadData>;
   onVideoLoadStart?: DirectEventHandler<OnLoadStartData>;
   onVideoAspectRatio?: DirectEventHandler<OnVideoAspectRatioData>;

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -180,6 +180,8 @@ export enum PosterResizeModeType {
 
 export type AudioOutput = 'speaker' | 'earpiece';
 
+type LimitMaxResolutionMode = 'screen' | 'videoArea' | 'disabled';
+
 export interface ReactVideoProps extends ReactVideoEvents, ViewProps {
   source?: ReactVideoSource;
   drm?: Drm;
@@ -231,6 +233,7 @@ export interface ReactVideoProps extends ReactVideoEvents, ViewProps {
   trackId?: string; // Android
   useTextureView?: boolean; // Android
   useSecureView?: boolean; // Android
+  limitMaxResolution?: LimitMaxResolutionMode; // Android
   volume?: number;
   localSourceEncryptionKeyScheme?: string;
   debug?: DebugConfig;


### PR DESCRIPTION
## Summary
port of 
- #2722

### Motivation
- Allows to limit max video resolution to screen resolution - this should help on low end devices 
- Allows to limit bandwidth used on CDN side

### Changes
- added new prop `limitMaxResolution`
- updated docs

## Test plan
- [x] CI pass
- [x] Tested in `basic` example