### PR TITLE
Remove resume logic in notification seek closure

### DIFF
--- a/ios/Video/NowPlayingInfoCenterManager.swift
+++ b/ios/Video/NowPlayingInfoCenterManager.swift
@@ -167,9 +167,7 @@ class NowPlayingInfoCenterManager {
                 return .commandFailed
             }
             if let event = event as? MPChangePlaybackPositionCommandEvent {
-                player.seek(to: CMTime(seconds: event.positionTime, preferredTimescale: .max)) { _ in
-                    player.play()
-                }
+                player.seek(to: CMTime(seconds: event.positionTime, preferredTimescale: .max))
                 return .success
             }
             return .commandFailed


### PR DESCRIPTION
- Provide an example of how to test the change
Testable in example/basic on a physical iOS device

- Focus the PR on only one area
Focused on Notification Now Playing Center

- Describe the changes
Remove closure that calls player.play() after a seek event in notification media control.

## Summary
Ensure notification seek on iOS respects player state

### Motivation
After seeking while paused, the player should not resume playing unless the user clicks play.

### Changes
Remove closure.

## Test plan
Ensure `playInBackground={true}` and `playWhenInactive={true}`. Create an ipa build file of videoplayer, play a video, background the app, pause the player, slide down notif controls,  seek via notif controls, expect to see player still paused (correct).