### PR TITLE
chore: update homepage field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "react-native": "src/index",
     "license": "MIT",
     "author": "Community Contributors",
-    "homepage": "https://github.com/TheWidlarzGroup/react-native-video#readme",
+    "homepage": "https://thewidlarzgroup.github.io/react-native-video/",
     "repository": {
         "type": "git",
         "url": "git@github.com:TheWidlarzGroup/react-native-video.git"


### PR DESCRIPTION
## Summary

Replace `homepage` link in `package.json` to point out to the website instead of GitHub readme.

### Motivation

Metadata correctness + repository link will be shown on npm anyway, so it's a good pattern to expose other website or documentation in this field.

![Screenshot 2024-06-26 112039](https://github.com/TheWidlarzGroup/react-native-video/assets/719641/d6c418e9-24e9-419a-849c-c009688a1155)

## Test plan

N/A