### PR TITLE
fix(android): fix android source metadata compare

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1643,7 +1643,7 @@ public class ReactExoplayerView extends FrameLayout implements
 
     public void setSrc(final Uri uri, final long startPositionMs, final long cropStartMs, final long cropEndMs, final String extension, Map<String, String> headers, MediaMetadata customMetadata) {
 
-        if (this.customMetadata != customMetadata && player != null) {
+        if (!Util.areEqual(this.customMetadata, customMetadata) && player != null) {
             MediaItem currentMediaItem = player.getCurrentMediaItem();
 
             if (currentMediaItem != null) {


### PR DESCRIPTION
## Summary
fix internal android comparing code (compare source.metadata)

### Motivation

### Changes
- "!=" always return true even if all data is the same, so I modified it to use implemented Object.equals fn.

## Test plan