### PR TITLE
perf: ensure we do not provide callback to native if no callback provided from app

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1252,6 +1252,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     // When timeMetadata is read the event onTimedMetadata is triggered
     func handleTimeMetadataChange(timedMetadata: [AVMetadataItem]) {
+        guard onTimedMetadata != nil else { return }
         var metadata: [[String: String?]?] = []
         for item in timedMetadata {
             let value = item.value as? String
@@ -1510,6 +1511,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     @objc
     func handleAVPlayerAccess(notification: NSNotification!) {
+        guard onVideoBandwidthUpdate != nil else { return }
         guard let accessLog = (notification.object as? AVPlayerItem)?.accessLog() else {
             return
         }

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -542,38 +542,60 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           selectedAudioTrack={_selectedAudioTrack}
           selectedVideoTrack={_selectedVideoTrack}
           onGetLicense={useExternalGetLicense ? onGetLicense : undefined}
-          onVideoLoad={onVideoLoad as (e: NativeSyntheticEvent<object>) => void}
-          onVideoLoadStart={onVideoLoadStart}
-          onVideoError={onVideoError}
-          onVideoProgress={onVideoProgress}
-          onVideoSeek={onVideoSeek}
+          onVideoLoad={
+            onLoad
+              ? (onVideoLoad as (e: NativeSyntheticEvent<object>) => void)
+              : undefined
+          }
+          onVideoLoadStart={onLoadStart ? onVideoLoadStart : undefined}
+          onVideoError={onError ? onVideoError : undefined}
+          onVideoProgress={onProgress ? onVideoProgress : undefined}
+          onVideoSeek={onSeek ? onVideoSeek : undefined}
           onVideoEnd={onEnd}
-          onVideoBuffer={onVideoBuffer}
-          onVideoPlaybackStateChanged={onVideoPlaybackStateChanged}
-          onVideoBandwidthUpdate={_onBandwidthUpdate}
-          onTimedMetadata={_onTimedMetadata}
-          onAudioTracks={_onAudioTracks}
-          onTextTracks={_onTextTracks}
-          onTextTrackDataChanged={_onTextTrackDataChanged}
-          onVideoTracks={_onVideoTracks}
+          onVideoBuffer={onBuffer ? onVideoBuffer : undefined}
+          onVideoPlaybackStateChanged={
+            onPlaybackRateChange ? onVideoPlaybackStateChanged : undefined
+          }
+          onVideoBandwidthUpdate={
+            onBandwidthUpdate ? _onBandwidthUpdate : undefined
+          }
+          onTimedMetadata={onTimedMetadata ? _onTimedMetadata : undefined}
+          onAudioTracks={onAudioTracks ? _onAudioTracks : undefined}
+          onTextTracks={onTextTracks ? _onTextTracks : undefined}
+          onTextTrackDataChanged={
+            onTextTrackDataChanged ? _onTextTrackDataChanged : undefined
+          }
+          onVideoTracks={onVideoTracks ? _onVideoTracks : undefined}
           onVideoFullscreenPlayerDidDismiss={onFullscreenPlayerDidDismiss}
           onVideoFullscreenPlayerDidPresent={onFullscreenPlayerDidPresent}
           onVideoFullscreenPlayerWillDismiss={onFullscreenPlayerWillDismiss}
           onVideoFullscreenPlayerWillPresent={onFullscreenPlayerWillPresent}
-          onVideoExternalPlaybackChange={onVideoExternalPlaybackChange}
-          onVideoIdle={onVideoIdle}
-          onAudioFocusChanged={_onAudioFocusChanged}
-          onReadyForDisplay={_onReadyForDisplay}
-          onPlaybackRateChange={_onPlaybackRateChange}
-          onVolumeChange={_onVolumeChange}
+          onVideoExternalPlaybackChange={
+            onExternalPlaybackChange ? onVideoExternalPlaybackChange : undefined
+          }
+          onVideoIdle={onIdle ? onVideoIdle : undefined}
+          onAudioFocusChanged={
+            onAudioFocusChanged ? _onAudioFocusChanged : undefined
+          }
+          onReadyForDisplay={onReadyForDisplay ? _onReadyForDisplay : undefined}
+          onPlaybackRateChange={
+            onPlaybackRateChange ? _onPlaybackRateChange : undefined
+          }
+          onVolumeChange={onVolumeChange ? _onVolumeChange : undefined}
           onVideoAudioBecomingNoisy={onAudioBecomingNoisy}
-          onPictureInPictureStatusChanged={_onPictureInPictureStatusChanged}
+          onPictureInPictureStatusChanged={
+            onPictureInPictureStatusChanged
+              ? _onPictureInPictureStatusChanged
+              : undefined
+          }
           onRestoreUserInterfaceForPictureInPictureStop={
             onRestoreUserInterfaceForPictureInPictureStop
           }
-          onVideoAspectRatio={_onVideoAspectRatio}
+          onVideoAspectRatio={onAspectRatio ? _onVideoAspectRatio : undefined}
           onReceiveAdEvent={
-            _onReceiveAdEvent as (e: NativeSyntheticEvent<object>) => void
+            onReceiveAdEvent
+              ? (_onReceiveAdEvent as (e: NativeSyntheticEvent<object>) => void)
+              : undefined
           }
         />
         {hasPoster && showPoster ? (

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -339,10 +339,6 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
     );
 
     // android only
-    const onVideoIdle = useCallback(() => {
-      onIdle?.();
-    }, [onIdle]);
-
     const _onTimedMetadata = useCallback(
       (e: NativeSyntheticEvent<OnTimedMetadataData>) => {
         onTimedMetadata?.(e.nativeEvent);
@@ -573,7 +569,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           onVideoExternalPlaybackChange={
             onExternalPlaybackChange ? onVideoExternalPlaybackChange : undefined
           }
-          onVideoIdle={onIdle ? onVideoIdle : undefined}
+          onVideoIdle={onIdle}
           onAudioFocusChanged={
             onAudioFocusChanged ? _onAudioFocusChanged : undefined
           }

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -539,11 +539,13 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           selectedVideoTrack={_selectedVideoTrack}
           onGetLicense={useExternalGetLicense ? onGetLicense : undefined}
           onVideoLoad={
-            onLoad
+            onLoad || hasPoster
               ? (onVideoLoad as (e: NativeSyntheticEvent<object>) => void)
               : undefined
           }
-          onVideoLoadStart={onLoadStart ? onVideoLoadStart : undefined}
+          onVideoLoadStart={
+            onLoadStart || hasPoster ? onVideoLoadStart : undefined
+          }
           onVideoError={onError ? onVideoError : undefined}
           onVideoProgress={onProgress ? onVideoProgress : undefined}
           onVideoSeek={onSeek ? onVideoSeek : undefined}


### PR DESCRIPTION
## Summary
As discussed with @KrzysztofMoch a possible optimization is to avoid giving callback functions (starting with 'on*') to native if application didn't provide it 

### Motivation
performances improvements.
Additionnally, we must keep the useCallback as paramters of the function are differents between native & applicative, for exemple:
```TS
    const _onTimedMetadata = useCallback(
      (e: NativeSyntheticEvent<OnTimedMetadataData>) => {
        onTimedMetadata?.(e.nativeEvent);
      },
      [onTimedMetadata],
    );
````
send e.nativeEvent to application

### Changes
Just add ternary to check to avoid giving the callback to native

## Test plan
Basic tests done on android/ios with the sample
