### PR TITLE
feat(android): hide seekBar for props ( can be used for live broadcast)

### DIFF
--- a/android/src/main/java/com/brentvatne/common/api/ControlsConfig.kt
+++ b/android/src/main/java/com/brentvatne/common/api/ControlsConfig.kt
@@ -1,0 +1,21 @@
+package com.brentvatne.common.api
+
+import com.brentvatne.common.toolbox.ReactBridgeUtils
+import com.facebook.react.bridge.ReadableMap
+
+class ControlsConfig {
+    var hideSeekBar: Boolean = false
+
+    companion object {
+        @JvmStatic
+        fun parse(src: ReadableMap?): ControlsConfig {
+            val config = ControlsConfig()
+
+            if (src != null) {
+                config.hideSeekBar = ReactBridgeUtils.safeGetBool(src, "hideSeekBar", false)
+            }
+
+            return config
+        }
+    }
+}

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -182,6 +182,10 @@ public class ReactExoplayerView extends FrameLayout implements
     private boolean playerNeedsSource;
     private MediaMetadata customMetadata;
 
+     private DefaultTimeBar exoProgress;
+     private TextView exoDuration;
+     private TextView exoPosition;
+
     private ServiceConnection playbackServiceConnection;
     private PlaybackServiceBinder playbackServiceBinder;
 
@@ -236,6 +240,7 @@ public class ReactExoplayerView extends FrameLayout implements
     private String[] drmLicenseHeader = null;
     private boolean controls;
     private Uri adTagUrl;
+    private boolean hideSeekBar = false;
 
     private boolean showNotificationControls = false;
     // \ End props
@@ -501,6 +506,31 @@ public class ReactExoplayerView extends FrameLayout implements
         view.measure(MeasureSpec.makeMeasureSpec(getMeasuredWidth(), MeasureSpec.EXACTLY),
                 MeasureSpec.makeMeasureSpec(getMeasuredHeight(), MeasureSpec.EXACTLY));
         view.layout(view.getLeft(), view.getTop(), view.getMeasuredWidth(), view.getMeasuredHeight());
+
+         if(view == playerControlView){
+            exoProgress = findViewById(R.id.exo_progress);
+            exoDuration = findViewById(R.id.exo_duration);
+            exoPosition = findViewById(R.id.exo_position);
+            if(hideSeekBar){
+                LinearLayout.LayoutParams param = new LinearLayout.LayoutParams(
+                                LayoutParams.MATCH_PARENT,
+                                LayoutParams.MATCH_PARENT,
+                                1.0f
+                        );
+                exoProgress.setVisibility(GONE);
+                exoDuration.setVisibility(GONE);
+                exoPosition.setLayoutParams(param);
+            }else{
+               exoProgress.setVisibility(VISIBLE);
+                exoDuration.setVisibility(VISIBLE);
+                // Reset the layout parameters of exoPosition to their default state
+                LinearLayout.LayoutParams defaultParam = new LinearLayout.LayoutParams(
+                               LayoutParams.WRAP_CONTENT,
+                                LayoutParams.WRAP_CONTENT
+                        );
+                exoPosition.setLayoutParams(defaultParam);
+                    }
+                }
     }
 
     private void reLayoutControls() {
@@ -2268,5 +2298,9 @@ public class ReactExoplayerView extends FrameLayout implements
     public void onAdError(AdErrorEvent adErrorEvent) {
         AdError error = adErrorEvent.getError();
         eventEmitter.receiveAdErrorEvent(error.getMessage(), String.valueOf(error.getErrorCode()), String.valueOf(error.getErrorType()));
+    }
+
+    public void setHideSeekBar(boolean hideSeekBar) {
+        this.hideSeekBar = hideSeekBar;
     }
 }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -187,10 +187,6 @@ public class ReactExoplayerView extends FrameLayout implements
     private boolean playerNeedsSource;
     private MediaMetadata customMetadata;
 
-     private DefaultTimeBar exoProgress;
-     private TextView exoDuration;
-     private TextView exoPosition;
-
     private ServiceConnection playbackServiceConnection;
     private PlaybackServiceBinder playbackServiceBinder;
 
@@ -216,7 +212,6 @@ public class ReactExoplayerView extends FrameLayout implements
     private Runnable mainRunnable;
     private DataSource.Factory cacheDataSourceFactory;
     private ControlsConfig controlsConfig = new ControlsConfig();
