### PR TITLE
fix(ios): don't crash app if view wasn't found

### DIFF
--- a/examples/basic/ios/Podfile.lock
+++ b/examples/basic/ios/Podfile.lock
@@ -935,7 +935,7 @@ PODS:
   - React-Mapbuffer (0.74.1):
     - glog
     - React-debug
-  - react-native-video (6.0.0):
+  - react-native-video (6.1.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -949,7 +949,7 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
-    - react-native-video/Video (= 6.0.0)
+    - react-native-video/Video (= 6.1.2)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -957,7 +957,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-video/Video (6.0.0):
+  - react-native-video/Video (6.1.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1398,7 +1398,7 @@ SPEC CHECKSUMS:
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 16b8530de1b383cdada1476cf52d1b52f0692cbc
-  RCT-Folly: 045d6ecaa59d826c5736dfba0b2f4083ff8d79df
+  RCT-Folly: 02617c592a293bd6d418e0a88ff4ee1f88329b47
   RCTDeprecation: efb313d8126259e9294dc4ee0002f44a6f676aba
   RCTRequired: f49ea29cece52aee20db633ae7edc4b271435562
   RCTTypeSafety: a11979ff0570d230d74de9f604f7d19692157bc4
@@ -1422,7 +1422,7 @@ SPEC CHECKSUMS:
   React-jsitracing: 3de522f8f794dccd3c54af9160dc992ee65bd494
   React-logger: 7e7403a2b14c97f847d90763af76b84b152b6fce
   React-Mapbuffer: c5844bf3c2206f5475c0fc2340a89b049ea23c97
-  react-native-video: e0c12a51732b3a6c46baf5f0d26986b34ca286b4
+  react-native-video: edecf23162492d4f41f96ff167684fc0507ca63a
   React-nativeconfig: 21d89c65ca39875fad2c5c465e0e013e514eba21
   React-NativeModulesApple: e2e180dae4486b2978fcf3564cc4c8de4b453a68
   React-perflogger: 3d31e0d1e8ad891e43a09ac70b7b17a79773003a
@@ -1452,4 +1452,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: bbe1bd5f521b6b9366288dbaf8af1cec85c0a95a
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.13.0

--- a/ios/Video/RCTVideoManager.swift
+++ b/ios/Video/RCTVideoManager.swift
@@ -17,7 +17,7 @@ class RCTVideoManager: RCTViewManager {
                 callback(nil)
                 return
             }
-            
+
             let view = self.bridge.uiManager.view(forReactTag: reactTag)
 
             guard let videoView = view as? RCTVideo else {

--- a/ios/Video/RCTVideoManager.swift
+++ b/ios/Video/RCTVideoManager.swift
@@ -17,14 +17,16 @@ class RCTVideoManager: RCTViewManager {
                 callback(nil)
                 return
             }
+            
+            let view = self.bridge.uiManager.view(forReactTag: reactTag)
 
-            guard let view = self.bridge.uiManager.view(forReactTag: reactTag) as? RCTVideo else {
-                RCTLogError("Invalid view returned from registry, expecting RCTVideo, got: \(String(describing: view))")
+            guard let videoView = view as? RCTVideo else {
+                DebugLog("Invalid view returned from registry, expecting RCTVideo, got: \(String(describing: view))")
                 callback(nil)
                 return
             }
 
-            callback(view)
+            callback(videoView)
         }
     }
 


### PR DESCRIPTION
## Summary
Change RCTError to DebugLog to fix App crashes that are using `react-native-video` with Interop Layer (new arch)

I have an app where this issue appears and this patch is fixing it

### Motivation
Fix App crashes that are using `react-native-video` with Interop Layer (new arch)

### Changes
- change RCTError to DebugLog
- add additional variable to make DebugLog message working correctly 

## Test plan
- Run basic app with new arch
- Crash should happen when using ref functions