### PR TITLE
docs: update min iOS version info

### DIFF
--- a/docs/pages/component/props.mdx
+++ b/docs/pages/component/props.mdx
@@ -836,6 +836,8 @@ textTracks={[
 Controls whether to show media controls in the notification area.
 For Android each Video component will have its own notification controls and for iOS only one notification control will be shown for the last Active Video component.
 
+On android this will also allow for external controls, Google Assisten session and other benefits of MediaSession.
+
 You propably want also set `playInBackground` to `true` to keep the video playing when the app is in the background or `playWhenInactive` to `true` to keep the video playing when notifications or the Control Center are in front of the video.
 
 To customize the notification controls you can use `metadata` property in the `source` prop.

--- a/docs/pages/component/props.mdx
+++ b/docs/pages/component/props.mdx
@@ -836,7 +836,7 @@ textTracks={[
 Controls whether to show media controls in the notification area.
 For Android each Video component will have its own notification controls and for iOS only one notification control will be shown for the last Active Video component.
 
-On android this will also allow for external controls, Google Assisten session and other benefits of MediaSession.
+On android this will also allow for external controls, Google Assistant session and other benefits of MediaSession.
 
 You propably want also set `playInBackground` to `true` to keep the video playing when the app is in the background or `playWhenInactive` to `true` to keep the video playing when notifications or the Control Center are in front of the video.
 

--- a/docs/pages/installation.md
+++ b/docs/pages/installation.md
@@ -24,6 +24,8 @@ Then follow the instructions for your platform to link react-native-video into y
 ### Standard Method
 Run `pod install` in the `ios` directory of your project.
 
+⚠️ from version `6.0.0` the minimum iOS version required is `13.0`. For more information see [updating section](updating.md)
+
 ### Enable custom feature in podfile file
 
 Samples available in sample app see [sample pod file](https://github.com/TheWidlarzGroup/react-native-video/blob/9c669a2d8a53df36773fd82ff0917280d0659bc7/examples/basic/ios/Podfile#L34)

--- a/docs/pages/updating.md
+++ b/docs/pages/updating.md
@@ -4,6 +4,19 @@
 
 #### iOS
 
+##### Min iOS version
+From version 6.0.0, the minimum iOS version supported is 13.0. Projects that are using `react-native < 0.73` will need to set the minimum iOS version to 13.0 in the Podfile.
+
+You can do it by adding the following code to your Podfile:
+```diff
+- platform :ios, min_ios_version_supported
+
++ MIN_IOS_OVERRIDE = '13.0'
++ if Gem::Version.new(MIN_IOS_OVERRIDE) > Gem::Version.new(min_ios_version_supported)
++   min_ios_version_supported = MIN_IOS_OVERRIDE
++ end
+```
+
 ##### linking
 In your project Podfile add support for static dependency linking. This is required to support the new Promises subdependency in the iOS swift conversion.
 


### PR DESCRIPTION
## Summary
Add information to docs about min iOS version

### Motivation
Less count of issue generated by wrong min iOS version < 13.0

### Changes
- updated installation and updating version

## Test plan
- [x] docs builds