### PR TITLE
fix(ios): add workaround for crash when using `TouchableWithoutFeedback`

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1533,4 +1533,8 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             self.onTextTrackDataChanged?(["subtitleTracks": subtitles.string])
         }
     }
+
+    // Workaround for #3418 - https://github.com/react-native-video/react-native-video/issues/3418#issuecomment-2043508862
+    @objc
+    func setOnClick(_: Any) {}
 }


### PR DESCRIPTION
## Summary
Add workaround for crash when using `<Video />` in `<TouchableWithoutFeedback />`

### Motivation
fixes #3418

### Changes
- added function that missing was causing crash

## Test plan
- [x] Tested locally
- [x] CI passes