### PR TITLE
feat(android): add `onControlsVisiblityChange`

### DIFF
--- a/android/src/main/java/com/brentvatne/common/react/VideoEventEmitter.java
+++ b/android/src/main/java/com/brentvatne/common/react/VideoEventEmitter.java
@@ -37,6 +37,7 @@ public class VideoEventEmitter {
     private static final String EVENT_ERROR = "onVideoError";
     private static final String EVENT_PROGRESS = "onVideoProgress";
     private static final String EVENT_BANDWIDTH = "onVideoBandwidthUpdate";
+    private static final String EVENT_CONTROLS_VISIBILITY_CHANGE = "onControlsVisibilityChange";
     private static final String EVENT_SEEK = "onVideoSeek";
     private static final String EVENT_END = "onVideoEnd";
     private static final String EVENT_FULLSCREEN_WILL_PRESENT = "onVideoFullscreenPlayerWillPresent";
@@ -89,6 +90,7 @@ public class VideoEventEmitter {
             EVENT_TEXT_TRACK_DATA_CHANGED,
             EVENT_VIDEO_TRACKS,
             EVENT_BANDWIDTH,
+            EVENT_CONTROLS_VISIBILITY_CHANGE,
             EVENT_ON_RECEIVE_AD_EVENT
     };
 
@@ -120,6 +122,7 @@ public class VideoEventEmitter {
             EVENT_TEXT_TRACK_DATA_CHANGED,
             EVENT_VIDEO_TRACKS,
             EVENT_BANDWIDTH,
+            EVENT_CONTROLS_VISIBILITY_CHANGE,
             EVENT_ON_RECEIVE_AD_EVENT
     })
     @interface VideoEvents {
@@ -163,6 +166,8 @@ public class VideoEventEmitter {
     private static final String EVENT_PROP_BITRATE = "bitrate";
 
     private static final String EVENT_PROP_IS_PLAYING = "isPlaying";
+
+    private static final String EVENT_CONTROLS_VISIBLE = "isVisible";
 
     public void setViewId(int viewId) {
         this.viewId = viewId;
@@ -352,6 +357,12 @@ public class VideoEventEmitter {
 
     public void end() {
         receiveEvent(EVENT_END, null);
+    }
+
+    public void controlsVisibilityChanged(boolean isVisible) {
+        WritableMap map = Arguments.createMap();
+        map.putBoolean(EVENT_CONTROLS_VISIBLE, isVisible);
+        receiveEvent(EVENT_CONTROLS_VISIBILITY_CHANGE, map);
     }
 
     public void fullscreenWillPresent() {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -416,6 +416,12 @@ public class ReactExoplayerView extends FrameLayout implements
     private void initializePlayerControl() {
         if (playerControlView == null) {
             playerControlView = new LegacyPlayerControlView(getContext());
+            playerControlView.addVisibilityListener(new LegacyPlayerControlView.VisibilityListener() {
+                @Override
+                public void onVisibilityChange(int visibility) {
+                    eventEmitter.controlsVisibilityChanged(visibility == View.VISIBLE);
+                }
+            });
         }
 
         if (fullScreenPlayerView == null) {

--- a/docs/pages/component/events.mdx
+++ b/docs/pages/component/events.mdx
@@ -121,6 +121,26 @@ Example:
 }
 ```
 
+### `onControlsVisibilityChange`
+
+<PlatformsList types={['Android']} />
+
+Callback function that is called when the controls are hidden or shown. Not possible on iOS.
+
+Payload:
+
+| Property    | Type    | Description                                    |
+| ----------- | ------- | ---------------------------------------------- |
+| isVisible | boolean | Boolean indicating whether controls are visible |
+
+Example:
+
+```javascript
+{
+  isVisible: true;
+}
+```
+
 ### `onEnd`
 
 <PlatformsList types={['All']} />

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -22,6 +22,7 @@ import NativeVideoComponent, {
   type OnAudioTracksData,
   type OnBandwidthUpdateData,
   type OnBufferData,
+  type OnControlsVisibilityChange,
   type OnExternalPlaybackChangeData,
   type OnGetLicenseData,
   type OnLoadStartData,
@@ -91,6 +92,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       onEnd,
       onBuffer,
       onBandwidthUpdate,
+      onControlsVisibilityChange,
       onExternalPlaybackChange,
       onFullscreenPlayerWillPresent,
       onFullscreenPlayerDidPresent,
@@ -391,13 +393,6 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       [onVideoTracks],
     );
 
-    const _onPlaybackRateChange = useCallback(
-      (e: NativeSyntheticEvent<Readonly<{playbackRate: number}>>) => {
-        onPlaybackRateChange?.(e.nativeEvent);
-      },
-      [onPlaybackRateChange],
-    );
-
     const _onVolumeChange = useCallback(
       (e: NativeSyntheticEvent<Readonly<{volume: number}>>) => {
         onVolumeChange?.(e.nativeEvent);
@@ -458,6 +453,20 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       },
       [onAspectRatio],
     );
+
+    const _onPlaybackRateChange = useCallback(
+      (e: NativeSyntheticEvent<Readonly<{playbackRate: number}>>) => {
+        onPlaybackRateChange?.(e.nativeEvent);
+      },
+      [onPlaybackRateChange],
+    );
+
+    const _onControlsVisibilityChange = useCallback(
+      (e: NativeSyntheticEvent<OnControlsVisibilityChange>) => {
+        onControlsVisibilityChange?.(e.nativeEvent);
+      },
+      [onControlsVisibilityChange],
+    )
 
     const useExternalGetLicense = drm?.getLicense instanceof Function;
 
@@ -616,6 +625,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
               ? (_onReceiveAdEvent as (e: NativeSyntheticEvent<object>) => void)
               : undefined
           }
+          onControlsVisibilityChange={onControlsVisibilityChange ? _onControlsVisibilityChange : undefined}
         />
         {hasPoster && showPoster ? (
           <Image style={posterStyle} source={{uri: poster}} />

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -626,8 +626,8 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
               : undefined
           }
           onControlsVisibilityChange={
-            onControlsVisibilityChange 
-              ? _onControlsVisibilityChange 
+            onControlsVisibilityChange
+              ? _onControlsVisibilityChange
               : undefined
           }
         />

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -627,8 +627,8 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           }
           onControlsVisibilityChange={
             onControlsVisibilityChange 
-            ? _onControlsVisibilityChange 
-            : undefined
+              ? _onControlsVisibilityChange 
+              : undefined
           }
         />
         {hasPoster && showPoster ? (

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -393,6 +393,13 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       [onVideoTracks],
     );
 
+    const _onPlaybackRateChange = useCallback(
+      (e: NativeSyntheticEvent<Readonly<{playbackRate: number}>>) => {
+        onPlaybackRateChange?.(e.nativeEvent);
+      },
+      [onPlaybackRateChange],
+    );
+
     const _onVolumeChange = useCallback(
       (e: NativeSyntheticEvent<Readonly<{volume: number}>>) => {
         onVolumeChange?.(e.nativeEvent);
@@ -452,13 +459,6 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         onAspectRatio?.(e.nativeEvent);
       },
       [onAspectRatio],
-    );
-
-    const _onPlaybackRateChange = useCallback(
-      (e: NativeSyntheticEvent<Readonly<{playbackRate: number}>>) => {
-        onPlaybackRateChange?.(e.nativeEvent);
-      },
-      [onPlaybackRateChange],
     );
 
     const _onControlsVisibilityChange = useCallback(
@@ -626,9 +626,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
               : undefined
           }
           onControlsVisibilityChange={
-            onControlsVisibilityChange
-              ? _onControlsVisibilityChange
-              : undefined
+            onControlsVisibilityChange ? _onControlsVisibilityChange : undefined
           }
         />
         {hasPoster && showPoster ? (

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -466,7 +466,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         onControlsVisibilityChange?.(e.nativeEvent);
       },
       [onControlsVisibilityChange],
-    )
+    );
 
     const useExternalGetLicense = drm?.getLicense instanceof Function;
 
@@ -625,7 +625,11 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
               ? (_onReceiveAdEvent as (e: NativeSyntheticEvent<object>) => void)
               : undefined
           }
-          onControlsVisibilityChange={onControlsVisibilityChange ? _onControlsVisibilityChange : undefined}
+          onControlsVisibilityChange={
+            onControlsVisibilityChange 
+            ? _onControlsVisibilityChange 
+            : undefined
+          }
         />
         {hasPoster && showPoster ? (
           <Image style={posterStyle} source={{uri: poster}} />

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -289,6 +289,10 @@ type ControlsStyles = Readonly<{
   seekIncrementMS?: number;
 }>;
 
+export type OnControlsVisibilityChange = Readonly<{
+  isVisible: boolean;
+}>;
+
 export interface VideoNativeProps extends ViewProps {
   src?: VideoSrc;
   drm?: Drm;
@@ -337,6 +341,7 @@ export interface VideoNativeProps extends ViewProps {
   useSecureView?: boolean; // Android
   bufferingStrategy?: BufferingStrategyType; // Android
   controlsStyles?: ControlsStyles; // Android
+  onControlsVisibilityChange?: DirectEventHandler<OnControlsVisibilityChange>;
   onVideoLoad?: DirectEventHandler<OnLoadData>;
   onVideoLoadStart?: DirectEventHandler<OnLoadStartData>;
   onVideoAspectRatio?: DirectEventHandler<OnVideoAspectRatioData>;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -4,6 +4,7 @@ import type {
   OnAudioTracksData,
   OnBandwidthUpdateData,
   OnBufferData,
+  OnControlsVisibilityChange,
   OnExternalPlaybackChangeData,
   OnLoadStartData,
   OnPictureInPictureStatusChangedData,
@@ -237,6 +238,7 @@ export interface ReactVideoEvents {
   onIdle?: () => void; // Android
   onBandwidthUpdate?: (e: OnBandwidthUpdateData) => void; //Android
   onBuffer?: (e: OnBufferData) => void; //Android, iOS
+  onControlsVisibilityChange?: (e: OnControlsVisibilityChange) => void; // Android, iOS
   onEnd?: () => void; //All
   onError?: (e: OnVideoErrorData) => void; //Android, iOS
   onExternalPlaybackChange?: (e: OnExternalPlaybackChangeData) => void; //iOS


### PR DESCRIPTION
## Summary
A callback event for when the Android Exoplayer controls show and hide.
Issue request: https://github.com/TheWidlarzGroup/react-native-video/issues/2686

### Motivation
Since the Android video player LegacyControls have limited controls (play, pause, rewind, forward, scrubber, etc., and do not provide an interface for changing the Captions or Audio of a stream, or implementing additional buttons), having an event allows a consumer class to overlay buttons / information at the same time as controls are shown.

### Changes
Adds onControlsVisibilityChange to VideoEventEmitter
Adds a visibility listener to the playerControlView in ReactExoplayerview to trigger the new event

Not available for iOS, due to no public methods for monitoring native control visibility

## Test plan