### PR TITLE
fix: prevents crash from occurring when using the selected video track with resolution type

### DIFF
--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -221,10 +221,13 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       if (!selectedVideoTrack) {
         return;
       }
+      const value = selectedVideoTrack?.value
+        ? `${selectedVideoTrack.value}`
+        : undefined;
 
       return {
         type: selectedVideoTrack?.type,
-        value: selectedVideoTrack?.value,
+        value,
       };
     }, [selectedVideoTrack]);
 

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -81,7 +81,7 @@ type SelectedVideoTrackType = WithDefault<string, 'auto'>;
 
 type SelectedVideoTrack = Readonly<{
   type?: SelectedVideoTrackType;
-  value?: Int32;
+  value?: string;
 }>;
 
 export type Seek = Readonly<{


### PR DESCRIPTION
## Summary
fix: prevents crash from occurring when using the selected video track with resolution type

### Motivation
It may missed from PR #3594

### Changes
selectedVideoTrack prop's type conversion within JS side

## Test plan
selectedVideoTrack={{"type": "resolution", "value": 480}}