### PR TITLE
fix(android): allow notification tap to foreground app

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -139,6 +139,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.ArrayList;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -842,7 +843,8 @@ public class ReactExoplayerView extends FrameLayout implements
                 playbackServiceBinder = (PlaybackServiceBinder) service;
 
                 try {
-                    playbackServiceBinder.getService().registerPlayer(player);
+                    playbackServiceBinder.getService().registerPlayer(player,
+                            Objects.requireNonNull((Class<Activity>) (themedReactContext.getCurrentActivity()).getClass()));
                 } catch (Exception e) {
                     DebugLog.e(TAG, "Cloud not register ExoPlayer");
                 }


### PR DESCRIPTION
- Update the documentation
N/A

- Provide an example of how to test the change
https://github.com/TheWidlarzGroup/react-native-video/assets/107127397/a4f1e82d-47cb-439f-9998-665fb2f70714
set `showNotificationControls={true}` on video player

- Focus the PR on only one area
N/A

- Describe the changes
Passes the activity which spawns the notification service to the service so that the service can set the intent to foreground that service when clicked.

## Summary
Enable tapping on notification to foreground the original app.

### Motivation
Feature parity between iOS and Android. General expectation of tapping a notification.

### Changes
set the pending intent for setSessionActivity on mediaSession creation in Android.

## Test plan
N/A

### Other Notes
Address #3881
We might want to import android.app.Activity instead of using fully qualified type to maintain codestyle.
We might want to pass this in a different way... this is a first attempt that works.
Need to clean this up still
