### PR TITLE
chore(typescript)!: fix external loaded textTracks typing and add one in sample

### DIFF
--- a/examples/basic/src/VideoPlayer.tsx
+++ b/examples/basic/src/VideoPlayer.tsx
@@ -34,7 +34,8 @@ import Video, {
   SelectedTrack,
   DRMType,
   OnTextTrackDataChangedData,
-  SelectedTrackType,
+  TextTrackType,
+  ISO639_1,
 } from 'react-native-video';
 import ToggleControl from './ToggleControl';
 import MultiValueControl, {
@@ -126,6 +127,18 @@ class VideoPlayer extends Component {
     {
       description: 'sintel with subtitles',
       uri: 'https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
+    },
+    {
+      description: 'sintel with sideLoaded subtitles',
+      uri: 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8', // this is sample video, my actual video file is MP4
+      textTracks: [
+        {
+          title: 'test',
+          language: 'en' as ISO639_1,
+          type: TextTrackType.VTT,
+          uri: 'https://bitdash-a.akamaihd.net/content/sintel/subtitles/subtitles_en.vtt',
+        },
+      ]
     },
   ];
 
@@ -762,6 +775,7 @@ class VideoPlayer extends Component {
             this.video = ref;
           }}
           source={this.srcList[this.state.srcListId]}
+          textTracks={this.srcList[this.state.srcListId]?.textTracks}
           adTagUrl={this.srcList[this.state.srcListId]?.adTagUrl}
           drm={this.srcList[this.state.srcListId]?.drm}
           style={viewStyle}

--- a/src/types/TextTrackType.ts
+++ b/src/types/TextTrackType.ts
@@ -1,5 +1,5 @@
 enum TextTrackType {
-  SRT = 'application/x-subrip',
+  SUBRIP = 'application/x-subrip',
   TTML = 'application/ttml+xml',
   VTT = 'text/vtt',
 }

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -108,7 +108,7 @@ export type SubtitleStyle = {
   opacity?: number;
 };
 
-export enum TextTracksType {
+export enum TextTrackType {
   SUBRIP = 'application/x-subrip',
   TTML = 'application/ttml+xml',
   VTT = 'text/vtt',
@@ -117,11 +117,11 @@ export enum TextTracksType {
 export type TextTracks = {
   title: string;
   language: ISO639_1;
-  type: TextTracksType;
+  type: TextTrackType;
   uri: string;
 }[];
 
-export type TextTrackType =
+export type TextTrackSelectionType =
   | 'system'
   | 'disabled'
   | 'title'
@@ -129,11 +129,11 @@ export type TextTrackType =
   | 'index';
 
 export type SelectedTextTrack = Readonly<{
-  type: TextTrackType;
+  type: TextTrackSelectionType;
   value?: string | number;
 }>;
 
-export type AudioTrackType =
+export type AudioTrackSelectionType =
   | 'system'
   | 'disabled'
   | 'title'
@@ -141,7 +141,7 @@ export type AudioTrackType =
   | 'index';
 
 export type SelectedAudioTrack = Readonly<{
-  type: AudioTrackType;
+  type: AudioTrackSelectionType;
   value?: string | number;
 }>;
 


### PR DESCRIPTION
## Summary
Add sample of externally loaded textTracks.
⚠️ This is a typing breaking change

### Motivation
Improve sample and then fix textTracks typings

### Changes
- add new uri in sample
- rename SRT to SUBRIP 
- rename TextTrackType TextTrackSelectionType and then rename TextTracksType to TextTrackType
- sample for audioTrakcs

## Test plan
Check warning & the sample playback url with subtitle. (I tested only android for the sample file)