### PR TITLE
feat(ios): detect livestreams in now playing notification 

### DIFF
--- a/ios/Video/NowPlayingInfoCenterManager.swift
+++ b/ios/Video/NowPlayingInfoCenterManager.swift
@@ -226,6 +226,12 @@ class NowPlayingInfoCenterManager {
             })
         }
 
+        if CMTIME_IS_INDEFINITE(currentItem.asset.duration) {
+            nowPlayingInfo[MPNowPlayingInfoPropertyIsLiveStream] = true
+        } else {
+            nowPlayingInfo[MPNowPlayingInfoPropertyIsLiveStream] = false
+        }
+
         nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = currentItem.duration.seconds
         nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentItem.currentTime().seconds
         nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = player.rate
@@ -245,6 +251,11 @@ class NowPlayingInfoCenterManager {
             nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentItem.currentTime().seconds.rounded()
             nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = player.rate
 
+            if CMTIME_IS_INDEFINITE(currentItem.asset.duration) {
+                nowPlayingInfo[MPNowPlayingInfoPropertyIsLiveStream] = true
+            } else {
+                nowPlayingInfo[MPNowPlayingInfoPropertyIsLiveStream] = false
+            }
             MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
         }
     }


### PR DESCRIPTION
…am playing

This addresses part of https://github.com/TheWidlarzGroup/react-native-video/issues/3902

Apple however does encourage going further, "Consider indicating the progress of currently playing live content. People appreciate knowing where they’ll land when they jump into in-progress live content. You can use a progress bar or other indicator to show people how much content remains." (source: [Apple Design Guidelines](https://developer.apple.com/design/human-interface-guidelines/live-viewing-apps)). _**However**_ , Apple does not indicate if this goes for the minimal view of a Now Playing view. So this may be sufficient for many developers and audiences.

- Provide an example of how to test the change
To test the change, 
1. generate an ios build of the example/basic app, 
2. load it on a physical ios device, 
3. tap `show notification controls` on the ui, 
4. Drag from the top to see the notification controls

- Describe the changes
## Summary
Adds "LIVE" decorator to livestream notification (now playing)

Playback (can't remember which it was in example):
<img width="550" alt="Screenshot 2024-06-18 at 11 08 46 AM" src="https://github.com/TheWidlarzGroup/react-native-video/assets/9328123/526c9482-3074-46b4-ad52-e9a9fad91459">
Live (red bull live, another live sample):
<img width="497" alt="Screenshot 2024-06-18 at 10 18 59 AM" src="https://github.com/TheWidlarzGroup/react-native-video/assets/9328123/d1f08ffc-63b8-46a8-8bce-f590220a0422">


### Motivation
Saw that livestreams in our app show just --_-- <progress bar> --_-- which is what some apps (AP News, CNN (their pause/play doesn't work correctly though)) do on iOS but a few we saw show a LIVE decorator. To ensure our audience understand what is being shown, we should add this code.
iOS Apps that show --_-- on each side of a livestream now playing control center view: Fox (doesn't allow background play), FM Radio, NBC

### Changes
Added a check to determine if live content is currently playing

## Test plan
None