### PR TITLE
fix: inject onGetLicense prop properly for detect user defined or not

### DIFF
--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -478,7 +478,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           }
         }
       },
-      [drm?.getLicense, useExternalGetLicense],
+      [drm, useExternalGetLicense],
     );
 
     useImperativeHandle(

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -429,9 +429,11 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       [onAspectRatio],
     );
 
+    const useExternalGetLicense = drm?.getLicense instanceof Function;
+
     const onGetLicense = useCallback(
       (event: NativeSyntheticEvent<OnGetLicenseData>) => {
-        if (drm && drm.getLicense instanceof Function) {
+        if (useExternalGetLicense) {
           const data = event.nativeEvent;
           if (data && data.spcBase64) {
             const getLicenseOverride = drm.getLicense(
@@ -476,7 +478,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           }
         }
       },
-      [drm],
+      [drm?.getLicense, useExternalGetLicense],
     );
 
     useImperativeHandle(
@@ -518,7 +520,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           selectedTextTrack={_selectedTextTrack}
           selectedAudioTrack={_selectedAudioTrack}
           selectedVideoTrack={_selectedVideoTrack}
-          onGetLicense={onGetLicense}
+          onGetLicense={useExternalGetLicense ? onGetLicense : undefined}
           onVideoLoad={onVideoLoad}
           onVideoLoadStart={onVideoLoadStart}
           onVideoError={onVideoError}


### PR DESCRIPTION
## Summary
fix: inject onGetLicense prop properly for detect user defined or not

### Motivation
RCTVideo's onGetLicense property is always not nil even user doesn't define getLicense function

### Changes

## Test plan