### PR TITLE
Revert "fix(android): video flickering add playback start (#3746)"

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -1,12 +1,13 @@
 package com.brentvatne.exoplayer;
 
 import android.content.Context;
-
-import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.media3.common.AdViewProvider;
 import androidx.media3.common.C;
+import androidx.media3.common.PlaybackException;
+import androidx.media3.common.PlaybackParameters;
 import androidx.media3.common.Player;
+import androidx.media3.common.Timeline;
 import androidx.media3.common.Tracks;
 import androidx.media3.common.VideoSize;
 import androidx.media3.common.text.Cue;
@@ -37,8 +38,8 @@ public final class ExoPlayerView extends FrameLayout implements AdViewProvider {
     private final AspectRatioFrameLayout layout;
     private final ComponentListener componentListener;
     private ExoPlayer player;
-    final private Context context;
-    final private ViewGroup.LayoutParams layoutParams;
+    private Context context;
+    private ViewGroup.LayoutParams layoutParams;
     private final FrameLayout adOverlayFrameLayout;
 
     private boolean useTextureView = true;
@@ -112,7 +113,7 @@ public final class ExoPlayerView extends FrameLayout implements AdViewProvider {
     }
 
     public void setSubtitleStyle(SubtitleStyle style) {
-        // ensure we reset subtitle style before reapplying it
+        // ensure we reset subtile style before reapplying it
         subtitleLayout.setUserDefaultStyle();
         subtitleLayout.setUserDefaultTextSize();
 
@@ -210,6 +211,16 @@ public final class ExoPlayerView extends FrameLayout implements AdViewProvider {
         }
     }
 
+    /**
+     * Get the view onto which video is rendered. This is either a {@link SurfaceView} (default)
+     * or a {@link TextureView} if the {@code use_texture_view} view attribute has been set to true.
+     *
+     * @return either a {@link SurfaceView} or a {@link TextureView}.
+     */
+    public View getVideoSurfaceView() {
+        return surfaceView;
+    }
+
     public void setUseTextureView(boolean useTextureView) {
         if (useTextureView != this.useTextureView) {
             this.useTextureView = useTextureView;
@@ -252,24 +263,15 @@ public final class ExoPlayerView extends FrameLayout implements AdViewProvider {
         shutterView.setVisibility(this.hideShutterView ? View.INVISIBLE : View.VISIBLE);
     }
 
-    Runnable hideShutterViewRunnable = new Runnable() {
-        @Override
-        public void run() {
-            shutterView.setVisibility(INVISIBLE);
-        }
-    };
-
     public void invalidateAspectRatio() {
         // Resetting aspect ratio will force layout refresh on next video size changed
         layout.invalidateAspectRatio();
-
-        removeCallbacks(hideShutterViewRunnable);
     }
 
     private final class ComponentListener implements Player.Listener {
 
         @Override
-        public void onCues(@NonNull List<Cue> cues) {
+        public void onCues(List<Cue> cues) {
             subtitleLayout.setCues(cues);
         }
 
@@ -286,16 +288,11 @@ public final class ExoPlayerView extends FrameLayout implements AdViewProvider {
 
         @Override
         public void onRenderedFirstFrame() {
-            // The shutter view is use to hide dirty resizing issue when starting playback.
-            // In case video doesn't match your View aspect ratio, at playback startup you may have flickering during resize.
-            // we saw that onRenderedFirstFrame is called before first resizing
-            // Then hiding the shutterView directly may not hide the flickering.
-            // This small delay avoid the flickering
-            postDelayed(hideShutterViewRunnable, 15);
+            shutterView.setVisibility(INVISIBLE);
         }
 
         @Override
-        public void onTracksChanged(@NonNull Tracks tracks) {
+        public void onTracksChanged(Tracks tracks) {
             updateForCurrentTrackSelections();
         }
     }


### PR DESCRIPTION
This reverts commit b1cd52bc58b3dfd02dab4784ea423ebddae874c4.



<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
Revert the video flickering PR, as changes related to shutterView never loading the video

### Motivation
this was causing issue, it was never letting the player to load the video

### Changes

## Test plan
Will test it