### PR TITLE
chore: disable codegen

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,10 +64,5 @@
         "!**/*.tsbuildinfo",
         "!docs",
         "!examples"
-    ],
-    "codegenConfig": {
-        "name": "RNCVideo",
-        "type": "components",
-        "jsSrcsDir": "./src/specs"
-    }
+    ]
 }

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import type {HostComponent, ViewProps} from 'react-native';
-import {NativeModules} from 'react-native';
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import {NativeModules, requireNativeComponent} from 'react-native';
 import type {
   DirectEventHandler,
   Double,
@@ -565,6 +564,6 @@ export const VideoManager = NativeModules.VideoManager as VideoManagerType;
 export const VideoDecoderProperties =
   NativeModules.VideoDecoderProperties as VideoDecoderPropertiesType;
 
-export default codegenNativeComponent<VideoNativeProps>(
+export default requireNativeComponent<VideoNativeProps>(
   'RCTVideo',
 ) as VideoComponentType;


### PR DESCRIPTION
## Summary
We can not use Interop Layer with codegen - to be reverted once we integrate new architecture

### Motivation
Add proper support for Interop Layer

### Changes
- removed codegen

## Test plan
- [x] Tested locally
- [x] CI pass