### PR TITLE
fix: fix/performOnPlayerViewCrash

### DIFF
--- a/android/src/main/java/com/brentvatne/react/VideoManagerModule.kt
+++ b/android/src/main/java/com/brentvatne/react/VideoManagerModule.kt
@@ -18,16 +18,20 @@ class VideoManagerModule(reactContext: ReactApplicationContext?) : ReactContextB
 
     private fun performOnPlayerView(reactTag: Int, callback: (ReactExoplayerView?) -> Unit) {
         UiThreadUtil.runOnUiThread {
-            val uiManager = UIManagerHelper.getUIManager(
-                reactApplicationContext,
-                if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) UIManagerType.FABRIC else UIManagerType.DEFAULT
-            )
+            try {
+                val uiManager = UIManagerHelper.getUIManager(
+                    reactApplicationContext,
+                    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) UIManagerType.FABRIC else UIManagerType.DEFAULT
+                )
 
-            val view = uiManager?.resolveView(reactTag)
+                val view = uiManager?.resolveView(reactTag)
 
-            if (view is ReactExoplayerView) {
-                callback(view)
-            } else {
+                if (view is ReactExoplayerView) {
+                    callback(view)
+                } else {
+                    callback(null)
+                }
+            } catch (e: Exception) {
                 callback(null)
             }
         }


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
```
04-17 18:25:33.400 25186 25186 E AndroidRuntime: com.facebook.react.uimanager.IllegalViewOperationException: Trying to resolve view with tag 2947 which doesn't exist
04-17 18:25:33.400 25186 25186 E AndroidRuntime: 	at com.facebook.react.uimanager.NativeViewHierarchyManager.resolveView(SourceFile:38)
04-17 18:25:33.400 25186 25186 E AndroidRuntime: 	at com.facebook.react.uimanager.UIManagerModule.resolveView(SourceFile:14)
04-17 18:25:33.400 25186 25186 E AndroidRuntime: 	at com.brentvatne.react.VideoManagerModule.performOnPlayerView$lambda$0(SourceFile:23)
04-17 18:25:33.400 25186 25186 E AndroidRuntime: 	at com.brentvatne.react.VideoManagerModule.O000O0O00OO0O0OOO0O(SourceFile:1)
04-17 18:25:33.400 25186 25186 E AndroidRuntime: 	at com.brentvatne.react.O000O0O00OO0O0OOO0O.run(SourceFile:1)
04-17 18:25:33.400 25186 25186 E AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:938)
04-17 18:25:33.400 25186 25186 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:99)
04-17 18:25:33.400 25186 25186 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:246)
04-17 18:25:33.400 25186 25186 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:8633)
04-17 18:25:33.400 25186 25186 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
04-17 18:25:33.400 25186 25186 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
04-17 18:25:33.400 25186 25186 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
```
Quickly switching videos will cause a crash because uiManager?.resolveView cannot obtain the view

### Motivation
fix crash bug

### Changes

## Test plan