### PR TITLE
fix(sample): boot failure on emulator

### DIFF
--- a/examples/basic/android/app/build.gradle
+++ b/examples/basic/android/app/build.gradle
@@ -83,8 +83,10 @@ android {
     namespace "com.videoplayer"
 
     compileOptions {
-        // These options are necessary to be able to build fro source
-        coreLibraryDesugaringEnabled true
+        // These options are necessary to be able to build from source
+        // coreLibraryDesugaringEnabled is mandatory to be able to build exoplayer from source
+        // uncomment this line if you want to build from source
+        // coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
     }

--- a/examples/basic/src/VideoPlayer.tsx
+++ b/examples/basic/src/VideoPlayer.tsx
@@ -26,7 +26,6 @@ import Video, {
   type OnPlaybackRateChangeData,
   type OnVideoTracksData,
   type ReactVideoSource,
-  type TextTracks,
   type VideoTrack,
   type SelectedTrack,
   type SelectedVideoTrack,
@@ -36,13 +35,6 @@ import styles from './styles';
 import {type AdditionalSourceInfo} from './types';
 import {bufferConfig, srcList, textTracksSelectionBy} from './constants';
 import {Overlay, toast} from './components';
-
-type AdditionnalSourceInfo = {
-  textTracks: TextTracks;
-  adTagUrl: string;
-  description: string;
-  noView: boolean;
-};
 
 type Props = NonNullable<unknown>;
 


### PR DESCRIPTION
## Summary
This PR fixes 2 issues:
- remove unused from this comment: https://github.com/TheWidlarzGroup/react-native-video/pull/3867#pullrequestreview-2175363083
- Fix symbol issue at app boot:

07-17 14:05:36.352 23802 23802 F DEBUG   : Abort message: 'JNI DETECTED ERROR IN APPLICATION: JNI NewGlobalRef called with pending exception java.lang.NoSuchMethodError: no static or non-static method "Lcom/facebook/react/devsupport/CxxInspectorPackagerConnection$WebSocketDelegate;.didFailWithError(Ljava/util/OptionalInt;Ljava/lang/String;)V"


### Motivation
A working and clean sample app

## Test plan
Build and run the sample