### PR TITLE
fix(typescript): type checks on selectedTextTrack, selectedAudioTrack, selectedVideoTrack

### DIFF
--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -194,8 +194,15 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         return;
       }
       const typeOfValueProp = typeof selectedTextTrack.value;
-      if (typeOfValueProp !== 'number' && typeOfValueProp !== 'string' && typeOfValueProp !== 'undefined') {
-        console.log('invalid type provided to selectedTextTrack.value: ', typeOfValueProp);
+      if (
+        typeOfValueProp !== 'number' &&
+        typeOfValueProp !== 'string' &&
+        typeOfValueProp !== 'undefined'
+      ) {
+        console.log(
+          'invalid type provided to selectedTextTrack.value: ',
+          typeOfValueProp,
+        );
         return;
       }
       return {
@@ -209,8 +216,15 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         return;
       }
       const typeOfValueProp = typeof selectedAudioTrack.value;
-      if (typeOfValueProp !== 'number' && typeOfValueProp !== 'string' && typeOfValueProp !== 'undefined') {
-        console.log('invalid type provided to selectedAudioTrack.value: ', typeOfValueProp);
+      if (
+        typeOfValueProp !== 'number' &&
+        typeOfValueProp !== 'string' &&
+        typeOfValueProp !== 'undefined'
+      ) {
+        console.log(
+          'invalid type provided to selectedAudioTrack.value: ',
+          typeOfValueProp,
+        );
         return;
       }
 
@@ -225,8 +239,15 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         return;
       }
       const typeOfValueProp = typeof selectedVideoTrack.value;
-      if (typeOfValueProp !== 'number' && typeOfValueProp !== 'string' && typeOfValueProp !== 'undefined') {
-        console.log('invalid type provided to selectedVideoTrack.value: ', typeOfValueProp);
+      if (
+        typeOfValueProp !== 'number' &&
+        typeOfValueProp !== 'string' &&
+        typeOfValueProp !== 'undefined'
+      ) {
+        console.log(
+          'invalid type provided to selectedVideoTrack.value: ',
+          typeOfValueProp,
+        );
         return;
       }
       return {

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -194,8 +194,8 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         return;
       }
       const type = typeof selectedTextTrack.value;
-      if (type !== 'number' && type !== 'string') {
-        console.log('invalid type provided to selectedTextTrack');
+      if (type !== 'number' && type !== 'string' && type !== 'undefined') {
+        console.log('invalid type provided to selectedTextTrack.value');
         return;
       }
       return {
@@ -209,8 +209,8 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         return;
       }
       const type = typeof selectedAudioTrack.value;
-      if (type !== 'number' && type !== 'string') {
-        console.log('invalid type provided to selectedAudioTrack');
+      if (type !== 'number' && type !== 'string' && type !== 'undefined') {
+        console.log('invalid type provided to selectedAudioTrack.value');
         return;
       }
 

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -193,9 +193,9 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       if (!selectedTextTrack) {
         return;
       }
-      const type = typeof selectedTextTrack.value;
-      if (type !== 'number' && type !== 'string' && type !== 'undefined') {
-        console.log('invalid type provided to selectedTextTrack.value: ', type);
+      const typeOfValueProp = typeof selectedTextTrack.value;
+      if (typeOfValueProp !== 'number' && typeOfValueProp !== 'string' && typeOfValueProp !== 'undefined') {
+        console.log('invalid type provided to selectedTextTrack.value: ', typeOfValueProp);
         return;
       }
       return {
@@ -208,9 +208,9 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       if (!selectedAudioTrack) {
         return;
       }
-      const type = typeof selectedAudioTrack.value;
-      if (type !== 'number' && type !== 'string' && type !== 'undefined') {
-        console.log('invalid type provided to selectedAudioTrack.value: ', type);
+      const typeOfValueProp = typeof selectedAudioTrack.value;
+      if (typeOfValueProp !== 'number' && typeOfValueProp !== 'string' && typeOfValueProp !== 'undefined') {
+        console.log('invalid type provided to selectedAudioTrack.value: ', typeOfValueProp);
         return;
       }
 

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -244,7 +244,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         typeOfValueProp !== 'string' &&
         typeOfValueProp !== 'undefined'
       ) {
-        console.log(
+        console.warn(
           'invalid type provided to selectedVideoTrack.value: ',
           typeOfValueProp,
         );

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -224,9 +224,9 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       if (!selectedVideoTrack) {
         return;
       }
-      const type = typeof selectedVideoTrack.value;
-      if (type !== 'number' && type !== 'string') {
-        console.log('invalid type provided to selectedVideoTrack');
+      const typeOfValueProp = typeof selectedVideoTrack.value;
+      if (typeOfValueProp !== 'number' && typeOfValueProp !== 'string' && typeOfValueProp !== 'undefined') {
+        console.log('invalid type provided to selectedVideoTrack.value: ', typeOfValueProp);
         return;
       }
       return {

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -195,7 +195,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       }
       const type = typeof selectedTextTrack.value;
       if (type !== 'number' && type !== 'string' && type !== 'undefined') {
-        console.log('invalid type provided to selectedTextTrack.value');
+        console.log('invalid type provided to selectedTextTrack.value: ', type);
         return;
       }
       return {
@@ -210,7 +210,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       }
       const type = typeof selectedAudioTrack.value;
       if (type !== 'number' && type !== 'string' && type !== 'undefined') {
-        console.log('invalid type provided to selectedAudioTrack.value');
+        console.log('invalid type provided to selectedAudioTrack.value: ', type);
         return;
       }
 

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -199,7 +199,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         typeOfValueProp !== 'string' &&
         typeOfValueProp !== 'undefined'
       ) {
-        console.log(
+        console.warn(
           'invalid type provided to selectedTextTrack.value: ',
           typeOfValueProp,
         );

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -221,7 +221,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         typeOfValueProp !== 'string' &&
         typeOfValueProp !== 'undefined'
       ) {
-        console.log(
+        console.warn(
           'invalid type provided to selectedAudioTrack.value: ',
           typeOfValueProp,
         );


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary

Fix type checks on `selectedTextTrack`, `selectedAudioTrack` and `selectedVideoTrack` properties which were added in #3704.

### Motivation

[selectedTextTrack](https://thewidlarzgroup.github.io/react-native-video/component/props#selectedtexttrack), [selectedAudioTrack](https://thewidlarzgroup.github.io/react-native-video/component/props#selectedaudiotrack) and [selectedVideoTrack](https://thewidlarzgroup.github.io/react-native-video/component/props#selectedvideotrack) can both be an object with a `type` property and an undefined `value`. This allows `react-native-video` to distinguish between disabled subtitles and subtitles following system settings.

However this behavior was broken by the addition of an incorrect type check in #3704 which does not allow the `value` property to be undefined.

### Changes

Adapted the type check to allow `value` property to be `undefined`, as per documentation and TypeScript type definitions.

## Test plan