### PR TITLE
fix(android): set title for external subtitles

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1326,7 +1326,7 @@ public class ReactExoplayerView extends FrameLayout implements
         track.setIndex(trackIndex);
         if (format.sampleMimeType != null) track.setMimeType(format.sampleMimeType);
         if (format.language != null) track.setLanguage(format.language);
-        if (format.id != null) track.setTitle(format.id);
+        if (format.label != null) track.setTitle(format.label);
         track.setSelected(isTrackSelected(selection, group, 0));
         return track;
     }


### PR DESCRIPTION
## Summary
fix issue with title getter in `exoplayerTrackToGenericTrack`

### Motivation
fixes #3663

### Changes
- changed `exoplayerTrackToGenericTrack` function to get value from `label` instead of `id`

## Test plan
- [x] Tested locally
- [x] CI passes