### PR TITLE
fix(android): handle aspect ratio for rotated videos

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -235,8 +235,16 @@ public final class ExoPlayerView extends FrameLayout implements AdViewProvider {
                 // get the first track of the group to identify aspect ratio
                 Format format = group.getTrackFormat(0);
 
-                // update aspect ratio !
-                layout.setVideoAspectRatio(format.height == 0 ? 1 : (format.width * format.pixelWidthHeightRatio) / format.height);
+                // There are weird cases when video height and width did not change with rotation so we need change aspect ration to fix it
+                switch (format.rotationDegrees) {
+                    // update aspect ratio !
+                    case 90, 270 -> {
+                        layout.setVideoAspectRatio(format.width == 0 ? 1 : (format.height * format.pixelWidthHeightRatio) / format.width);
+                    }
+                    default -> {
+                        layout.setVideoAspectRatio(format.height == 0 ? 1 : (format.width * format.pixelWidthHeightRatio) / format.height);
+                    }
+                }
                 return;
             }
         }


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
Adjust aspect ratio handling for rotated videos

Closes #3929
### Motivation
In certain cases, the height and width of videos were not adjusting correctly with rotation. This PR addresses this issue by properly handling aspect ratio adjustments based on rotation angles.
### Changes
Modified logic to switch height and width when the rotation angle is 90 or 270 degrees.
## Test plan

1. Run the example video with the repeat mode flag from the [following URL](https://d1c40hpuz0tre6.cloudfront.net/stories/01HZRFTRYCM19PZ49BE54Z4FSY.mp4).
2. Verify that the aspect ratio is correctly adjusted when the video rotates during playback.