### PR TITLE
fix(android): implement seek backward in notification service

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/VideoPlaybackCallback.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/VideoPlaybackCallback.kt
@@ -36,7 +36,7 @@ class VideoPlaybackCallback(private val seekIntervalMS: Long) : MediaSession.Cal
     ): ListenableFuture<SessionResult> {
         when (customCommand.customAction) {
             VideoPlaybackService.COMMAND_SEEK_FORWARD -> session.player.seekTo(session.player.contentPosition + seekIntervalMS)
-            VideoPlaybackService.COMMAND_SEEK_BACKWARD -> session.player.seekTo(session.player.contentPosition + seekIntervalMS)
+            VideoPlaybackService.COMMAND_SEEK_BACKWARD -> session.player.seekTo(session.player.contentPosition - seekIntervalMS)
         }
         return super.onCustomCommand(session, controller, customCommand, args)
     }


### PR DESCRIPTION
- Update the documentation
No update needed.

- Provide an example of how to test the change

https://github.com/TheWidlarzGroup/react-native-video/assets/107127397/fb8bfc97-1a6d-4ed8-ad01-e536d85a6b2b

- Describe the changes
Subtract from the content position instead of adding to it

## Summary
Fix seek backward in notification controls on Android by subtracting seek seconds instead of adding them.

### Motivation
Correctness

## Test plan
Review example/basic