### PR TITLE
fix(ios): destroy adsManager when player detach from super view (#3716)

### DIFF
--- a/ios/Video/Features/RCTIMAAdsManager.swift
+++ b/ios/Video/Features/RCTIMAAdsManager.swift
@@ -49,9 +49,9 @@
             // Destroy AdsManager may be delayed for a few milliseconds
             // But what we want is it stopped producing sound immediately
             // Issue found on tvOS 17, or iOS if view detach & STARTED event happen at the same moment
-            adsManager.volume = 0;
-            adsManager.pause();
-            adsManager.destroy();
+            adsManager.volume = 0
+            adsManager.pause()
+            adsManager.destroy()
         }
 
         // MARK: - Getters

--- a/ios/Video/Features/RCTIMAAdsManager.swift
+++ b/ios/Video/Features/RCTIMAAdsManager.swift
@@ -44,6 +44,16 @@
             }
         }
 
+        func releaseAds() {
+            guard let adsManager else { return }
+            // Destroy AdsManager may be delayed for a few milliseconds
+            // But what we want is it stopped producing sound immediately
+            // Issue found on tvOS 17, or iOS if view detach & STARTED event happen at the same moment
+            adsManager.volume = 0;
+            adsManager.pause();
+            adsManager.destroy();
+        }
+
         // MARK: - Getters
 
         func getAdsLoader() -> IMAAdsLoader? {

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1188,7 +1188,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         _playerObserver.clearPlayer()
 
         #if USE_GOOGLE_IMA
-        _imaAdsManager.releaseAds()
+            _imaAdsManager.releaseAds()
         #endif
 
         self.removePlayerLayer()

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1187,6 +1187,10 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         _resouceLoaderDelegate = nil
         _playerObserver.clearPlayer()
 
+        #if USE_GOOGLE_IMA
+        _imaAdsManager.releaseAds()
+        #endif
+
         self.removePlayerLayer()
 
         if let _playerViewController {


### PR DESCRIPTION
## Summary
* In iOS/tvOS, when the player is detached from the superview, the adsManager is not destroyed and keeps playing ads until they finish.

### Motivation
* Issue #3716

### Changes
* Added `releaseAds` method to `RCTIMAAdsManager`.
* Called `releaseAds()` in `removeFromSuperview` of `RCTVideo`.

## Test Plan
* Remove player when ads are playing; the adsManager should stop producing sound immediately.
