### PR TITLE
fix(ios): Implicit use of 'self' in closure - use 'self.' to make capture semantics explicit (#3764)

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -258,6 +258,7 @@ public class ReactExoplayerView extends FrameLayout implements
     private long lastBufferDuration = -1;
     private long lastDuration = -1;
 
+    private boolean viewHasDropped = false;
     private void updateProgress() {
         if (player != null) {
             if (playerControlView != null && isPlayingAd() && controls) {
@@ -375,6 +376,8 @@ public class ReactExoplayerView extends FrameLayout implements
     public void cleanUpResources() {
         stopPlayback();
         themedReactContext.removeLifecycleEventListener(this);
+        releasePlayer();
+        viewHasDropped = true;
     }
 
     //BandwidthMeter.EventListener implementation
@@ -647,6 +650,9 @@ public class ReactExoplayerView extends FrameLayout implements
         Activity activity = themedReactContext.getCurrentActivity();
         // This ensures all props have been settled, to avoid async racing conditions.
         mainRunnable = () -> {
+            if (viewHasDropped) {
+                return;
+            }
             try {
                 if (player == null) {
                     // Initialize core configuration and listeners
@@ -658,7 +664,9 @@ public class ReactExoplayerView extends FrameLayout implements
                     ExecutorService es = Executors.newSingleThreadExecutor();
                     es.execute(() -> {
                         // DRM initialization must run on a different thread
-
+                        if (viewHasDropped) {
+                            return;
+                        }
                         if (activity == null) {
                             DebugLog.e(TAG, "Failed to initialize Player!, null activity");
                             eventEmitter.error("Failed to initialize Player!", new Exception("Current Activity is null!"), "1001");
@@ -667,12 +675,15 @@ public class ReactExoplayerView extends FrameLayout implements
 
                         // Initialize handler to run on the main thread
                         activity.runOnUiThread(() -> {
+                            if (viewHasDropped) {
+                                return;
+                            }
                             try {
                                 // Source initialization must run on the main thread
                                 initializePlayerSource();
                             } catch (Exception ex) {
                                 self.playerNeedsSource = true;
-                                DebugLog.e(TAG, "Failed to initialize Player!");
+                                DebugLog.e(TAG, "Failed to initialize Player! 1");
                                 DebugLog.e(TAG, ex.toString());
                                 ex.printStackTrace();
                                 self.eventEmitter.error(ex.toString(), ex, "1001");
@@ -684,7 +695,7 @@ public class ReactExoplayerView extends FrameLayout implements
                 }
             } catch (Exception ex) {
                 self.playerNeedsSource = true;
-                DebugLog.e(TAG, "Failed to initialize Player!");
+                DebugLog.e(TAG, "Failed to initialize Player! 2");
                 DebugLog.e(TAG, ex.toString());
                 ex.printStackTrace();
                 eventEmitter.error(ex.toString(), ex, "1001");

--- a/ios/Video/NowPlayingInfoCenterManager.swift
+++ b/ios/Video/NowPlayingInfoCenterManager.swift
@@ -61,11 +61,11 @@ class NowPlayingInfoCenterManager {
             return
         }
 
-        if let observer = observers[players.hashValue] {
+        if let observer = observers[player.hashValue] {
             observer.invalidate()
         }
 
-        observers.removeValue(forKey: players.hashValue)
+        observers.removeValue(forKey: player.hashValue)
         players.remove(player)
 
         if currentPlayer == player {

--- a/ios/Video/NowPlayingInfoCenterManager.swift
+++ b/ios/Video/NowPlayingInfoCenterManager.swift
@@ -150,7 +150,7 @@ class NowPlayingInfoCenterManager {
             guard let self, let player = self.currentPlayer else {
                 return .commandFailed
             }
-            let newTime = player.currentTime() - CMTime(seconds: SEEK_INTERVAL_SECONDS, preferredTimescale: .max)
+            let newTime = player.currentTime() - CMTime(seconds: self.SEEK_INTERVAL_SECONDS, preferredTimescale: .max)
             player.seek(to: newTime)
             return .success
         }
@@ -160,7 +160,7 @@ class NowPlayingInfoCenterManager {
                 return .commandFailed
             }
 
-            let newTime = player.currentTime() + CMTime(seconds: SEEK_INTERVAL_SECONDS, preferredTimescale: .max)
+            let newTime = player.currentTime() + CMTime(seconds: self.SEEK_INTERVAL_SECONDS, preferredTimescale: .max)
             player.seek(to: newTime)
             return .success
         }
@@ -266,15 +266,15 @@ class NowPlayingInfoCenterManager {
 
             // case where there is new player that is not paused
             // In this case event is triggered by non currentPlayer
-            if rate != 0 && currentPlayer != player {
-                setCurrentPlayer(player: player)
+            if rate != 0 && self.currentPlayer != player {
+                self.setCurrentPlayer(player: player)
                 return
             }
 
             // case where currentPlayer was paused
             // In this case event is triggeret by currentPlayer
-            if rate == 0 && currentPlayer == player {
-                findNewCurrentPlayer()
+            if rate == 0 && self.currentPlayer == player {
+                self.findNewCurrentPlayer()
             }
         }
     }

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1241,10 +1241,19 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     // MARK: - Lifecycle
 
     override func removeFromSuperview() {
+        self._player?.replaceCurrentItem(with: nil)
         if let player = _player {
             player.pause()
             NowPlayingInfoCenterManager.shared.removePlayer(player: player)
         }
+        _playerItem = nil
+        _source = nil
+        _chapters = nil
+        _drm = nil
+        _textTracks = nil
+        _selectedTextTrackCriteria = nil
+        _selectedAudioTrackCriteria = nil
+        _presentingViewController = nil
 
         _player = nil
         _resouceLoaderDelegate = nil
@@ -1252,6 +1261,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
         #if USE_GOOGLE_IMA
             _imaAdsManager.releaseAds()
+            _imaAdsManager = nil
         #endif
 
         self.removePlayerLayer()

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -525,7 +525,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                     guard let self else { throw NSError(domain: "", code: 0, userInfo: nil) }
 
                     let playerItem = try await self.preparePlayerItem()
-                    try await setupPlayer(playerItem: playerItem)
+                    try await self.setupPlayer(playerItem: playerItem)
                 } catch {
                     DebugLog("An error occurred: \(error.localizedDescription)")
 
@@ -763,7 +763,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             guard let self else { return }
 
             self._playerObserver.addTimeObserverIfNotSet()
-            self.setPaused(_paused)
+            self.setPaused(self._paused)
             self.onVideoSeek?(["currentTime": NSNumber(value: Float(CMTimeGetSeconds(item.currentTime()))),
                                "seekTime": seekTime,
                                "target": self.reactTag])

--- a/ios/Video/RCTVideoManager.swift
+++ b/ios/Video/RCTVideoManager.swift
@@ -21,7 +21,7 @@ class RCTVideoManager: RCTViewManager {
             let view = self.bridge.uiManager.view(forReactTag: reactTag)
 
             guard let videoView = view as? RCTVideo else {
-                DebugLog("Invalid view returned from registry, expecting RCTVideo, got: \(String(describing: view))")
+                DebugLog("Invalid view returned from registry, expecting RCTVideo, got: \(String(describing: self.view))")
                 callback(nil)
                 return
             }


### PR DESCRIPTION
Patch commit to fix the error: `Implicit use of 'self' in closure; use 'self.' to make capture semantics explicit`

### Fix
#3764
