### PR TITLE
fix(ios): fix PiP callback

### DIFF
--- a/ios/Video/Features/RCTPictureInPicture.swift
+++ b/ios/Video/Features/RCTPictureInPicture.swift
@@ -6,27 +6,33 @@ import React
 
 #if os(iOS)
     class RCTPictureInPicture: NSObject, AVPictureInPictureControllerDelegate {
-        private var _onPictureInPictureStatusChanged: (() -> Void)?
+        private var _onPictureInPictureEnter: (() -> Void)?
+        private var _onPictureInPictureExit: (() -> Void)?
         private var _onRestoreUserInterfaceForPictureInPictureStop: (() -> Void)?
         private var _restoreUserInterfaceForPIPStopCompletionHandler: ((Bool) -> Void)?
         private var _pipController: AVPictureInPictureController?
         private var _isActive = false
 
-        init(_ onPictureInPictureStatusChanged: (() -> Void)? = nil, _ onRestoreUserInterfaceForPictureInPictureStop: (() -> Void)? = nil) {
-            _onPictureInPictureStatusChanged = onPictureInPictureStatusChanged
+        init(
+            _ onPictureInPictureEnter: (() -> Void)? = nil,
+            _ onPictureInPictureExit: (() -> Void)? = nil,
+            _ onRestoreUserInterfaceForPictureInPictureStop: (() -> Void)? = nil
+        ) {
+            _onPictureInPictureEnter = onPictureInPictureEnter
+            _onPictureInPictureExit = onPictureInPictureExit
             _onRestoreUserInterfaceForPictureInPictureStop = onRestoreUserInterfaceForPictureInPictureStop
         }
 
         func pictureInPictureControllerDidStartPictureInPicture(_: AVPictureInPictureController) {
-            guard let _onPictureInPictureStatusChanged else { return }
+            guard let _onPictureInPictureEnter else { return }
 
-            _onPictureInPictureStatusChanged()
+            _onPictureInPictureEnter()
         }
 
         func pictureInPictureControllerDidStopPictureInPicture(_: AVPictureInPictureController) {
-            guard let _onPictureInPictureStatusChanged else { return }
+            guard let _onPictureInPictureExit else { return }
 
-            _onPictureInPictureStatusChanged()
+            _onPictureInPictureExit()
         }
 
         func pictureInPictureController(

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -120,12 +120,12 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     @objc var onTextTrackDataChanged: RCTDirectEventBlock?
 
     @objc
-    func _onPictureInPictureStatusChanged() {
+    func _onPictureInPictureEnter() {
         onPictureInPictureStatusChanged?(["isActive": NSNumber(value: true)])
     }
 
     @objc
-    func _onRestoreUserInterfaceForPictureInPictureStop() {
+    func _onPictureInPictureExit() {
         onPictureInPictureStatusChanged?(["isActive": NSNumber(value: false)])
     }
 
@@ -143,9 +143,11 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
         #if os(iOS)
             _pip = RCTPictureInPicture({ [weak self] in
-                self?._onPictureInPictureStatusChanged()
+                self?._onPictureInPictureEnter()
             }, { [weak self] in
-                self?._onRestoreUserInterfaceForPictureInPictureStop()
+                self?._onPictureInPictureExit()
+            }, { [weak self] in
+                self?.onRestoreUserInterfaceForPictureInPictureStop?([:])
             })
         #endif
 


### PR DESCRIPTION
## Summary

`onPictureInPictureStatusChanged` PiP callback was called twice after PiP exit with bad value, this should be fixed.

`onRestoreUserInterfaceForPictureInPictureStop` was never called,  this should be fixed.

### Motivation

should fix #3598 & #3501

### Changes

- We rename internal call back to`onPictureInPictureEnter` & `onPictureInPictureExit` for better understanding 
- We do not call `onPictureInPictureStatusChanged` twice on PiP exit
- We do call `onRestoreUserInterfaceForPictureInPictureStop` on PiP exit

## Test plan

- Install & run https://github.com/gkueny/PiPStatusChangedFireTwice
- Reproduce the issues 
- Install patch 
```sh
yarn add react-native-video@https://github.com/gkueny/react-native-video.git#20d1576c373ba81718c6788498e26cacd4d963e3
```
- Check that issues are fixed