### PR TITLE
fix(ios): fix fullscreen view controller ANR

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -962,7 +962,8 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     @objc
     func setFullscreen(_ fullscreen: Bool) {
-        if fullscreen && !_fullscreenPlayerPresented && _player != nil {
+        var alreadyFullscreenPresented = _presentingViewController?.presentedViewController != nil
+        if fullscreen && !_fullscreenPlayerPresented && _player != nil && !alreadyFullscreenPresented {
             // Ensure player view controller is not null
             // Controls will be displayed even if it is disabled in configuration
             if _playerViewController == nil {


### PR DESCRIPTION
## Summary
- prevent iOS view controller ANR

### Motivation
- ANR occurred call `setFullscreen(true)` when view controller presenting

### Changes

## Test plan
```tsx
        const [full, toggleFull] = useReducer(v => !v, false);
        <Video {...rest} fullscreen={full} />
        <Button
          title="toggle fullscreen"
          onPress={() => {
            if (full) {
              videoRef.current?.setFullscreen(false);
            } else {
              videoRef.current?.setFullscreen(true);
            }
            toggleFull();
          }}
        />
```