### PR TITLE
fix(android): added setAllowChunklessPreparation to HlsMediaSource.Factory stub

### DIFF
--- a/android/src/main/java/androidx/media3/exoplayer/hls/HlsMediaSource.java
+++ b/android/src/main/java/androidx/media3/exoplayer/hls/HlsMediaSource.java
@@ -30,5 +30,9 @@ public class HlsMediaSource {
         public MediaSource createMediaSource(MediaItem mediaItem) {
             return null;
         }
+
+        public Factory setAllowChunklessPreparation(boolean allowChunklessPreparation) {
+            return this;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Updated the HlsMediaSource.Factory stub to include setAllowChunklessPreparation, to allow the Android project to build when Media3 HLS libraries are excluded (useExoplayerHls = false)

### Motivation

Fix #3948

## Test plan

Successful build