### PR TITLE
feat: add `isSeeking` to `onPlaybackStateChanged`

### DIFF
--- a/android/src/main/java/com/brentvatne/common/react/VideoEventEmitter.kt
+++ b/android/src/main/java/com/brentvatne/common/react/VideoEventEmitter.kt
@@ -69,7 +69,7 @@ class VideoEventEmitter {
     lateinit var onVideoError: (errorString: String, exception: Exception, errorCode: String) -> Unit
     lateinit var onVideoProgress: (currentPosition: Long, bufferedDuration: Long, seekableDuration: Long, currentPlaybackTime: Double) -> Unit
     lateinit var onVideoBandwidthUpdate: (bitRateEstimate: Long, height: Int, width: Int, trackId: String) -> Unit
-    lateinit var onVideoPlaybackStateChanged: (isPlaying: Boolean) -> Unit
+    lateinit var onVideoPlaybackStateChanged: (isPlaying: Boolean, isSeeking: Boolean) -> Unit
     lateinit var onVideoSeek: (currentPosition: Long, seekTime: Long) -> Unit
     lateinit var onVideoEnd: () -> Unit
     lateinit var onVideoFullscreenPlayerWillPresent: () -> Unit
@@ -158,9 +158,10 @@ class VideoEventEmitter {
                     putString("trackId", trackId)
                 }
             }
-            onVideoPlaybackStateChanged = { isPlaying ->
+            onVideoPlaybackStateChanged = { isPlaying, isSeeking ->
                 event.dispatch(EventTypes.EVENT_PLAYBACK_STATE_CHANGED) {
                     putBoolean("isPlaying", isPlaying)
+                    putBoolean("isSeeking", isSeeking)
                 }
             }
             onVideoSeek = { currentPosition, seekTime ->

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -221,6 +221,7 @@ public class ReactExoplayerView extends FrameLayout implements
     private Runnable mainRunnable;
     private boolean useCache = false;
     private ControlsConfig controlsConfig = new ControlsConfig();
+    private boolean wasSeeking = false;
 
     // Props from React
     private Source source = new Source();
@@ -1627,6 +1628,7 @@ public class ReactExoplayerView extends FrameLayout implements
     @Override
     public void onPositionDiscontinuity(@NonNull Player.PositionInfo oldPosition, @NonNull Player.PositionInfo newPosition, @Player.DiscontinuityReason int reason) {
         if (reason == Player.DISCONTINUITY_REASON_SEEK) {
+            wasSeeking = true;
             eventEmitter.onVideoSeek.invoke(player.getCurrentPosition(), newPosition.positionMs % 1000); // time are in seconds /°\
             if (isUsingContentResolution) {
                 // We need to update the selected track to make sure that it still matches user selection if track list has changed in this period
@@ -1678,7 +1680,11 @@ public class ReactExoplayerView extends FrameLayout implements
 
     @Override
     public void onIsPlayingChanged(boolean isPlaying) {
-        eventEmitter.onVideoPlaybackStateChanged.invoke(isPlaying);
+        if (isPlaying) {
+            wasSeeking = false;
+        }
+
+        eventEmitter.onVideoPlaybackStateChanged.invoke(isPlaying, wasSeeking);
     }
 
     @Override

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1628,7 +1628,7 @@ public class ReactExoplayerView extends FrameLayout implements
         }
 
         if (isPaused && isSeeking && !buffering) {
-            eventEmitter.seek(player.getCurrentPosition(), seekPosition);
+            eventEmitter.onVideoSeek.invoke(player.getCurrentPosition(), seekPosition);
             isSeeking = false;
         }
 
@@ -1692,7 +1692,7 @@ public class ReactExoplayerView extends FrameLayout implements
     @Override
     public void onIsPlayingChanged(boolean isPlaying) {
         if (isPlaying && isSeeking) {
-            eventEmitter.seek(player.getCurrentPosition(), seekPosition);
+            eventEmitter.onVideoSeek.invoke(player.getCurrentPosition(), seekPosition);
         }
 
         eventEmitter.onVideoPlaybackStateChanged.invoke(isPlaying, isSeeking);

--- a/docs/pages/component/events.mdx
+++ b/docs/pages/component/events.mdx
@@ -296,15 +296,17 @@ Callback function that is called when the playback state changes.
 
 Payload:
 
-| Property  | Type        | Description                                       |
-| --------- | ----------- | ------------------------------------------------- |
-| isPlaying | boolean     | Boolean indicating if the media is playing or not |
+| Property  | Type        | Description                                        |
+| --------- | ----------- | -------------------------------------------------- |
+| isPlaying | boolean     | Boolean indicating if the media is playing or not  |
+| isSeeking | boolean     | Boolean indicating if the player is seeking or not |
 
 Example:
 
 ```javascript
 {
   isPlaying: true,
+  isSeeking: false
 }
 ```
 

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -758,8 +758,10 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         let seekTime: NSNumber! = info["time"] as! NSNumber
         let seekTolerance: NSNumber! = info["tolerance"] as! NSNumber
         let item: AVPlayerItem? = _player?.currentItem
+
+        _pendingSeek = true
+
         guard item != nil, let player = _player, let item, item.status == AVPlayerItem.Status.readyToPlay else {
-            _pendingSeek = true
             _pendingSeekTime = seekTime.floatValue
             return
         }
@@ -1487,7 +1489,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
         guard _isPlaying != isPlaying else { return }
         _isPlaying = isPlaying
-        onVideoPlaybackStateChanged?(["isPlaying": isPlaying, "target": reactTag as Any])
+        onVideoPlaybackStateChanged?(["isPlaying": isPlaying, "isSeeking": self._pendingSeek == true, "target": reactTag as Any])
     }
 
     func handlePlaybackRateChange(player: AVPlayer, change: NSKeyValueObservedChange<Float>) {

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -187,6 +187,7 @@ export type OnSeekData = Readonly<{
 
 export type OnPlaybackStateChangedData = Readonly<{
   isPlaying: boolean;
+  isSeeking: boolean;
 }>;
 
 export type OnTimedMetadataData = Readonly<{


### PR DESCRIPTION
## Summary
Add `isSeeking` to `onPlaybackStateChanged` callback

### Motivation
This is pretty useful for devs that are using custom controls, bcs they can check if `onPlaybackStateChanged` was made bcs of pause/resume or seeking

fixes #3895

### Changes
- add  `isSeeking` to `onPlaybackStateChanged`
- on android i have created new variable to track seeking (not sure if it's ok but it's working)

## Test plan
Tested on android & iOS simulators