### PR TITLE
fix(ios): call `onLoadStart` earlier

### DIFF
--- a/examples/basic/ios/Podfile.lock
+++ b/examples/basic/ios/Podfile.lock
@@ -935,7 +935,7 @@ PODS:
   - React-Mapbuffer (0.74.0):
     - glog
     - React-debug
-  - react-native-video (6.0.0-rc.0):
+  - react-native-video (6.0.0-rc.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -949,7 +949,7 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
-    - react-native-video/Video (= 6.0.0-rc.0)
+    - react-native-video/Video (= 6.0.0-rc.1)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -957,7 +957,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-video/Video (6.0.0-rc.0):
+  - react-native-video/Video (6.0.0-rc.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1421,7 +1421,7 @@ SPEC CHECKSUMS:
   React-jsitracing: 72dce571a387f9d085482142837222c31a8d6c3a
   React-logger: 03f2f7b955cfe24593a2b8c9705c23e142d1ad24
   React-Mapbuffer: 1ab3316cb736411bc641311b4b71e75099ae56ad
-  react-native-video: 3262598f55f8632e5d4dae90ba63d9d6e09bd563
+  react-native-video: 6bcf0049420848ecf85a46bc5ab3225022843fe6
   React-nativeconfig: fef0a46effa630d72f137636a990d7df2f6a5f7c
   React-NativeModulesApple: 8257dd73991f2e410b9c9d12801691439a0dc821
   React-perflogger: 271f1111779fef70f9502d1d38da5132e5585230

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -375,6 +375,17 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             throw NSError(domain: "", code: 0, userInfo: nil)
         }
 
+        // Perform on next run loop, otherwise onVideoLoadStart is nil
+        onVideoLoadStart?([
+            "src": [
+                "uri": _source?.uri ?? NSNull(),
+                "type": _source?.type ?? NSNull(),
+                "isNetwork": NSNumber(value: _source?.isNetwork ?? false),
+            ],
+            "drm": _drm?.json ?? NSNull(),
+            "target": reactTag,
+        ])
+
         if let uri = source.uri, uri.starts(with: "ph://") {
             let photoAsset = await RCTVideoUtils.preparePHAsset(uri: uri)
             return await playerItemPrepareText(asset: photoAsset, assetOptions: nil, uri: source.uri ?? "")
@@ -467,16 +478,6 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                 _imaAdsManager.setUpAdsLoader()
             }
         #endif
-        // Perform on next run loop, otherwise onVideoLoadStart is nil
-        onVideoLoadStart?([
-            "src": [
-                "uri": _source?.uri ?? NSNull(),
-                "type": _source?.type ?? NSNull(),
-                "isNetwork": NSNumber(value: _source?.isNetwork ?? false),
-            ],
-            "drm": _drm?.json ?? NSNull(),
-            "target": reactTag,
-        ])
         isSetSourceOngoing = false
         applyNextSource()
     }

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -80,6 +80,11 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             #endif
         }
     }
+    private var _isBuffering = false {
+        didSet {
+            onVideoBuffer?(["isBuffering": _isBuffering, "target": reactTag as Any])
+        }
+    }
 
     /* IMA Ads */
     private var _adTagUrl: String?
@@ -1297,7 +1302,9 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     }
 
     func handleReadyForDisplay(changeObject _: Any, change _: NSKeyValueObservedChange<Bool>) {
-        onVideoBuffer?(["isBuffering": false, "target": reactTag as Any])
+        if _isBuffering {
+            _isBuffering = false
+        }
         onReadyForDisplay?([
             "target": reactTag,
         ])
@@ -1431,16 +1438,16 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     }
 
     func handlePlaybackBufferKeyEmpty(playerItem _: AVPlayerItem, change _: NSKeyValueObservedChange<Bool>) {
-        onVideoBuffer?(["isBuffering": true, "target": reactTag as Any])
+        if !_isBuffering {
+            _isBuffering = true
+        }
     }
 
     // Continue playing (or not if paused) after being paused due to hitting an unbuffered zone.
     func handlePlaybackLikelyToKeepUp(playerItem _: AVPlayerItem, change: NSKeyValueObservedChange<Bool>) {
-        if change.newValue == change.oldValue {
-            return
+        if _isBuffering {
+            _isBuffering = false
         }
-
-        onVideoBuffer?(["isBuffering": false, "target": reactTag as Any])
     }
 
     func handleTimeControlStatusChange(player: AVPlayer, change: NSKeyValueObservedChange<AVPlayer.TimeControlStatus>) {

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1435,7 +1435,11 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     }
 
     // Continue playing (or not if paused) after being paused due to hitting an unbuffered zone.
-    func handlePlaybackLikelyToKeepUp(playerItem _: AVPlayerItem, change _: NSKeyValueObservedChange<Bool>) {
+    func handlePlaybackLikelyToKeepUp(playerItem _: AVPlayerItem, change: NSKeyValueObservedChange<Bool>) {
+        if change.newValue == change.oldValue {
+            return
+        }
+
         onVideoBuffer?(["isBuffering": false, "target": reactTag as Any])
     }
 

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -80,6 +80,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             #endif
         }
     }
+
     private var _isBuffering = false {
         didSet {
             onVideoBuffer?(["isBuffering": _isBuffering, "target": reactTag as Any])
@@ -1444,7 +1445,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     }
 
     // Continue playing (or not if paused) after being paused due to hitting an unbuffered zone.
-    func handlePlaybackLikelyToKeepUp(playerItem _: AVPlayerItem, change: NSKeyValueObservedChange<Bool>) {
+    func handlePlaybackLikelyToKeepUp(playerItem _: AVPlayerItem, change _: NSKeyValueObservedChange<Bool>) {
         if _isBuffering {
             _isBuffering = false
         }


### PR DESCRIPTION
## Summary
call callback `onLoadStart` earlier to make it work properly 

### Motivation
fix #3744

### Changes
- move callback `onLoadStart` earlier
- don't call `onVideoBuffer` in `handlePlaybackLikelyToKeepUp` if value is same as previous

## Test plan
- [x] Tested Locally
- [x] CI pass