### PR TITLE
fix(ios): metadata update race

### DIFF
--- a/ios/Video/NowPlayingInfoCenterManager.swift
+++ b/ios/Video/NowPlayingInfoCenterManager.swift
@@ -107,13 +107,11 @@ class NowPlayingInfoCenterManager {
         registerCommandTargets()
 
         updateMetadata()
-
-        // one second observer
         playbackObserver = player.addPeriodicTimeObserver(
             forInterval: CMTime(value: 1, timescale: 4),
             queue: .global(),
             using: { [weak self] _ in
-                self?.updatePlaybackInfo()
+                self?.updateMetadata()
             }
         )
     }
@@ -217,26 +215,6 @@ class NowPlayingInfoCenterManager {
         ]
 
         MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
-    }
-
-    private func updatePlaybackInfo() {
-        guard let player = currentPlayer, let currentItem = player.currentItem else {
-            return
-        }
-
-        // We dont want to update playback if we did not set metadata yet
-        if var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo {
-            let newNowPlayingInfo: [String: Any] = [
-                MPMediaItemPropertyPlaybackDuration: currentItem.duration.seconds,
-                MPNowPlayingInfoPropertyElapsedPlaybackTime: currentItem.currentTime().seconds.rounded(),
-                MPNowPlayingInfoPropertyPlaybackRate: player.rate,
-                MPNowPlayingInfoPropertyIsLiveStream: CMTIME_IS_INDEFINITE(currentItem.asset.duration),
-            ]
-
-            nowPlayingInfo.merge(newNowPlayingInfo) { _, v in v }
-
-            MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
-        }
     }
 
     private func findNewCurrentPlayer() {

--- a/ios/Video/NowPlayingInfoCenterManager.swift
+++ b/ios/Video/NowPlayingInfoCenterManager.swift
@@ -204,7 +204,7 @@ class NowPlayingInfoCenterManager {
         let image = imgData.flatMap { UIImage(data: $0) } ?? UIImage()
         let artworkItem = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
 
-        let nowPlayingInfo: [String: Any] = [
+        let newNowPlayingInfo: [String: Any] = [
             MPMediaItemPropertyTitle: titleItem,
             MPMediaItemPropertyArtist: artistItem,
             MPMediaItemPropertyArtwork: artworkItem,
@@ -213,8 +213,9 @@ class NowPlayingInfoCenterManager {
             MPNowPlayingInfoPropertyPlaybackRate: player.rate,
             MPNowPlayingInfoPropertyIsLiveStream: CMTIME_IS_INDEFINITE(currentItem.asset.duration),
         ]
+        let currentNowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
 
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = currentNowPlayingInfo.merging(newNowPlayingInfo) {(_, new) in new }
     }
 
     private func findNewCurrentPlayer() {

--- a/ios/Video/NowPlayingInfoCenterManager.swift
+++ b/ios/Video/NowPlayingInfoCenterManager.swift
@@ -215,7 +215,7 @@ class NowPlayingInfoCenterManager {
         ]
         let currentNowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
 
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = currentNowPlayingInfo.merging(newNowPlayingInfo) {(_, new) in new }
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = currentNowPlayingInfo.merging(newNowPlayingInfo) { _, new in new }
     }
 
     private func findNewCurrentPlayer() {

--- a/ios/Video/NowPlayingInfoCenterManager.swift
+++ b/ios/Video/NowPlayingInfoCenterManager.swift
@@ -72,7 +72,7 @@ class NowPlayingInfoCenterManager {
 
         if currentPlayer == player {
             currentPlayer = nil
-            updateMetadata()
+            updateNowPlayingInfo()
         }
 
         if players.allObjects.isEmpty {
@@ -106,12 +106,12 @@ class NowPlayingInfoCenterManager {
         currentPlayer = player
         registerCommandTargets()
 
-        updateMetadata()
+        updateNowPlayingInfo()
         playbackObserver = player.addPeriodicTimeObserver(
             forInterval: CMTime(value: 1, timescale: 4),
             queue: .global(),
             using: { [weak self] _ in
-                self?.updateMetadata()
+                self?.updateNowPlayingInfo()
             }
         )
     }
@@ -184,7 +184,7 @@ class NowPlayingInfoCenterManager {
         remoteCommandCenter.changePlaybackPositionCommand.removeTarget(playbackPositionTarget)
     }
 
-    public func updateMetadata() {
+    public func updateNowPlayingInfo() {
         guard let player = currentPlayer, let currentItem = player.currentItem else {
             invalidateCommandTargets()
             MPNowPlayingInfoCenter.default().nowPlayingInfo = [:]

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -490,8 +490,8 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         } else {
             _player?.replaceCurrentItem(with: playerItem)
 
-            // later we can just call "updateMetadata:
-            NowPlayingInfoCenterManager.shared.updateMetadata()
+            // later we can just call "updateNowPlayingInfo:
+            NowPlayingInfoCenterManager.shared.updateNowPlayingInfo()
         }
 
         _playerObserver.player = _player


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary

This fixes a bug where metadata sometimes did not update correctly in the notification center when the video source was changed. I believe this was caused by a race condition between 2 methods updating it.
As I don't know much about this codebase nor it contain any tests, I'm happy to know your feedback on it.
I'm already testing it in my project and it seems to work just fine.

### Motivation

Fix for: https://github.com/TheWidlarzGroup/react-native-video/issues/4032

### Changes

- unified methods that update metadata in the notification center
- removed misleading comment

## Test plan

1. play a video with metadata (title, artwork)
1. move the app into background observing metadata in the notification center
1. swap video source to different one until issue happens (just a few swaps are enough)