### PR TITLE
fix(android): ResizeMode.COVER

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/AspectRatioFrameLayout.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/AspectRatioFrameLayout.kt
@@ -75,9 +75,9 @@ class AspectRatioFrameLayout(context: Context) : FrameLayout(context) {
 
                 // Scale video if it doesn't fill the measuredWidth
                 if (width < measuredWidth) {
-                    val scaleFactor: Int = measuredWidth / width
-                    width *= scaleFactor
-                    height = measuredHeight * scaleFactor
+                    val scaleFactor: Float = measuredWidth.toFloat() / width
+                    width = (scaleFactor * width).toInt()
+                    height = (scaleFactor * height).toInt()
                 }
             }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
fixes ResizeMode.COVER for android. 

### Motivation

bug is introduced by https://github.com/TheWidlarzGroup/react-native-video/pull/3985 
where now when in ResizeMode.COVER or ResizeMode.RESIZE_MODE_CENTER_CROP, the scale factor calculation is [incorrectly attributed to be an int](https://github.com/TheWidlarzGroup/react-native-video/pull/3985/files#diff-0c158b2223c50f4a55102be652bf9de67364f992f9c8db20bf31b41708f2d629R78), [instead of float](https://github.com/TheWidlarzGroup/react-native-video/pull/3985/files#diff-a09ba36f3353b2b6f75c6c988bdee00e756471444035ca71164c3c11b9d5c732L132). 

### Changes

changes the scale factor calculation to float then recast width and height back to int

## Test plan

Set resizemode in the example app