### PR TITLE
fix(ios): don't pause playback when entering background

### DIFF
--- a/ios/Video/Features/RCTPictureInPicture.swift
+++ b/ios/Video/Features/RCTPictureInPicture.swift
@@ -6,12 +6,12 @@ import React
 
 #if os(iOS)
     class RCTPictureInPicture: NSObject, AVPictureInPictureControllerDelegate {
+        public private(set) var _pipController: AVPictureInPictureController?
         private var _onPictureInPictureEnter: (() -> Void)?
         private var _onPictureInPictureExit: (() -> Void)?
         private var _onRestoreUserInterfaceForPictureInPictureStop: (() -> Void)?
         private var _restoreUserInterfaceForPIPStopCompletionHandler: ((Bool) -> Void)?
-        private var _pipController: AVPictureInPictureController?
-        public private(set) var _isActive = false
+        private var _isActive = false
 
         init(
             _ onPictureInPictureEnter: (() -> Void)? = nil,

--- a/ios/Video/Features/RCTPictureInPicture.swift
+++ b/ios/Video/Features/RCTPictureInPicture.swift
@@ -11,7 +11,7 @@ import React
         private var _onRestoreUserInterfaceForPictureInPictureStop: (() -> Void)?
         private var _restoreUserInterfaceForPIPStopCompletionHandler: ((Bool) -> Void)?
         private var _pipController: AVPictureInPictureController?
-        private var _isActive = false
+        public private(set) var _isActive = false
 
         init(
             _ onPictureInPictureEnter: (() -> Void)? = nil,

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -156,6 +156,12 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     func handlePictureInPictureExit() {
         onPictureInPictureStatusChanged?(["isActive": NSNumber(value: false)])
+
+        if _playInBackground {
+            _playerLayer?.player = nil
+            _playerViewController?.player = nil
+            _player?.play()
+        }
     }
 
     func handleRestoreUserInterfaceForPictureInPictureStop() {
@@ -293,7 +299,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     @objc
     func applicationDidEnterBackground(notification _: NSNotification!) {
         let isExternalPlaybackActive = _player?.isExternalPlaybackActive ?? false
-        if !_playInBackground || isExternalPlaybackActive { return }
+        if !_playInBackground || isExternalPlaybackActive || _pip?._isActive == true { return }
         // Needed to play sound in background. See https://developer.apple.com/library/ios/qa/qa1668/_index.html
         _playerLayer?.player = nil
         _playerViewController?.player = nil

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -299,7 +299,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     @objc
     func applicationDidEnterBackground(notification _: NSNotification!) {
         let isExternalPlaybackActive = _player?.isExternalPlaybackActive ?? false
-        if !_playInBackground || isExternalPlaybackActive || _pip?._isActive == true { return }
+        if !_playInBackground || isExternalPlaybackActive || _pip?._pipController?.isPictureInPictureActive == true { return }
         // Needed to play sound in background. See https://developer.apple.com/library/ios/qa/qa1668/_index.html
         _playerLayer?.player = nil
         _playerViewController?.player = nil

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -293,7 +293,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     @objc
     func applicationDidEnterBackground(notification _: NSNotification!) {
         let isExternalPlaybackActive = _player?.isExternalPlaybackActive ?? false
-        if _playInBackground || isExternalPlaybackActive { return }
+        if !_playInBackground || isExternalPlaybackActive { return }
         // Needed to play sound in background. See https://developer.apple.com/library/ios/qa/qa1668/_index.html
         _playerLayer?.player = nil
         _playerViewController?.player = nil

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -157,7 +157,10 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     func handlePictureInPictureExit() {
         onPictureInPictureStatusChanged?(["isActive": NSNumber(value: false)])
 
-        if _playInBackground {
+        // To continue audio playback in backgroud we need to set
+        // player in _playerLayer & _playerViewController to nil
+        let appState = UIApplication.shared.applicationState
+        if _playInBackground && appState == .background {
             _playerLayer?.player = nil
             _playerViewController?.player = nil
             _player?.play()


### PR DESCRIPTION
## Summary
Fix condition in order to don't pause playback when entering background

### Motivation
Fix entering background behaviour

## Test plan
- run app with Video, that has prop `playInBackground`
- go to home screen
- playback should be still playing