### PR TITLE
feat(android): Change subtitleLayout from child to sibling of layout

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -86,10 +86,10 @@ public final class ExoPlayerView extends FrameLayout implements AdViewProvider {
         adOverlayFrameLayout = new FrameLayout(context);
 
         layout.addView(shutterView, 1, layoutParams);
-        layout.addView(subtitleLayout, 2, layoutParams);
-        layout.addView(adOverlayFrameLayout, 3, layoutParams);
+        layout.addView(adOverlayFrameLayout, 2, layoutParams);
 
         addViewInLayout(layout, 0, aspectRatioParams);
+        addViewInLayout(subtitleLayout, 1, layoutParams);
     }
 
     private void clearVideoView() {


### PR DESCRIPTION
## Summary
Change subtitleLayout from child to sibling of layout

### Motivation
I think the behavior of subtitle position changing by resize mode is a bug, but if not, please close it.

### Changes
- as-is
<img src="https://github.com/TheWidlarzGroup/react-native-video/assets/35353546/01e9495b-dd82-48eb-beba-da6ba09f5f93" width=20%>
<img src="https://github.com/TheWidlarzGroup/react-native-video/assets/35353546/9a4af82d-c076-4c51-8f2d-761f4242ae9e" width=20%>
<img src="https://github.com/TheWidlarzGroup/react-native-video/assets/35353546/462454e7-71ea-4ca3-9256-cc35e4fab4a3" width=40%>
<img src="https://github.com/TheWidlarzGroup/react-native-video/assets/35353546/2491d39d-6257-4c59-9352-af0d1db10c99" width=40%>

- to-be
<img src="https://github.com/TheWidlarzGroup/react-native-video/assets/35353546/76bf794b-1196-4a82-b76d-3361a6c81718" width=20%>
<img src="https://github.com/TheWidlarzGroup/react-native-video/assets/35353546/266cbfd4-e5d3-4f4e-8162-6a1579264311" width=20%>
<img src="https://github.com/TheWidlarzGroup/react-native-video/assets/35353546/fb7b3037-3385-457f-b0b8-c3f54d9e47fa" width=40%>
<img src="https://github.com/TheWidlarzGroup/react-native-video/assets/35353546/118d28c1-5d69-4a87-aa0a-008b120362c2" width=40%>

## Test plan
change resize mode (CONTAIN / COVER)