### PR TITLE
fix!(android): improve and backBufferDurationMs. mainly let exoplayer manage the prop

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -191,6 +191,7 @@ public class ReactExoplayerView extends FrameLayout implements
     private int maxBufferMs = DefaultLoadControl.DEFAULT_MAX_BUFFER_MS;
     private int bufferForPlaybackMs = DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS;
     private int bufferForPlaybackAfterRebufferMs = DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS;
+    private int backBufferDurationMs = DefaultLoadControl.DEFAULT_BACK_BUFFER_DURATION_MS;
     private double maxHeapAllocationPercent = ReactExoplayerView.DEFAULT_MAX_HEAP_ALLOCATION_PERCENT;
     private double minBackBufferMemoryReservePercent = ReactExoplayerView.DEFAULT_MIN_BACK_BUFFER_MEMORY_RESERVE;
     private double minBufferMemoryReservePercent = ReactExoplayerView.DEFAULT_MIN_BUFFER_MEMORY_RESERVE;
@@ -198,7 +199,6 @@ public class ReactExoplayerView extends FrameLayout implements
     private Runnable mainRunnable;
 
     // Props from React
-    private int backBufferDurationMs = DefaultLoadControl.DEFAULT_BACK_BUFFER_DURATION_MS;
     private Uri srcUri;
     private long startPositionMs = -1;
     private long cropStartMs = -1;
@@ -1944,20 +1944,6 @@ public class ReactExoplayerView extends FrameLayout implements
         exoPlayerView.setFocusable(this.focusable);
     }
 
-    public void setBackBufferDurationMs(int backBufferDurationMs) {
-        Runtime runtime = Runtime.getRuntime();
-        long usedMemory = runtime.totalMemory() - runtime.freeMemory();
-        long freeMemory = runtime.maxMemory() - usedMemory;
-        long reserveMemory = (long)minBackBufferMemoryReservePercent * runtime.maxMemory();
-        if (reserveMemory > freeMemory) {
-            // We don't have enough memory in reserve so we will
-            DebugLog.w("ExoPlayer Warning", "Not enough reserve memory, setting back buffer to 0ms to reduce memory pressure!");
-            this.backBufferDurationMs = 0;
-            return;
-        }
-        this.backBufferDurationMs = backBufferDurationMs;
-    }
-
     public void setContentStartTime(int contentStartTime) {
         this.contentStartTime = contentStartTime;
     }
@@ -2043,7 +2029,7 @@ public class ReactExoplayerView extends FrameLayout implements
         exoPlayerView.setHideShutterView(hideShutterView);
     }
 
-    public void setBufferConfig(int newMinBufferMs, int newMaxBufferMs, int newBufferForPlaybackMs, int newBufferForPlaybackAfterRebufferMs, double newMaxHeapAllocationPercent, double newMinBackBufferMemoryReservePercent, double newMinBufferMemoryReservePercent) {
+    public void setBufferConfig(int newMinBufferMs, int newMaxBufferMs, int newBufferForPlaybackMs, int newBufferForPlaybackAfterRebufferMs, double newMaxHeapAllocationPercent, double newMinBackBufferMemoryReservePercent, double newMinBufferMemoryReservePercent, int newBackBufferDurationMs) {
         minBufferMs = newMinBufferMs;
         maxBufferMs = newMaxBufferMs;
         bufferForPlaybackMs = newBufferForPlaybackMs;
@@ -2051,6 +2037,7 @@ public class ReactExoplayerView extends FrameLayout implements
         maxHeapAllocationPercent = newMaxHeapAllocationPercent;
         minBackBufferMemoryReservePercent = newMinBackBufferMemoryReservePercent;
         minBufferMemoryReservePercent = newMinBufferMemoryReservePercent;
+        backBufferDurationMs = newBackBufferDurationMs;
         releasePlayer();
         initializePlayer();
     }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -58,7 +58,6 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_MUTED = "muted";
     private static final String PROP_AUDIO_OUTPUT = "audioOutput";
     private static final String PROP_VOLUME = "volume";
-    private static final String PROP_BACK_BUFFER_DURATION_MS = "backBufferDurationMs";
     private static final String PROP_BUFFER_CONFIG = "bufferConfig";
     private static final String PROP_BUFFER_CONFIG_MIN_BUFFER_MS = "minBufferMs";
     private static final String PROP_BUFFER_CONFIG_MAX_BUFFER_MS = "maxBufferMs";
@@ -67,6 +66,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_BUFFER_CONFIG_MAX_HEAP_ALLOCATION_PERCENT = "maxHeapAllocationPercent";
     private static final String PROP_BUFFER_CONFIG_MIN_BACK_BUFFER_MEMORY_RESERVE_PERCENT = "minBackBufferMemoryReservePercent";
     private static final String PROP_BUFFER_CONFIG_MIN_BUFFER_MEMORY_RESERVE_PERCENT = "minBufferMemoryReservePercent";
+    private static final String PROP_BUFFER_CONFIG_BACK_BUFFER_DURATION_MS = "backBufferDurationMs";
     private static final String PROP_PREVENTS_DISPLAY_SLEEP_DURING_VIDEO_PLAYBACK = "preventsDisplaySleepDuringVideoPlayback";
     private static final String PROP_PROGRESS_UPDATE_INTERVAL = "progressUpdateInterval";
     private static final String PROP_REPORT_BANDWIDTH = "reportBandwidth";
@@ -356,11 +356,6 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
         videoView.setFocusable(focusable);
     }
 
