### PR TITLE
fix(ios): notification controls enabled by default

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -459,8 +459,10 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             _player = AVPlayer()
             _player!.replaceCurrentItem(with: playerItem)
 
-            // We need to register player after we set current item and only for init
-            NowPlayingInfoCenterManager.shared.registerPlayer(player: _player!)
+            if _showNotificationControls {
+                // We need to register player after we set current item and only for init
+                NowPlayingInfoCenterManager.shared.registerPlayer(player: _player!)
+            }
         } else {
             _player?.replaceCurrentItem(with: playerItem)
 


### PR DESCRIPTION
## Summary
Fix notification controls enabled by default

### Motivation
fixes #3856

### Changes
- Check if `showNotificationControls` is `true`

## Test plan
- set `showNotificationControls` to `false`
- build on real device
- notification controls should not be visible