### PR TITLE
fix(android): playback doesn't work with 0 startPositionMs

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -745,11 +745,11 @@ public class ReactExoplayerView extends FrameLayout implements
         boolean haveResumePosition = resumeWindow != C.INDEX_UNSET;
         if (haveResumePosition) {
             player.seekTo(resumeWindow, resumePosition);
-        }
-        if (startPositionMs >= 0) {
+            player.setMediaSource(mediaSource, false);
+        } else if (startPositionMs > 0) {
             player.setMediaSource(mediaSource, startPositionMs);
         } else {
-            player.setMediaSource(mediaSource, !haveResumePosition);
+            player.setMediaSource(mediaSource, true);
         }
         player.prepare();
         playerNeedsSource = false;


### PR DESCRIPTION
## Summary
Some device(maybe low performance device) doesn't work with zero startPositionMs and DRM
(playback doesn't work before user trigger seek)
So I use resetPosition = true when startPositionMs is 0

### Motivation

### Changes

## Test plan