-
 
     // Props from React
     private Uri srcUri;

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -247,7 +247,6 @@ public class ReactExoplayerView extends FrameLayout implements
     private String[] drmLicenseHeader = null;
     private boolean controls;
     private Uri adTagUrl;
-    private boolean hideSeekBar = false;
 
     private boolean showNotificationControls = false;
     // \ End props
@@ -517,31 +516,33 @@ public class ReactExoplayerView extends FrameLayout implements
 
     }
 
-    @SuppressLint("SuspiciousIndentation")
     private void refreshProgressBarVisibility (){
         if(playerControlView == null) return;
-            exoProgress = playerControlView.findViewById(R.id.exo_progress);
-            exoDuration = playerControlView.findViewById(R.id.exo_duration);
-            exoPosition = playerControlView.findViewById(R.id.exo_position);
-            if(hideSeekBar){
-                LinearLayout.LayoutParams param = new LinearLayout.LayoutParams(
-                        LayoutParams.MATCH_PARENT,
-                        LayoutParams.MATCH_PARENT,
-                        1.0f
-                );
-                exoProgress.setVisibility(GONE);
-                exoDuration.setVisibility(GONE);
-                exoPosition.setLayoutParams(param);
-            }else{
-                exoProgress.setVisibility(VISIBLE);
-                exoDuration.setVisibility(VISIBLE);
-                // Reset the layout parameters of exoPosition to their default state
-                LinearLayout.LayoutParams defaultParam = new LinearLayout.LayoutParams(
-                        LayoutParams.WRAP_CONTENT,
-                        LayoutParams.WRAP_CONTENT
-                );
-                exoPosition.setLayoutParams(defaultParam);
-            }
+        DefaultTimeBar exoProgress;
+        TextView exoDuration;
+        TextView exoPosition;
+        exoProgress = playerControlView.findViewById(R.id.exo_progress);
+        exoDuration = playerControlView.findViewById(R.id.exo_duration);
+        exoPosition = playerControlView.findViewById(R.id.exo_position);
+        if(controlsConfig.getHideSeekBar()){
+            LinearLayout.LayoutParams param = new LinearLayout.LayoutParams(
+                    LayoutParams.MATCH_PARENT,
+                    LayoutParams.MATCH_PARENT,
+                    1.0f
+            );
+            exoProgress.setVisibility(GONE);
+            exoDuration.setVisibility(GONE);
+            exoPosition.setLayoutParams(param);
+        }else{
+            exoProgress.setVisibility(VISIBLE);
+            exoDuration.setVisibility(VISIBLE);
+            // Reset the layout parameters of exoPosition to their default state
+            LinearLayout.LayoutParams defaultParam = new LinearLayout.LayoutParams(
+                    LayoutParams.WRAP_CONTENT,
+                    LayoutParams.WRAP_CONTENT
+            );
+            exoPosition.setLayoutParams(defaultParam);
+        }
     }
 
     private void reLayoutControls() {
@@ -2313,7 +2314,6 @@ public class ReactExoplayerView extends FrameLayout implements
 
     public void setControlsStyles(ControlsConfig controlsStyles) {
         controlsConfig = controlsStyles;
-        this.hideSeekBar = controlsStyles.getHideSeekBar();
         refreshProgressBarVisibility();
     }
 }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -508,7 +508,6 @@ public class ReactExoplayerView extends FrameLayout implements
         view.measure(MeasureSpec.makeMeasureSpec(getMeasuredWidth(), MeasureSpec.EXACTLY),
                 MeasureSpec.makeMeasureSpec(getMeasuredHeight(), MeasureSpec.EXACTLY));
         view.layout(view.getLeft(), view.getTop(), view.getMeasuredWidth(), view.getMeasuredHeight());
