### PR TITLE
fix(ios): keep subtitle selection on foreground

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -848,9 +848,12 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             setMaxBitRate(_maxBitRate)
         }
 
+        if _selectedTextTrackCriteria != nil {
+            setSelectedTextTrack(_selectedTextTrackCriteria)
+        }
+
         setAudioOutput(_audioOutput)
         setSelectedAudioTrack(_selectedAudioTrackCriteria)
-        setSelectedTextTrack(_selectedTextTrackCriteria)
         setResizeMode(_resizeMode)
         setRepeat(_repeat)
         setControls(_controls)


### PR DESCRIPTION
## Summary
- When playing an `m3u8` file with embedded subtitle tracks, the user's subtitle selections are wiped out whenever the player is foregrounded.  This PR prevents that scenario

### Motivation
- Users were losing subtitle settings when the app was minimized/the screen was turned off, then the app was foregrounded again.

### Changes
- Only update `selectedTextTrack` if there is a value being passed in `selectedTextTrackCriteria`

## Test plan
- On IOS, Play an `m3u8` file that includes embedded subtitle tracks such as the [sintel with subtitles](https://github.com/react-native-video/react-native-video/blob/e8ce4979b38a8ef6f0db9ae6049f4d1c230bd280/examples/basic/src/VideoPlayer.tsx#L133) example
- Choose one of the embedded subtitle tracks
- Minimize the app or turn off the screen
- Foreground the app or turn the screen back on
- The previously selected subtitles should continue to display when the video resumes