### PR TITLE
fix(ios): fix regression when playing source starting with ph://

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -351,8 +351,6 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                         throw NSError(domain: "", code: 0, userInfo: nil)
                     }
                     if let uri = source.uri, uri.starts(with: "ph://") {
-                        self.isSetSourceOngoing = false
-                        self.applyNextSource()
                         return Promise {
                             RCTVideoUtils.preparePHAsset(uri: uri).then { asset in
                                 return self.playerItemPrepareText(asset: asset, assetOptions: nil, uri: source.uri ?? "")


### PR DESCRIPTION
## Summary
fix regression when playing source starting with ph:// 

### Motivation
Linked issue: https://github.com/react-native-video/react-native-video/issues/3611

### Changes
We were considering starting a source with uri starting with ph://  as a failure. 
fix -> just continue starting playback

## Test plan
playback a source starting with ph://