-
     }
 
     private void refreshProgressBarVisibility (){

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -212,15 +212,15 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
             }
         } else {
             int identifier = context.getResources().getIdentifier(
-                    uriString,
-                    "drawable",
-                    context.getPackageName()
+                uriString,
+                "drawable",
+                context.getPackageName()
             );
             if (identifier == 0) {
                 identifier = context.getResources().getIdentifier(
-                        uriString,
-                        "raw",
-                        context.getPackageName()
+                uriString,
+                "raw",
+                context.getPackageName()
                 );
             }
             if (identifier > 0) {
@@ -275,28 +275,28 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     }
 
     @ReactProp(name = PROP_SELECTED_VIDEO_TRACK)
-    public void setSelectedVideoTrack(final ReactExoplayerView videoView,
-                                      @Nullable ReadableMap selectedVideoTrack) {
-        String typeString = null;
-        String value = null;
-        if (selectedVideoTrack != null) {
-            typeString = ReactBridgeUtils.safeGetString(selectedVideoTrack, PROP_SELECTED_VIDEO_TRACK_TYPE);
-            value = ReactBridgeUtils.safeGetString(selectedVideoTrack, PROP_SELECTED_VIDEO_TRACK_VALUE);
+        public void setSelectedVideoTrack(final ReactExoplayerView videoView,
+                                         @Nullable ReadableMap selectedVideoTrack) {
+            String typeString = null;
+            String value = null;
+            if (selectedVideoTrack != null) {
+                typeString = ReactBridgeUtils.safeGetString(selectedVideoTrack, PROP_SELECTED_VIDEO_TRACK_TYPE);
+                value = ReactBridgeUtils.safeGetString(selectedVideoTrack, PROP_SELECTED_VIDEO_TRACK_VALUE);
+            }
+            videoView.setSelectedVideoTrack(typeString, value);
         }
-        videoView.setSelectedVideoTrack(typeString, value);
-    }
 
-    @ReactProp(name = PROP_SELECTED_AUDIO_TRACK)
-    public void setSelectedAudioTrack(final ReactExoplayerView videoView,
-                                      @Nullable ReadableMap selectedAudioTrack) {
-        String typeString = null;
-        String value = null;
-        if (selectedAudioTrack != null) {
-            typeString = ReactBridgeUtils.safeGetString(selectedAudioTrack, PROP_SELECTED_AUDIO_TRACK_TYPE);
-            value = ReactBridgeUtils.safeGetString(selectedAudioTrack, PROP_SELECTED_AUDIO_TRACK_VALUE);
+        @ReactProp(name = PROP_SELECTED_AUDIO_TRACK)
+        public void setSelectedAudioTrack(final ReactExoplayerView videoView,
+                                         @Nullable ReadableMap selectedAudioTrack) {
+            String typeString = null;
+            String value = null;
+            if (selectedAudioTrack != null) {
+                typeString = ReactBridgeUtils.safeGetString(selectedAudioTrack, PROP_SELECTED_AUDIO_TRACK_TYPE);
+                value = ReactBridgeUtils.safeGetString(selectedAudioTrack, PROP_SELECTED_AUDIO_TRACK_VALUE);
+            }
+            videoView.setSelectedAudioTrack(typeString, value);
         }
-        videoView.setSelectedAudioTrack(typeString, value);
-    }
 
     @ReactProp(name = PROP_SELECTED_TEXT_TRACK)
     public void setSelectedTextTrack(final ReactExoplayerView videoView,

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -13,6 +13,7 @@ import androidx.media3.datasource.RawResourceDataSource;
 
 import com.brentvatne.common.api.BufferConfig;
 import com.brentvatne.common.api.BufferingStrategy;
+import com.brentvatne.common.api.ControlsConfig;
 import com.brentvatne.common.api.ResizeMode;
 import com.brentvatne.common.api.SideLoadedTextTrackList;
 import com.brentvatne.common.api.SubtitleStyle;
@@ -88,7 +89,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SHUTTER_COLOR = "shutterColor";
     private static final String PROP_SHOW_NOTIFICATION_CONTROLS = "showNotificationControls";
     private static final String PROP_DEBUG = "debug";
-    private static final String HIDE_SEEKBAR = "hideSeekBar";
+    private static final String PROP_CONTROLS_STYLES = "controlsStyles";
 
     private final ReactExoplayerConfig config;
 
@@ -211,15 +212,15 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
             }
         } else {
             int identifier = context.getResources().getIdentifier(
-                uriString,
-                "drawable",
-                context.getPackageName()
+                    uriString,
+                    "drawable",
+                    context.getPackageName()
             );
             if (identifier == 0) {
                 identifier = context.getResources().getIdentifier(
-                    uriString,
-                    "raw",
-                    context.getPackageName()
+                        uriString,
+                        "raw",
+                        context.getPackageName()
                 );
             }
             if (identifier > 0) {
@@ -275,7 +276,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
 
     @ReactProp(name = PROP_SELECTED_VIDEO_TRACK)
     public void setSelectedVideoTrack(final ReactExoplayerView videoView,
-                                     @Nullable ReadableMap selectedVideoTrack) {
+                                      @Nullable ReadableMap selectedVideoTrack) {
         String typeString = null;
         String value = null;
         if (selectedVideoTrack != null) {
@@ -287,7 +288,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
 
     @ReactProp(name = PROP_SELECTED_AUDIO_TRACK)
     public void setSelectedAudioTrack(final ReactExoplayerView videoView,
-                                     @Nullable ReadableMap selectedAudioTrack) {
+                                      @Nullable ReadableMap selectedAudioTrack) {
         String typeString = null;
         String value = null;
         if (selectedAudioTrack != null) {
@@ -451,10 +452,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
         }
     }
 
-    @ReactProp(name = HIDE_SEEKBAR, defaultBoolean = false)
-        public void setHideSeekBar(final ReactExoplayerView videoView, final boolean hideSeekBar) {
-            videoView.setHideSeekBar(hideSeekBar);
-        }
+    @ReactProp(name = PROP_CONTROLS_STYLES)
+    public void setControlsStyles(final ReactExoplayerView videoView, @Nullable ReadableMap controlsStyles) {
+        ControlsConfig controlsConfig = ControlsConfig.parse(controlsStyles);
+        videoView.setControlsStyles(controlsConfig);
+    }
 
     private boolean startsWithValidScheme(String uriString) {
         String lowerCaseUri = uriString.toLowerCase();

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -288,7 +288,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
 
     @ReactProp(name = PROP_SELECTED_AUDIO_TRACK)
     public void setSelectedAudioTrack(final ReactExoplayerView videoView,
-                                      @Nullable ReadableMap selectedAudioTrack) {
+                                     @Nullable ReadableMap selectedAudioTrack) {
         String typeString = null;
         String value = null;
         if (selectedAudioTrack != null) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -213,7 +213,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
         } else {
             int identifier = context.getResources().getIdentifier(
                 uriString,
-                    "drawable",
+                "drawable",
                 context.getPackageName()
             );
             if (identifier == 0) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -458,12 +458,6 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
         videoView.setControlsStyles(controlsConfig);
     }
 
-    @ReactProp(name = PROP_CONTROLS_STYLES)
-    public void setControlsStyles(final ReactExoplayerView videoView, @Nullable ReadableMap controlsStyles) {
-        ControlsConfig controlsConfig = ControlsConfig.parse(controlsStyles);
-        videoView.setControlsStyles(controlsConfig);
-    }
-
     private boolean startsWithValidScheme(String uriString) {
         String lowerCaseUri = uriString.toLowerCase();
         return lowerCaseUri.startsWith("http://")

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -88,6 +88,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SHUTTER_COLOR = "shutterColor";
     private static final String PROP_SHOW_NOTIFICATION_CONTROLS = "showNotificationControls";
     private static final String PROP_DEBUG = "debug";
+    private static final String HIDE_SEEKBAR = "hideSeekBar";
 
     private final ReactExoplayerConfig config;
 
@@ -449,6 +450,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
             DebugLog.setConfig(Log.WARN, enableThreadDebug);
         }
     }
+
+    @ReactProp(name = HIDE_SEEKBAR, defaultBoolean = false)
+        public void setHideSeekBar(final ReactExoplayerView videoView, final boolean hideSeekBar) {
+            videoView.setHideSeekBar(hideSeekBar);
+        }
 
     private boolean startsWithValidScheme(String uriString) {
         String lowerCaseUri = uriString.toLowerCase();

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -212,15 +212,15 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
             }
         } else {
             int identifier = context.getResources().getIdentifier(
-                uriString,
-                "drawable",
-                context.getPackageName()
+                    uriString,
+                    "drawable",
+                    context.getPackageName()
             );
             if (identifier == 0) {
                 identifier = context.getResources().getIdentifier(
-                uriString,
-                "raw",
-                context.getPackageName()
+                        uriString,
+                        "raw",
+                        context.getPackageName()
                 );
             }
             if (identifier > 0) {
@@ -275,28 +275,28 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     }
 
     @ReactProp(name = PROP_SELECTED_VIDEO_TRACK)
-        public void setSelectedVideoTrack(final ReactExoplayerView videoView,
-                                         @Nullable ReadableMap selectedVideoTrack) {
-            String typeString = null;
-            String value = null;
-            if (selectedVideoTrack != null) {
-                typeString = ReactBridgeUtils.safeGetString(selectedVideoTrack, PROP_SELECTED_VIDEO_TRACK_TYPE);
-                value = ReactBridgeUtils.safeGetString(selectedVideoTrack, PROP_SELECTED_VIDEO_TRACK_VALUE);
-            }
-            videoView.setSelectedVideoTrack(typeString, value);
+    public void setSelectedVideoTrack(final ReactExoplayerView videoView,
+                                      @Nullable ReadableMap selectedVideoTrack) {
+        String typeString = null;
+        String value = null;
+        if (selectedVideoTrack != null) {
+            typeString = ReactBridgeUtils.safeGetString(selectedVideoTrack, PROP_SELECTED_VIDEO_TRACK_TYPE);
+            value = ReactBridgeUtils.safeGetString(selectedVideoTrack, PROP_SELECTED_VIDEO_TRACK_VALUE);
         }
+        videoView.setSelectedVideoTrack(typeString, value);
+    }
 
-        @ReactProp(name = PROP_SELECTED_AUDIO_TRACK)
-        public void setSelectedAudioTrack(final ReactExoplayerView videoView,
-                                         @Nullable ReadableMap selectedAudioTrack) {
-            String typeString = null;
-            String value = null;
-            if (selectedAudioTrack != null) {
-                typeString = ReactBridgeUtils.safeGetString(selectedAudioTrack, PROP_SELECTED_AUDIO_TRACK_TYPE);
-                value = ReactBridgeUtils.safeGetString(selectedAudioTrack, PROP_SELECTED_AUDIO_TRACK_VALUE);
-            }
-            videoView.setSelectedAudioTrack(typeString, value);
+    @ReactProp(name = PROP_SELECTED_AUDIO_TRACK)
+    public void setSelectedAudioTrack(final ReactExoplayerView videoView,
+                                      @Nullable ReadableMap selectedAudioTrack) {
+        String typeString = null;
+        String value = null;
+        if (selectedAudioTrack != null) {
+            typeString = ReactBridgeUtils.safeGetString(selectedAudioTrack, PROP_SELECTED_AUDIO_TRACK_TYPE);
+            value = ReactBridgeUtils.safeGetString(selectedAudioTrack, PROP_SELECTED_AUDIO_TRACK_VALUE);
         }
+        videoView.setSelectedAudioTrack(typeString, value);
+    }
 
     @ReactProp(name = PROP_SELECTED_TEXT_TRACK)
     public void setSelectedTextTrack(final ReactExoplayerView videoView,
@@ -450,6 +450,12 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
         } else {
             DebugLog.setConfig(Log.WARN, enableThreadDebug);
         }
+    }
+
+    @ReactProp(name = PROP_CONTROLS_STYLES)
+    public void setControlsStyles(final ReactExoplayerView videoView, @Nullable ReadableMap controlsStyles) {
+        ControlsConfig controlsConfig = ControlsConfig.parse(controlsStyles);
+        videoView.setControlsStyles(controlsConfig);
     }
 
     @ReactProp(name = PROP_CONTROLS_STYLES)

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -219,7 +219,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
             if (identifier == 0) {
                 identifier = context.getResources().getIdentifier(
                     uriString,
-                        "raw",
+                    "raw",
                         context.getPackageName()
                 );
             }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -218,7 +218,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
             );
             if (identifier == 0) {
                 identifier = context.getResources().getIdentifier(
-                        uriString,
+                    uriString,
                         "raw",
                         context.getPackageName()
                 );

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -212,7 +212,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
             }
         } else {
             int identifier = context.getResources().getIdentifier(
-                    uriString,
+                uriString,
                     "drawable",
                     context.getPackageName()
             );

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -220,7 +220,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
                 identifier = context.getResources().getIdentifier(
                     uriString,
                     "raw",
-                        context.getPackageName()
+                    context.getPackageName()
                 );
             }
             if (identifier > 0) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -214,7 +214,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
             int identifier = context.getResources().getIdentifier(
                 uriString,
                     "drawable",
-                    context.getPackageName()
+                context.getPackageName()
             );
             if (identifier == 0) {
                 identifier = context.getResources().getIdentifier(

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -276,7 +276,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
 
     @ReactProp(name = PROP_SELECTED_VIDEO_TRACK)
     public void setSelectedVideoTrack(final ReactExoplayerView videoView,
-                                      @Nullable ReadableMap selectedVideoTrack) {
+                                     @Nullable ReadableMap selectedVideoTrack) {
         String typeString = null;
         String value = null;
         if (selectedVideoTrack != null) {

--- a/docs/pages/component/props.mdx
+++ b/docs/pages/component/props.mdx
@@ -51,7 +51,7 @@ A Boolean value that indicates whether the player should automatically delay pla
 
 <PlatformsList types={['Android']} />
 
-Adjust the control styles. This prop takes an object with one property listed below.
+Adjust the control styles. This prop is need only if `controls={true}` and is an object. See the list of prop supported below.
 
 | Property    | Type    | Description                                                                          |
 |-------------|---------|--------------------------------------------------------------------------------------|
@@ -65,6 +65,7 @@ controlsStyles={{
 }}
 ```
 
+
 ### `bufferConfig`
 
 <PlatformsList types={['Android']} />
@@ -72,7 +73,7 @@ controlsStyles={{
 Adjust the buffer settings. This prop takes an object with one or more of the properties listed below.
 
 | Property                          | Type   | Description                                                                                                                                                                                     |
-|-----------------------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --------------------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | minBufferMs                       | number | The default minimum duration of media that the player will attempt to ensure is buffered at all times, in milliseconds.                                                                         |
 | maxBufferMs                       | number | The default maximum duration of media that the player will attempt to buffer, in milliseconds.                                                                                                  |
 | bufferForPlaybackMs               | number | The default duration of media that must be buffered for playback to start or resume following a user action such as a seek, in milliseconds.                                                    |
@@ -115,7 +116,7 @@ Configure buffering / data loading strategy.
 To provide a custom chapter source for tvOS. This prop takes an array of objects with the properties listed below.
 
 | Property  | Type    | Description                                                                                                                                               |
-|-----------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | title     | string  | The title of the chapter to create                                                                                                                        |
 | startTime | number  | The start time of the chapter in seconds                                                                                                                  |
 | endTime   | number  | The end time of the chapter in seconds                                                                                                                    |
@@ -156,7 +157,7 @@ Enable more verbosity in logs.
 > Do not use this open in production build
 
 | Property | Type    | Description                                   |
-|----------|---------|-----------------------------------------------|
+| -------- | ------- | --------------------------------------------- |
 | `enable` | boolean | when true, display logs with verbosity higher |
 | `thread` | boolean | enable thread display                         |
 
@@ -519,7 +520,7 @@ selectedAudioTrack={{
 ```
 
 | Type               | Value  | Description                                                                                 |
-|--------------------|--------|---------------------------------------------------------------------------------------------|
+| ------------------ | ------ | ------------------------------------------------------------------------------------------- |
 | "system" (default) | N/A    | Play the audio track that matches the system language. If none match, play the first track. |
 | "disabled"         | N/A    | Turn off audio                                                                              |
 | "title"            | string | Play the audio track with the title specified as the Value, e.g. "French"                   |
@@ -551,7 +552,7 @@ selectedTextTrack={{
 ```
 
 | Type               | Value  | Description                                                                   |
-|--------------------|--------|-------------------------------------------------------------------------------|
+| ------------------ | ------ | ----------------------------------------------------------------------------- |
 | "system" (default) | N/A    | Display captions only if the system preference for captions is enabled        |
 | "disabled"         | N/A    | Don't display a text track                                                    |
 | "title"            | string | Display the text track with the title specified as the Value, e.g. "French 1" |
@@ -585,7 +586,7 @@ selectedVideoTrack={{
 ```
 
 | Type             | Value  | Description                                                                  |
-|------------------|--------|------------------------------------------------------------------------------|
+| ---------------- | ------ | ---------------------------------------------------------------------------- |
 | "auto" (default) | N/A    | Let the player determine which track to play using ABR                       |
 | "disabled"       | N/A    | Turn off video                                                               |
 | "resolution"     | number | Play the video track with the height specified, e.g. 480 for the 480p stream |
@@ -757,7 +758,7 @@ source={{
 ### `subtitleStyle`
 
 | Property      | Description                                                                                                                                                                                        | Platforms    |
-|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
 | fontSize      | Adjust the font size of the subtitles. Default: font size of the device                                                                                                                            | Android      |
 | paddingTop    | Adjust the top padding of the subtitles. Default: 0                                                                                                                                                | Android      |
 | paddingBottom | Adjust the bottom padding of the subtitles. Default: 0                                                                                                                                             | Android      |
@@ -780,7 +781,7 @@ Load one or more "sidecar" text tracks. This takes an array of objects represent
 > ⚠️ This feature does not work with HLS playlists (e.g m3u8) on iOS
 
 | Property | Description                                                                                                                                                                      |
-|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | title    | Descriptive name for the track                                                                                                                                                   |
 | language | 2 letter [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) representing the language                                                                       |
 | type     | Mime type of the track _ TextTrackType.SRT - SubRip (.srt) _ TextTrackType.TTML - TTML (.ttml) \* TextTrackType.VTT - WebVTT (.vtt)iOS only supports VTT, Android supports all 3 |

--- a/docs/pages/component/props.mdx
+++ b/docs/pages/component/props.mdx
@@ -47,6 +47,24 @@ A Boolean value that indicates whether the player should automatically delay pla
 - **false** - Immediately starts playback
 - **true (default)** - Delays playback in order to minimize stalling
 
+### `controlsStyles`
+
+<PlatformsList types={['Android']} />
+
+Adjust the control styles. This prop takes an object with one property listed below.
+
+| Property    | Type    | Description                                                                          |
+|-------------|---------|--------------------------------------------------------------------------------------|
+| hideSeekBar | boolean | The default value is `false`, allowing you to hide the seek bar for live broadcasts. |
+
+Example with default values:
+
+```javascript
+controlsStyles={{
+  hideSeekBar: false,
+}}
+```
+
 ### `bufferConfig`
 
 <PlatformsList types={['Android']} />
@@ -54,7 +72,7 @@ A Boolean value that indicates whether the player should automatically delay pla
 Adjust the buffer settings. This prop takes an object with one or more of the properties listed below.
 
 | Property                          | Type   | Description                                                                                                                                                                                     |
-| --------------------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-----------------------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | minBufferMs                       | number | The default minimum duration of media that the player will attempt to ensure is buffered at all times, in milliseconds.                                                                         |
 | maxBufferMs                       | number | The default maximum duration of media that the player will attempt to buffer, in milliseconds.                                                                                                  |
 | bufferForPlaybackMs               | number | The default duration of media that must be buffered for playback to start or resume following a user action such as a seek, in milliseconds.                                                    |
@@ -97,7 +115,7 @@ Configure buffering / data loading strategy.
 To provide a custom chapter source for tvOS. This prop takes an array of objects with the properties listed below.
 
 | Property  | Type    | Description                                                                                                                                               |
-| --------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-----------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | title     | string  | The title of the chapter to create                                                                                                                        |
 | startTime | number  | The start time of the chapter in seconds                                                                                                                  |
 | endTime   | number  | The end time of the chapter in seconds                                                                                                                    |
@@ -138,7 +156,7 @@ Enable more verbosity in logs.
 > Do not use this open in production build
 
 | Property | Type    | Description                                   |
-| -------- | ------- | --------------------------------------------- |
+|----------|---------|-----------------------------------------------|
 | `enable` | boolean | when true, display logs with verbosity higher |
 | `thread` | boolean | enable thread display                         |
 
@@ -501,7 +519,7 @@ selectedAudioTrack={{
 ```
 
 | Type               | Value  | Description                                                                                 |
-| ------------------ | ------ | ------------------------------------------------------------------------------------------- |
+|--------------------|--------|---------------------------------------------------------------------------------------------|
 | "system" (default) | N/A    | Play the audio track that matches the system language. If none match, play the first track. |
 | "disabled"         | N/A    | Turn off audio                                                                              |
 | "title"            | string | Play the audio track with the title specified as the Value, e.g. "French"                   |
@@ -533,7 +551,7 @@ selectedTextTrack={{
 ```
 
 | Type               | Value  | Description                                                                   |
-| ------------------ | ------ | ----------------------------------------------------------------------------- |
+|--------------------|--------|-------------------------------------------------------------------------------|
 | "system" (default) | N/A    | Display captions only if the system preference for captions is enabled        |
 | "disabled"         | N/A    | Don't display a text track                                                    |
 | "title"            | string | Display the text track with the title specified as the Value, e.g. "French 1" |
@@ -567,7 +585,7 @@ selectedVideoTrack={{
 ```
 
 | Type             | Value  | Description                                                                  |
-| ---------------- | ------ | ---------------------------------------------------------------------------- |
+|------------------|--------|------------------------------------------------------------------------------|
 | "auto" (default) | N/A    | Let the player determine which track to play using ABR                       |
 | "disabled"       | N/A    | Turn off video                                                               |
 | "resolution"     | number | Play the video track with the height specified, e.g. 480 for the 480p stream |
@@ -739,7 +757,7 @@ source={{
 ### `subtitleStyle`
 
 | Property      | Description                                                                                                                                                                                        | Platforms    |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
 | fontSize      | Adjust the font size of the subtitles. Default: font size of the device                                                                                                                            | Android      |
 | paddingTop    | Adjust the top padding of the subtitles. Default: 0                                                                                                                                                | Android      |
 | paddingBottom | Adjust the bottom padding of the subtitles. Default: 0                                                                                                                                             | Android      |
@@ -762,7 +780,7 @@ Load one or more "sidecar" text tracks. This takes an array of objects represent
 > ⚠️ This feature does not work with HLS playlists (e.g m3u8) on iOS
 
 | Property | Description                                                                                                                                                                      |
-| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | title    | Descriptive name for the track                                                                                                                                                   |
 | language | 2 letter [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) representing the language                                                                       |
 | type     | Mime type of the track _ TextTrackType.SRT - SubRip (.srt) _ TextTrackType.TTML - TTML (.ttml) \* TextTrackType.VTT - WebVTT (.vtt)iOS only supports VTT, Android supports all 3 |
@@ -797,7 +815,7 @@ textTracks={[
 
 <PlatformsList types={['Android', 'iOS']}/>
 
-Controls whether to show media controls in the notification area. 
+Controls whether to show media controls in the notification area.
 For Android each Video component will have its own notification controls and for iOS only one notification control will be shown for the last Active Video component.
 
 You propably want also set `playInBackground` to `true` to keep the video playing when the app is in the background or `playWhenInactive` to `true` to keep the video playing when notifications or the Control Center are in front of the video.

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -320,6 +320,7 @@ export interface VideoNativeProps extends ViewProps {
   useTextureView?: boolean; // Android
   useSecureView?: boolean; // Android
   bufferingStrategy?: BufferingStrategyType; // Android
+  hideSeekBar?: boolean; // Android
   onVideoLoad?: DirectEventHandler<OnLoadData>;
   onVideoLoadStart?: DirectEventHandler<OnLoadStartData>;
   onVideoAspectRatio?: DirectEventHandler<OnVideoAspectRatioData>;

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -274,7 +274,7 @@ export type OnAudioFocusChangedData = Readonly<{
 }>;
 
 type ControlsStyles = Readonly<{
-  hideSeekBar?: boolean
+  hideSeekBar?: boolean;
 }>;
 
 export interface VideoNativeProps extends ViewProps {

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -273,6 +273,10 @@ export type OnAudioFocusChangedData = Readonly<{
   hasAudioFocus: boolean;
 }>;
 
+type ControlsStyles = Readonly<{
+  hideSeekBar?: boolean
+}>;
+
 export interface VideoNativeProps extends ViewProps {
   src?: VideoSrc;
   drm?: Drm;
@@ -320,7 +324,7 @@ export interface VideoNativeProps extends ViewProps {
   useTextureView?: boolean; // Android
   useSecureView?: boolean; // Android
   bufferingStrategy?: BufferingStrategyType; // Android
-  hideSeekBar?: boolean; // Android
+  controlsStyles?: ControlsStyles; // Android
   onVideoLoad?: DirectEventHandler<OnLoadData>;
   onVideoLoadStart?: DirectEventHandler<OnLoadStartData>;
   onVideoAspectRatio?: DirectEventHandler<OnVideoAspectRatioData>;

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -247,4 +247,5 @@ export interface ReactVideoProps extends ReactVideoEvents, ViewProps {
   localSourceEncryptionKeyScheme?: string;
   debug?: DebugConfig;
   allowsExternalPlayback?: boolean; // iOS
+  hideSeekBar?: boolean; // Android
 }

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -194,7 +194,7 @@ export enum PosterResizeModeType {
 export type AudioOutput = 'speaker' | 'earpiece';
 
 export type ControlsStyles = {
-  hideSeekBar?: boolean
+  hideSeekBar?: boolean;
 };
 
 export interface ReactVideoProps extends ReactVideoEvents, ViewProps {

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -193,6 +193,10 @@ export enum PosterResizeModeType {
 
 export type AudioOutput = 'speaker' | 'earpiece';
 
+export type ControlsStyles = {
+  hideSeekBar?: boolean
+};
+
 export interface ReactVideoProps extends ReactVideoEvents, ViewProps {
   source?: ReactVideoSource;
   drm?: Drm;
@@ -247,5 +251,5 @@ export interface ReactVideoProps extends ReactVideoEvents, ViewProps {
   localSourceEncryptionKeyScheme?: string;
   debug?: DebugConfig;
   allowsExternalPlayback?: boolean; // iOS
-  hideSeekBar?: boolean; // Android
+  controlsStyles?: ControlsStyles; // Android
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary

### Motivation
My goal was to address an issue with the excellent library on Android devices.

### Changes
I introduced a new property called `hideSeekBar` to manage the visibility of the seekBar when the `controls` property is set to true.

## Test plan