-    @ReactProp(name = PROP_BACK_BUFFER_DURATION_MS, defaultInt = 0)
-    public void setBackBufferDurationMs(final ReactExoplayerView videoView, final int backBufferDurationMs) {
-        videoView.setBackBufferDurationMs(backBufferDurationMs);
-    }
-
     @ReactProp(name = PROP_CONTENT_START_TIME, defaultInt = -1)
     public void setContentStartTime(final ReactExoplayerView videoView, final int contentStartTime) {
         videoView.setContentStartTime(contentStartTime);
@@ -417,6 +412,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
         int maxBufferMs = DefaultLoadControl.DEFAULT_MAX_BUFFER_MS;
         int bufferForPlaybackMs = DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS;
         int bufferForPlaybackAfterRebufferMs = DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS;
+        int backBufferDurationMs = DefaultLoadControl.DEFAULT_BACK_BUFFER_DURATION_MS;
         double maxHeapAllocationPercent = ReactExoplayerView.DEFAULT_MAX_HEAP_ALLOCATION_PERCENT;
         double minBackBufferMemoryReservePercent = ReactExoplayerView.DEFAULT_MIN_BACK_BUFFER_MEMORY_RESERVE;
         double minBufferMemoryReservePercent = ReactExoplayerView.DEFAULT_MIN_BUFFER_MEMORY_RESERVE;
@@ -429,7 +425,8 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
             maxHeapAllocationPercent = ReactBridgeUtils.safeGetDouble(bufferConfig, PROP_BUFFER_CONFIG_MAX_HEAP_ALLOCATION_PERCENT, maxHeapAllocationPercent);
             minBackBufferMemoryReservePercent = ReactBridgeUtils.safeGetDouble(bufferConfig, PROP_BUFFER_CONFIG_MIN_BACK_BUFFER_MEMORY_RESERVE_PERCENT, minBackBufferMemoryReservePercent);
             minBufferMemoryReservePercent = ReactBridgeUtils.safeGetDouble(bufferConfig, PROP_BUFFER_CONFIG_MIN_BUFFER_MEMORY_RESERVE_PERCENT, minBufferMemoryReservePercent);
-            videoView.setBufferConfig(minBufferMs, maxBufferMs, bufferForPlaybackMs, bufferForPlaybackAfterRebufferMs, maxHeapAllocationPercent, minBackBufferMemoryReservePercent, minBufferMemoryReservePercent);
+            backBufferDurationMs = ReactBridgeUtils.safeGetInt(bufferConfig, PROP_BUFFER_CONFIG_BACK_BUFFER_DURATION_MS, backBufferDurationMs);
+            videoView.setBufferConfig(minBufferMs, maxBufferMs, bufferForPlaybackMs, bufferForPlaybackAfterRebufferMs, maxHeapAllocationPercent, minBackBufferMemoryReservePercent, minBufferMemoryReservePercent, backBufferDurationMs);
         }
     }
 

--- a/docs/pages/component/props.mdx
+++ b/docs/pages/component/props.mdx
@@ -58,12 +58,6 @@ A Boolean value that indicates whether the player should automatically delay pla
 - **false** - Immediately starts playback
 - **true (default)** - Delays playback in order to minimize stalling
 
