### PR TITLE
fix(ios): call PictureInPicture callbacks with native controls

### DIFF
--- a/ios/Video/Features/RCTPlayerObserver.swift
+++ b/ios/Video/Features/RCTPlayerObserver.swift
@@ -29,6 +29,7 @@ protocol RCTPlayerObserverHandler: RCTPlayerObserverHandlerObjc {
     func handleLegibleOutput(strings: [NSAttributedString])
     func handlePictureInPictureEnter()
     func handlePictureInPictureExit()
+    func handleRestoreUserInterfaceForPictureInPictureStop()
 }
 
 // MARK: - RCTPlayerObserver
@@ -107,6 +108,7 @@ class RCTPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate, AVPla
     private var _playerLayerReadyForDisplayObserver: NSKeyValueObservation?
     private var _playerViewControllerOverlayFrameObserver: NSKeyValueObservation?
     private var _playerTracksObserver: NSKeyValueObservation?
+    private var _restoreUserInterfaceForPIPStopCompletionHandler: ((Bool) -> Void)?
 
     deinit {
         if let _handlers {
@@ -304,5 +306,23 @@ class RCTPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate, AVPla
         guard let _handlers else { return }
 
         _handlers.handlePictureInPictureExit()
+    }
+
+    func playerViewController(
+        _: AVPlayerViewController,
+        restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void
+    ) {
+        guard let _handlers else { return }
+
+        _handlers.handleRestoreUserInterfaceForPictureInPictureStop()
+
+        _restoreUserInterfaceForPIPStopCompletionHandler = completionHandler
+    }
+
+    func setRestoreUserInterfaceForPIPStopCompletionHandler(_ restore: Bool) {
+        guard let _restoreUserInterfaceForPIPStopCompletionHandler else { return }
+
+        _restoreUserInterfaceForPIPStopCompletionHandler(restore)
+        self._restoreUserInterfaceForPIPStopCompletionHandler = nil
     }
 }

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -129,6 +129,14 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         onPictureInPictureStatusChanged?(["isActive": NSNumber(value: false)])
     }
 
+    func handlePictureInPictureEnter() {
+        onPictureInPictureStatusChanged?(["isActive": NSNumber(value: true)])
+    }
+
+    func handlePictureInPictureExit() {
+        onPictureInPictureStatusChanged?(["isActive": NSNumber(value: false)])
+    }
+
     func isPipEnabled() -> Bool {
         return _pictureInPictureEnabled
     }

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -137,6 +137,10 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         onPictureInPictureStatusChanged?(["isActive": NSNumber(value: false)])
     }
 
+    func handleRestoreUserInterfaceForPictureInPictureStop() {
+        onRestoreUserInterfaceForPictureInPictureStop?([:])
+    }
+
     func isPipEnabled() -> Bool {
         return _pictureInPictureEnabled
     }
@@ -599,7 +603,11 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     @objc
     func setRestoreUserInterfaceForPIPStopCompletionHandler(_ restore: Bool) {
         #if os(iOS)
-            _pip?.setRestoreUserInterfaceForPIPStopCompletionHandler(restore)
+            if _pip != nil {
+                _pip?.setRestoreUserInterfaceForPIPStopCompletionHandler(restore)
+            } else {
+                _playerObserver.setRestoreUserInterfaceForPIPStopCompletionHandler(restore)
+            }
         #endif
     }
 


### PR DESCRIPTION
## Summary

When we enter PiP from native controls, `onPictureInPictureStatusChanged` is never called.
When we exit PiP after enter from native controls, `onPictureInPictureStatusChanged` & `onRestoreUserInterfaceForPictureInPictureStop` are never called.

Should fix https://github.com/react-native-video/react-native-video/issues/3602

### Motivation

Be notified when PictureInPicture status changed no matter how you enter this mode.
Has `onRestoreUserInterfaceForPictureInPictureStop` callback fire no matter how you exit PiP mode.

### Changes

We add RCTPlayerObserver as playerViewController delegate to be notified with PiP lifecycle

## Test plan

- Install https://github.com/gkueny/NativeControlsPiPCallback
- Reproduce the issue
- Install patch
```sh
yarn add react-native-video@https://github.com/gkueny/react-native-video.git#72ba955c464dc15a3db935de6fe8542c2b3cc0d3
```
- Validate that `onPictureInPictureStatusChanged` is called if you enter PiP mode from native controls
- Validate that `onPictureInPictureStatusChanged` is called if you exit PiP mode after enter it from native controls
- Validate that `onRestoreUserInterfaceForPictureInPictureStop `is called if you exit PiP mode after enter it from native controls
