### PR TITLE
Chore/fix strange management of resume

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -357,8 +357,7 @@ public class ReactExoplayerView extends FrameLayout implements
 
     @Override
     public void onHostDestroy() {
-        stopPlayback();
-        themedReactContext.removeLifecycleEventListener(this);
+        cleanUpResources();
     }
 
     public void cleanUpResources() {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -998,26 +998,13 @@ public class ReactExoplayerView extends FrameLayout implements
         }
     }
 
-    private void startPlayback() {
+    private void resumePlayback() {
         if (player != null) {
-            switch (player.getPlaybackState()) {
-                case Player.STATE_IDLE:
-                case Player.STATE_ENDED:
-                    initializePlayer();
-                    break;
-                case Player.STATE_BUFFERING:
-                case Player.STATE_READY:
-                    if (!player.getPlayWhenReady()) {
-                        setPlayWhenReady(true);
-                    }
-                    break;
-                default:
-                    break;
+            if (!player.getPlayWhenReady()) {
+                setPlayWhenReady(true);
             }
-        } else {
-            initializePlayer();
+            setKeepScreenOn(preventsDisplaySleepDuringVideoPlayback);
         }
-        setKeepScreenOn(preventsDisplaySleepDuringVideoPlayback);
     }
 
     private void pausePlayback() {
@@ -1850,7 +1837,7 @@ public class ReactExoplayerView extends FrameLayout implements
         isPaused = paused;
         if (player != null) {
             if (!paused) {
-                startPlayback();
+                resumePlayback();
             } else {
                 pausePlayback();
             }


### PR DESCRIPTION
## Summary
Fix resume implamentation !
I cannot understand why this implementation has been done. I guess this is to workaround some issue...
now resume only resume playback and don't start a new playback during buffering...

### Motivation
Address: https://github.com/react-native-video/react-native-video/discussions/3585 and https://github.com/react-native-video/react-native-video/issues/3628
This issue can be reproduced when very fast zapping on basic player.

Another side effect of previous implementation: 
- play a content to the end
- pause and resume playback
-> the playback restart from the begining

### Changes
avoid to restart a playback when user set pause={false}

## Test plan
Fast zapping / source change can be tested