-### `backBufferDurationMs`
-
-<PlatformsList types={['Android']} />
-
-The number of milliseconds of buffer to keep before the current position. This allows rewinding without rebuffering within that duration.
-
 ### `bufferConfig`
 
 <PlatformsList types={['Android']} />
@@ -76,11 +70,11 @@ Adjust the buffer settings. This prop takes an object with one or more of the pr
 | maxBufferMs                       | number | The default maximum duration of media that the player will attempt to buffer, in milliseconds.                                                                                                  |
 | bufferForPlaybackMs               | number | The default duration of media that must be buffered for playback to start or resume following a user action such as a seek, in milliseconds.                                                    |
 | bufferForPlaybackAfterRebufferMs  | number | The default duration of media that must be buffered for playback to resume after a rebuffer, in milliseconds. A rebuffer is defined to be caused by buffer depletion rather than a user action. |
+| backBufferDurationMs              | number | The number of milliseconds of buffer to keep before the current position. This allows rewinding without rebuffering within that duration.                                                       |
 | maxHeapAllocationPercent          | number | The percentage of available heap that the video can use to buffer, between 0 and 1                                                                                                              |
 | minBackBufferMemoryReservePercent | number | The percentage of available app memory at which during startup the back buffer will be disabled, between 0 and 1                                                                                |
 | minBufferMemoryReservePercent     | number | The percentage of available app memory to keep in reserve that prevents buffer from using it, between 0 and 1                                                                                   |
 
-This prop should only be set when you are setting the source, changing it after the media is loaded will cause it to be reloaded.
 
 Example with default values:
 
@@ -89,7 +83,8 @@ bufferConfig={{
   minBufferMs: 15000,
   maxBufferMs: 50000,
   bufferForPlaybackMs: 2500,
-  bufferForPlaybackAfterRebufferMs: 5000
+  bufferForPlaybackAfterRebufferMs: 5000,
+  backBufferDurationMs: 120000,
 }}
 ```
 

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -108,6 +108,7 @@ type BufferConfig = Readonly<{
   bufferForPlaybackMs?: Float;
   bufferForPlaybackAfterRebufferMs?: Float;
   maxHeapAllocationPercent?: Float;
+  backBufferDurationMs?: Float; // Android
   minBackBufferMemoryReservePercent?: Float;
   minBufferMemoryReservePercent?: Float;
 }>;
@@ -484,7 +485,6 @@ export interface VideoNativeProps extends ViewProps {
   localSourceEncryptionKeyScheme?: string;
   debug?: DebugConfig;
 
-  backBufferDurationMs?: Int32; // Android
   bufferConfig?: BufferConfig; // Android
   contentStartTime?: Int32; // Android
   currentPlaybackTime?: Double; // Android

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -68,6 +68,7 @@ export type BufferConfig = {
   maxBufferMs?: number;
   bufferForPlaybackMs?: number;
   bufferForPlaybackAfterRebufferMs?: number;
+  backBufferDurationMs?: number; // Android
   maxHeapAllocationPercent?: number;
   minBackBufferMemoryReservePercent?: number;
   minBufferMemoryReservePercent?: number;
@@ -188,7 +189,6 @@ export interface ReactVideoProps extends ReactVideoEvents, ViewProps {
   audioOnly?: boolean;
   audioOutput?: AudioOutput; // Mobile
   automaticallyWaitsToMinimizeStalling?: boolean; // iOS
-  backBufferDurationMs?: number; // Android
   bufferConfig?: BufferConfig; // Android
   chapters?: Chapters[]; // iOS
   contentStartTime?: number; // Android


### PR DESCRIPTION
⚠️  BREAKING CHANGE: move backBufferDurationMs from root props to bufferConfig

## Summary
move backBufferDurationMs from root props to bufferConfig.
setBackBufferDurationMs was not working in case of low memory where exoplayer shall manage it by itself ...

### Motivation
Clean api and fix expected behavior
Will address: https://github.com/react-native-video/react-native-video/issues/2977

### Changes
move backBufferDurationMs from root props to bufferConfig.

## Test plan
Tested with sample:
- the the bufferingConfig prop and set backBufferDurationMs = 120000 (2 min)
- play a VOD during 1:30 min
- disconnect network
- seek backward
-> seek is done and playback continue (until end of buffered data)