### PR TITLE
fix: expo plugin export

### DIFF
--- a/docs/pages/other/_meta.json
+++ b/docs/pages/other/_meta.json
@@ -3,6 +3,6 @@
   "misc": "Misc",
   "debug": "Debugging",
   "new-arch": "New Architecture",
-  "expo": "Expo"
+  "expo": "Expo",
   "plugin": "Plugin (experimental)"
 }

--- a/docs/theme.config.jsx
+++ b/docs/theme.config.jsx
@@ -13,7 +13,7 @@ export default {
       />
       <meta
         name="og:image"
-        content="https://react-native-video.github.io/react-native-video/thumbnail.jpg"
+        content="https://thewidlarzgroup.github.io/react-native-video/thumbnail.jpg"
       />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:title" content="React Native Video" />
@@ -23,7 +23,7 @@ export default {
       />
       <meta
         name="twitter:image"
-        content="https://react-native-video.github.io/react-native-video/thumbnail.jpg"
+        content="https://thewidlarzgroup.github.io/react-native-video/thumbnail.jpg"
       />
       <meta name="twitter:image:alt" content="React Native Video" />
       <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -48,7 +48,7 @@ export default {
   footer: {
     text: (
       <span>
-        Built with love ❤️ by <strong>React Native Community</strong>
+        Built with ❤️ by <strong>React Native Community</strong>
       </span>
     ),
   },

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "src",
         "lib",
         "react-native-video.podspec",
+        "app.plugin.js",
         "!android/build",
         "!android/buildOutput_*",
         "!android/local.properties",


### PR DESCRIPTION
## Summary
Fix expo plugin export via adding missing files to flies in `package.json`

Also fixed docs metadata as "expo" section don't display now

### Motivation
Add missing file in builded library

### Changes
- add `app.plugin.js` to `files` in `package.json`
- fix docs metadata
- update docs link in docs config

## Test plan
