### PR TITLE
fix(android): fixed bug where video would not be visible after remount and change of drm source

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -322,12 +322,6 @@ public class ReactExoplayerView extends FrameLayout implements
         mainHandler = new Handler();
     }
 
-    @Override
-    protected void onAttachedToWindow() {
-        super.onAttachedToWindow();
-        initializePlayer();
-    }
-
     // LifecycleEventListener implementation
     @Override
     public void onHostResume() {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -328,15 +328,6 @@ public class ReactExoplayerView extends FrameLayout implements
         initializePlayer();
     }
 
-    @Override
-    protected void onDetachedFromWindow() {
-        super.onDetachedFromWindow();
-        /* We want to be able to continue playing audio when switching tabs.
-         * Leave this here in case it causes issues.
-         */
-        // stopPlayback();
-    }
-
     // LifecycleEventListener implementation
     @Override
     public void onHostResume() {


### PR DESCRIPTION
## Summary
fixed bug where video would not be visible after remount and change of drm source

### Motivation
`onAttachedToWindow` called when component remount.
and initialization of player with `drm` prop have networking delay.
these situations cause the `initializePlayer` function to be called again while it is running.
overridden `onAttachedToWindow` code was written with PR #426.
in that time this code needed, but current code doesn't need this behavior. (it can be replaced by an action called inside `setSrc`)

### Changes
- do not initialize player when view attached to window
- remove overridden Android native lifecycles (`onDetachedFromWindow`, `onAttachedToWindow`)

## Test plan
- prepare real device and two dash source with valid drm config.
- change source and drm prop with user action(`changeSource` function changes source)
```tsx
<Button title={'change source'} onPress={changeSource} />
<Video
    // for enforce remount without complicated component hierarchy
    key={source.uri}
    source={source}
    drm={drm}
 />
```