### PR TITLE
fix(android): fix null pointer exception at playback start with item metadata

### DIFF
--- a/android/src/main/java/com/brentvatne/common/api/Source.kt
+++ b/android/src/main/java/com/brentvatne/common/api/Source.kt
@@ -14,6 +14,7 @@ import com.brentvatne.common.toolbox.ReactBridgeUtils.safeGetMap
 import com.brentvatne.common.toolbox.ReactBridgeUtils.safeGetString
 import com.facebook.react.bridge.ReadableMap
 import java.util.Locale
+import java.util.Objects
 
 /**
  * Class representing Source props for host.
@@ -43,6 +44,8 @@ class Source {
 
     /** http header list */
     val headers: MutableMap<String, String> = HashMap()
+
+    override fun hashCode(): Int = Objects.hash(uriString, uri, startPositionMs, cropStartMs, cropEndMs, extension, metadata, headers)
 
     /** return true if this and src are equals  */
     override fun equals(other: Any?): Boolean {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -980,6 +980,8 @@ public class ReactExoplayerView extends FrameLayout implements
         MediaItem.Builder mediaItemBuilder = new MediaItem.Builder()
                 .setUri(uri);
 
+        // refresh custom Metadata
+        customMetadata = ConfigurationUtils.buildCustomMetadata(source.getMetadata());
         if (customMetadata != null) {
             mediaItemBuilder.setMediaMetadata(customMetadata);
         }
@@ -1750,19 +1752,6 @@ public class ReactExoplayerView extends FrameLayout implements
                     DataSourceUtil.getDefaultDataSourceFactory(this.themedReactContext, bandwidthMeter,
                             source.getHeaders());
 
-            // refresh custom Metadata
-            MediaMetadata newCustomMetadata = ConfigurationUtils.buildCustomMetadata(source.getMetadata());
-
-            // Apply custom metadata is possible
-            if (player != null && !Util.areEqual(newCustomMetadata, customMetadata)) {
-                customMetadata = newCustomMetadata;
-                MediaItem currentMediaItem = player.getCurrentMediaItem();
-                if (currentMediaItem != null) {
-                    MediaItem newMediaItem = currentMediaItem.buildUpon().setMediaMetadata(customMetadata).build();
-                    // This will cause video blink/reload but won't louse progress
-                    player.setMediaItem(newMediaItem, false);
-                }
-            }
             if (!isSourceEqual) {
                 reloadSource();
             }


### PR DESCRIPTION
## Summary
Ensure we don't cause nullPointer exception (internally to exoplayer) when starting playback with notification enabled

### Motivation
Avoid popup error

### Changes
Extracting notification patch from this pull request:
https://github.com/TheWidlarzGroup/react-native-video/pull/3846/files#diff-a35ae7e6ae6efee3b22522a836bcbcdd9d59a214f087df454e4ccbb8cd5c0e76
Changes consist in initializing only once the mediaMetadata during source initialization 


## Test plan
Can be tested in sample, current issue can be reproduced by going on "no view" with next channel and going back to live channel with channel down