### PR TITLE
feat(android): add error handling for Kotlin version mismatch

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,45 @@
 import com.android.Version
+import groovy.json.JsonSlurper
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+
+def getReactNativeVersion() {
+    def packageJsonFile = file("$rootDir/../package.json")
+    if (packageJsonFile.exists()) {
+        def packageJson = new JsonSlurper().parseText(packageJsonFile.text)
+        return packageJson.dependencies["react-native"] ?: packageJson.devDependencies["react-native"]
+    }
+    return null
+}
+
+def reactNativeVersion = getReactNativeVersion()
+
+def isReactNativeVersionBetween = { version, minVersion, maxVersionExclusive ->
+    def versionParts = { v -> v.replaceAll(/[^0-9.]/, '').tokenize('.')*.toInteger() }
+    def (v, minV, maxV) = [version, minVersion, maxVersionExclusive].collect { versionParts(it) }
+
+    def isAtLeastMin = { v1, v2 ->
+        for (int i = 0; i < Math.max(v1.size(), v2.size()); i++) {
+            int val1 = i < v1.size() ? v1[i] : 0
+            int val2 = i < v2.size() ? v2[i] : 0
+            if (val1 < val2) return false
+            if (val1 > val2) return true
+        }
+        return true
+    }
+
+    def isBelowMax = { v1, v2 ->
+        for (int i = 0; i < Math.max(v1.size(), v2.size()); i++) {
+            int val1 = i < v1.size() ? v1[i] : 0
+            int val2 = i < v2.size() ? v2[i] : 0
+            if (val1 > val2) return false
+            if (val1 < val2) return true
+        }
+        return false
+    }
+    return isAtLeastMin(v, minV) && isBelowMax(v, maxV)
+}
 
 buildscript {
     def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['RNVideo_kotlinVersion']
@@ -210,6 +248,8 @@ def media3_version = safeExtGet('media3Version')
 def kotlin_version = safeExtGet('kotlinVersion')
 def androidxCore_version = safeExtGet('androidxCoreVersion')
 def androidxActivity_version = safeExtGet('androidxActivityVersion')
+def minReactNativeVersion = safeExtGet("minReactNativeVersion")
+def maxReactNativeVersionExclusive = safeExtGet("maxReactNativeVersionExclusive")
 
 dependencies {
     // For < 0.71, this will be from the local maven repo
@@ -303,5 +343,8 @@ dependencies {
         // Common functionality used across multiple media libraries
         implementation "androidx.media3:media3-common:$media3_version"
     }
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
+    if (isReactNativeVersionBetween(reactNativeVersion, minReactNativeVersion, maxReactNativeVersionExclusive)) {
+        implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,45 +1,7 @@
 import com.android.Version
-import groovy.json.JsonSlurper
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-
-def getReactNativeVersion() {
-    def packageJsonFile = file("$rootDir/../package.json")
-    if (packageJsonFile.exists()) {
-        def packageJson = new JsonSlurper().parseText(packageJsonFile.text)
-        return packageJson.dependencies["react-native"] ?: packageJson.devDependencies["react-native"]
-    }
-    return null
-}
-
-def reactNativeVersion = getReactNativeVersion()
-
-def isReactNativeVersionBetween = { version, minVersion, maxVersionExclusive ->
-    def versionParts = { v -> v.replaceAll(/[^0-9.]/, '').tokenize('.')*.toInteger() }
-    def (v, minV, maxV) = [version, minVersion, maxVersionExclusive].collect { versionParts(it) }
-
-    def isAtLeastMin = { v1, v2 ->
-        for (int i = 0; i < Math.max(v1.size(), v2.size()); i++) {
-            int val1 = i < v1.size() ? v1[i] : 0
-            int val2 = i < v2.size() ? v2[i] : 0
-            if (val1 < val2) return false
-            if (val1 > val2) return true
-        }
-        return true
-    }
-
-    def isBelowMax = { v1, v2 ->
-        for (int i = 0; i < Math.max(v1.size(), v2.size()); i++) {
-            int val1 = i < v1.size() ? v1[i] : 0
-            int val2 = i < v2.size() ? v2[i] : 0
-            if (val1 > val2) return false
-            if (val1 < val2) return true
-        }
-        return false
-    }
-    return isAtLeastMin(v, minV) && isBelowMax(v, maxV)
-}
 
 buildscript {
     def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['RNVideo_kotlinVersion']
@@ -245,11 +207,8 @@ repositories {
 }
 
 def media3_version = safeExtGet('media3Version')
-def kotlin_version = safeExtGet('kotlinVersion')
 def androidxCore_version = safeExtGet('androidxCoreVersion')
 def androidxActivity_version = safeExtGet('androidxActivityVersion')
-def minReactNativeVersion = safeExtGet("minReactNativeVersion")
-def maxReactNativeVersionExclusive = safeExtGet("maxReactNativeVersionExclusive")
 
 dependencies {
     // For < 0.71, this will be from the local maven repo
@@ -342,9 +301,5 @@ dependencies {
 
         // Common functionality used across multiple media libraries
         implementation "androidx.media3:media3-common:$media3_version"
-    }
-
-    if (isReactNativeVersionBetween(reactNativeVersion, minReactNativeVersion, maxReactNativeVersionExclusive)) {
-        implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,10 +30,10 @@ buildscript {
     }
 
     ext {
-        if (!isVersionAtLeast(kotlinVersion, requiredKotlinVersion)) {
-            throw new GradleException("Kotlin version mismatch: Project is using Kotlin version $kotlinVersion, but it must be at least $requiredKotlinVersion. Please update the Kotlin version.")
+        if (!isVersionAtLeast(kotlin_version, requiredKotlinVersion)) {
+            throw new GradleException("Kotlin version mismatch: Project is using Kotlin version $kotlin_version, but it must be at least $requiredKotlinVersion. Please update the Kotlin version.")
         } else {
-            println("Kotlin version is correct: $kotlinVersion")
+            println("Kotlin version is correct: $kotlin_version")
         }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,20 @@ apply plugin: 'kotlin-android'
 buildscript {
     def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['RNVideo_kotlinVersion']
 
+    def isVersionAtLeast = { version, requiredVersion ->
+        def (v1, v2) = [version, requiredVersion].collect { it.tokenize('.')*.toInteger() }
+        for (int i = 0; i < Math.max(v1.size(), v2.size()); i++) {
+            int val1 = i < v1.size() ? v1[i] : 0
+            int val2 = i < v2.size() ? v2[i] : 0
+            if (val1 < val2) {
+                return false
+            } else if (val1 > val2) {
+                return true
+            }
+        }
+        return true
+    }
+
     repositories {
         mavenCentral()
     }
@@ -13,38 +27,16 @@ buildscript {
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
-}
 
-task checkKotlinVersion {
-    doLast {
+    ext {
         def kotlinVersion = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['RNVideo_kotlinVersion']
-        def requiredKotlinVersion = project.properties['RNVideo_requiredKotlinVersion']
-
-        // Function to compare version strings
-        def isVersionAtLeast = { version, requiredVersion ->
-            def (v1, v2) = [version, requiredVersion].collect { it.tokenize('.')*.toInteger() }
-            for (int i = 0; i < Math.max(v1.size(), v2.size()); i++) {
-                int val1 = i < v1.size() ? v1[i] : 0
-                int val2 = i < v2.size() ? v2[i] : 0
-                if (val1 < val2) {
-                    return false
-                } else if (val1 > val2) {
-                    return true
-                }
-            }
-            return true
-        }
-
+        def requiredKotlinVersion = project.properties['RNVideo_kotlinVersion']
         if (!isVersionAtLeast(kotlinVersion, requiredKotlinVersion)) {
             throw new GradleException("Kotlin version mismatch: Project is using Kotlin version $kotlinVersion, but it must be at least $requiredKotlinVersion. Please update the Kotlin version.")
         } else {
             println("Kotlin version is correct: $kotlinVersion")
         }
     }
-}
-
-tasks.matching { it.name.startsWith('pre') || it.name == 'compileDebugKotlin' }.all {
-    dependsOn checkKotlinVersion
 }
 
 // This looks funny but it's necessary to keep backwards compatibility (:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,7 +15,39 @@ buildscript {
     }
 }
 
-// This looks funny but it's necessary to keep backwards compatibility (: 
+task checkKotlinVersion {
+    doLast {
+        def kotlinVersion = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['RNVideo_kotlinVersion']
+        def requiredKotlinVersion = '1.9.0'
+
+        // Function to compare version strings
+        def isVersionAtLeast = { version, requiredVersion ->
+            def (v1, v2) = [version, requiredVersion].collect { it.tokenize('.')*.toInteger() }
+            for (int i = 0; i < Math.max(v1.size(), v2.size()); i++) {
+                int val1 = i < v1.size() ? v1[i] : 0
+                int val2 = i < v2.size() ? v2[i] : 0
+                if (val1 < val2) {
+                    return false
+                } else if (val1 > val2) {
+                    return true
+                }
+            }
+            return true
+        }
+
+        if (!isVersionAtLeast(kotlinVersion, requiredKotlinVersion)) {
+            throw new GradleException("Kotlin version mismatch: Project is using Kotlin version $kotlinVersion, but it must be at least $requiredKotlinVersion. Please update the Kotlin version.")
+        } else {
+            println("Kotlin version is correct: $kotlinVersion")
+        }
+    }
+}
+
+tasks.matching { it.name.startsWith('pre') || it.name == 'compileDebugKotlin' }.all {
+    dependsOn checkKotlinVersion
+}
+
+// This looks funny but it's necessary to keep backwards compatibility (:
 def safeExtGet(prop) {
     return rootProject.ext.has(prop) ?
             rootProject.ext.get(prop) : rootProject.ext.has("RNVideo_" + prop) ?
@@ -239,7 +271,7 @@ dependencies {
             implementation "androidx.media3:media3-exoplayer-rtsp:$media3_version"
         }
     }
-    
+
     // For ad insertion using the Interactive Media Ads SDK with ExoPlayer
     if (ExoplayerDependencies["useExoplayerIMA"]) {
         if (media3_buildFromSource) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'kotlin-android'
 
 buildscript {
     def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['RNVideo_kotlinVersion']
+    def requiredKotlinVersion = project.properties['RNVideo_kotlinVersion']
 
     def isVersionAtLeast = { version, requiredVersion ->
         def (v1, v2) = [version, requiredVersion].collect { it.tokenize('.')*.toInteger() }
@@ -29,8 +30,6 @@ buildscript {
     }
 
     ext {
-        def kotlinVersion = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['RNVideo_kotlinVersion']
-        def requiredKotlinVersion = project.properties['RNVideo_kotlinVersion']
         if (!isVersionAtLeast(kotlinVersion, requiredKotlinVersion)) {
             throw new GradleException("Kotlin version mismatch: Project is using Kotlin version $kotlinVersion, but it must be at least $requiredKotlinVersion. Please update the Kotlin version.")
         } else {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 task checkKotlinVersion {
     doLast {
         def kotlinVersion = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['RNVideo_kotlinVersion']
-        def requiredKotlinVersion = '1.9.0'
+        def requiredKotlinVersion = project.properties['RNVideo_requiredKotlinVersion']
 
         // Function to compare version strings
         def isVersionAtLeast = { version, requiredVersion ->

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -13,3 +13,5 @@ RNVideo_useExoplayerHls=true
 RNVideo_androidxCoreVersion=1.9.0
 RNVideo_androidxActivityVersion=1.7.0
 RNVideo_buildFromMedia3Source=false
+RNVideo_minReactNativeVersion=0.69.0
+RNVideo_maxReactNativeVersionExclusive=0.73.0

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -13,3 +13,4 @@ RNVideo_useExoplayerHls=true
 RNVideo_androidxCoreVersion=1.9.0
 RNVideo_androidxActivityVersion=1.7.0
 RNVideo_buildFromMedia3Source=false
+RNVideo_requiredKotlinVersion=1.9.0

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-RNVideo_kotlinVersion=1.7.0
+RNVideo_kotlinVersion=1.8.0
 RNVideo_minSdkVersion=23
 RNVideo_targetSdkVersion=34
 RNVideo_compileSdkVersion=34
@@ -13,4 +13,3 @@ RNVideo_useExoplayerHls=true
 RNVideo_androidxCoreVersion=1.9.0
 RNVideo_androidxActivityVersion=1.7.0
 RNVideo_buildFromMedia3Source=false
-RNVideo_requiredKotlinVersion=1.8.0

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -13,5 +13,3 @@ RNVideo_useExoplayerHls=true
 RNVideo_androidxCoreVersion=1.9.0
 RNVideo_androidxActivityVersion=1.7.0
 RNVideo_buildFromMedia3Source=false
-RNVideo_minReactNativeVersion=0.69.0
-RNVideo_maxReactNativeVersionExclusive=0.73.0

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -13,4 +13,4 @@ RNVideo_useExoplayerHls=true
 RNVideo_androidxCoreVersion=1.9.0
 RNVideo_androidxActivityVersion=1.7.0
 RNVideo_buildFromMedia3Source=false
-RNVideo_requiredKotlinVersion=1.9.0
+RNVideo_requiredKotlinVersion=1.8.0

--- a/android/src/main/java/com/brentvatne/exoplayer/FullScreenPlayerView.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/FullScreenPlayerView.kt
@@ -91,13 +91,12 @@ class FullScreenPlayerView(
         parent = null
     }
 
-    private fun getFullscreenIconResource(isFullscreen: Boolean): Int {
-        return if (isFullscreen) {
+    private fun getFullscreenIconResource(isFullscreen: Boolean): Int =
+        if (isFullscreen) {
             androidx.media3.ui.R.drawable.exo_icon_fullscreen_exit
         } else {
             androidx.media3.ui.R.drawable.exo_icon_fullscreen_enter
         }
-    }
 
     private fun updateFullscreenButton(playerControlView: LegacyPlayerControlView, isFullscreen: Boolean) {
         val imageButton = playerControlView.findViewById<ImageButton?>(com.brentvatne.react.R.id.exo_fullscreen)

--- a/docs/pages/installation.md
+++ b/docs/pages/installation.md
@@ -57,12 +57,14 @@ $RNVideoUseGoogleIMA=true
 
 ## Android
 
-From version >= 6.0.0, your application needs to have kotlin version >= 1.7.0
+From version >= 6.0.0, your application needs to have kotlin version >= 1.8.0
 
 ```:
 buildscript {
     ...
-    ext.kotlinVersion = '1.7.0'
+    ext.kotlinVersion = '1.8.0',
+    ext.compileSdkVersion = 34
+    ext.targetSdkVersion = 34
     ...
 }
 ```


### PR DESCRIPTION
## Summary
Create a custom task to check the Kotlin metadata version.

### Motivation
Show clarify error message for Kotlin version mismatch.
And fix: https://github.com/TheWidlarzGroup/react-native-video/issues/4009

### Changes

## Test plan
I changed the Kotlin version in the sample app to `1.7.0`, then ran the app and encountered a new error: `Kotlin version mismatch: Project is using Kotlin version '1.7.0' but it must be at least '1.8.0'. Please update the Kotlin version`. After reverting the Kotlin version to `1.8.0` or higher, the app worked correctly.
