### PR TITLE
fix(android): prevent changing resolution video track when video load

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1833,7 +1833,7 @@ public class ReactExoplayerView extends FrameLayout implements
     public void setSelectedVideoTrack(String type, String value) {
         videoTrackType = type;
         videoTrackValue = value;
-        setSelectedTrack(C.TRACK_TYPE_VIDEO, videoTrackType, videoTrackValue);
+        if (!loadVideoStarted) setSelectedTrack(C.TRACK_TYPE_VIDEO, videoTrackType, videoTrackValue);
     }
 
     public void setSelectedAudioTrack(String type, String value) {


### PR DESCRIPTION
## Summary
fix(android): prevent changing resolution video track when video load

### Motivation
- for prevent resolution video track changed by react prop when video is initially loaded
- In the above case, the `isUsingContentResolution` and `selectTrackWhenReady` flags don't work

### Changes
- `setSelectedVideoTrack` doesn't call `setSelectedTrack` when `loadVideoStarted` is `true`, it will call within `videoLoaded` after video ready

## Test plan