### PR TITLE
fix(android): viewType is ignored when set to ViewType.TEXTURE

### DIFF
--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -584,28 +584,32 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       const shallForceViewType =
         hasValidDrmProp && (viewType === ViewType.TEXTURE || useTextureView);
 
-      if (shallForceViewType) {
-        console.warn(
-          'cannot use DRM on texture view. please set useTextureView={false}',
-        );
-      }
       if (useSecureView && useTextureView) {
         console.warn(
           'cannot use SecureView on texture view. please set useTextureView={false}',
         );
       }
 
-      return shallForceViewType
-        ? useSecureView
-          ? ViewType.SURFACE_SECURE
-          : ViewType.SURFACE // check if we should force the type to Surface due to DRM
-        : viewType
-        ? viewType // else use ViewType from source
-        : useSecureView // else infer view type from useSecureView and useTextureView
-        ? ViewType.SURFACE_SECURE
-        : useTextureView
-        ? ViewType.TEXTURE
-        : ViewType.SURFACE;
+      if (shallForceViewType) {
+        console.warn(
+          'cannot use DRM on texture view. please set useTextureView={false}',
+        );
+        return useSecureView ? ViewType.SURFACE_SECURE : ViewType.SURFACE;
+      }
+
+      if (viewType !== undefined && viewType !== null) {
+        return viewType;
+      }
+
+      if (useSecureView) {
+        return ViewType.SURFACE_SECURE;
+      }
+
+      if (useTextureView) {
+        return ViewType.TEXTURE;
+      }
+
+      return ViewType.SURFACE;
     }, [drm, useSecureView, useTextureView, viewType]);
 
     const _renderPoster = useCallback(() => {


### PR DESCRIPTION
…XTURE

<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
The goal is to fix the behavior of `viewType={ViewType.TEXTURE}` which does not work (the value is ignored)

### Motivation
To fix #4030 

### Changes
I have changed a condition in order to have `ViewType.TEXTURE` (0) taken into account

## Test plan
It's a minor changement, I have tested it locally by setting `viewType` as `ViewType.TEXTURE` and it worked properly
