### PR TITLE
fix(ios): updated getLicense call to work with new syntax, and fixed spelling error (#4014)

### DIFF
--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -69,7 +69,7 @@ RCT_EXPORT_VIEW_PROPERTY(onAudioTracks, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onTextTrackDataChanged, RCTDirectEventBlock);
 
 RCT_EXTERN_METHOD(seekCmd : (nonnull NSNumber*)reactTag time : (nonnull NSNumber*)time tolerance : (nonnull NSNumber*)tolerance)
-RCT_EXTERN_METHOD(setLicenseResultCmd : (nonnull NSNumber*)reactTag lisence : (NSString*)license licenseUrl : (NSString*)licenseUrl)
+RCT_EXTERN_METHOD(setLicenseResultCmd : (nonnull NSNumber*)reactTag license : (NSString*)license licenseUrl : (NSString*)licenseUrl)
 RCT_EXTERN_METHOD(setLicenseResultErrorCmd : (nonnull NSNumber*)reactTag error : (NSString*)error licenseUrl : (NSString*)licenseUrl)
 RCT_EXTERN_METHOD(setPlayerPauseStateCmd : (nonnull NSNumber*)reactTag paused : (nonnull BOOL)paused)
 RCT_EXTERN_METHOD(setVolumeCmd : (nonnull NSNumber*)reactTag volume : (nonnull float*)volume)

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -531,7 +531,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
             data.contentId,
             data.licenseUrl,
             data.loadedLicenseUrl,
-            );
+            )
           ).catch(() => {
             throw new Error('fetch error');
           });

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -526,12 +526,13 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
             throw new Error('No spc received');
           }
           // Handles both scenarios, getLicenseOverride being a promise and not.
-          const license = await Promise.resolve(selectedDrm.getLicense(
-            data.spcBase64,
-            data.contentId,
-            data.licenseUrl,
-            data.loadedLicenseUrl,
-            )
+          const license = await Promise.resolve(
+            selectedDrm.getLicense(
+              data.spcBase64,
+              data.contentId,
+              data.licenseUrl,
+              data.loadedLicenseUrl,
+            ),
           ).catch(() => {
             throw new Error('fetch error');
           });
@@ -545,7 +546,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
               data.loadedLicenseUrl,
             );
           }
-        } catch (e) { 
+        } catch (e) {
           const msg = e instanceof Error ? e.message : 'fetch error';
           if (nativeRef.current) {
             NativeVideoManager.setLicenseResultErrorCmd(

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -522,15 +522,22 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         }
         const data = event.nativeEvent;
         try {
-          if (!data?.spcBase64) throw new Error('No spc received');
+          if (!data?.spcBase64) {
+            throw new Error('No spc received');
+          }
           // Handles both scenarios, getLicenseOverride being a promise and not.
           const license = await Promise.resolve(selectedDrm.getLicense(
             data.spcBase64,
             data.contentId,
             data.licenseUrl,
             data.loadedLicenseUrl,
-          )).catch(() => { throw new Error('fetch error') });
-          if (typeof license !== 'string') throw Error('Empty license result')
+            );
+          ).catch(() => {
+            throw new Error('fetch error');
+          });
+          if (typeof license !== 'string') {
+            throw Error('Empty license result');
+          }
           if (nativeRef.current) {
             NativeVideoManager.setLicenseResultCmd(
               getReactTag(nativeRef),
@@ -539,7 +546,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
             );
           }
         } catch (e) { 
-          const msg = e instanceof Error ? e.message : 'fetch error'
+          const msg = e instanceof Error ? e.message : 'fetch error';
           if (nativeRef.current) {
             NativeVideoManager.setLicenseResultErrorCmd(
               getReactTag(nativeRef),

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -542,7 +542,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
               return;
             } else {
               result = 'Empty license result';
-            } 
+            }
           } catch {
             result = 'fetch error';
           }

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -512,7 +512,8 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       [onControlsVisibilityChange],
     );
 
-    const usingExternalGetLicense = drm?.getLicense instanceof Function;
+    const selectedDrm = source?.drm || drm;
+    const usingExternalGetLicense = selectedDrm?.getLicense instanceof Function;
 
     const onGetLicense = useCallback(
       async (event: NativeSyntheticEvent<OnGetLicenseData>) => {
@@ -524,14 +525,24 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         if (data?.spcBase64) {
           try {
             // Handles both scenarios, getLicenseOverride being a promise and not.
-            const license = await drm.getLicense(
+            const license = await selectedDrm.getLicense(
               data.spcBase64,
               data.contentId,
               data.licenseUrl,
               data.loadedLicenseUrl,
             );
-            result =
-              typeof license === 'string' ? license : 'Empty license result';
+            if (typeof license === 'string') {
+              if (nativeRef.current) {
+                NativeVideoManager.setLicenseResultCmd(
+                  getReactTag(nativeRef),
+                  result,
+                  data.loadedLicenseUrl,
+                );
+              }
+              return;
+            } else {
+              result = 'Empty license result';
+            } 
           } catch {
             result = 'fetch error';
           }
@@ -546,7 +557,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           );
         }
       },
-      [drm, usingExternalGetLicense],
+      [selectedDrm, usingExternalGetLicense],
     );
 
     useImperativeHandle(

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -535,7 +535,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
               if (nativeRef.current) {
                 NativeVideoManager.setLicenseResultCmd(
                   getReactTag(nativeRef),
-                  result,
+                  license,
                   data.loadedLicenseUrl,
                 );
               }


### PR DESCRIPTION
## Summary

Corrected the typo (lisence -> license), and updated the getLicense call to be allowed in either the top level drm parameter, or drm inside source parameter

### Motivation

Fix #4041  

## Test plan

Successful playback of DRM protected content on iOS device