### PR TITLE
fix(ios): crash on source change after coming back from background

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -488,7 +488,17 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                 NowPlayingInfoCenterManager.shared.registerPlayer(player: _player!)
             }
         } else {
+            if #available(iOS 16.0, *) {
+                // This feature caused crashes, if the app was put in bg, before the source change
+                // https://github.com/TheWidlarzGroup/react-native-video/issues/3900
+                self._playerViewController?.allowsVideoFrameAnalysis = false
+            }
+
             _player?.replaceCurrentItem(with: playerItem)
+
+            if #available(iOS 16.0, *) {
+                self._playerViewController?.allowsVideoFrameAnalysis = true
+            }
 
             // later we can just call "updateNowPlayingInfo:
             NowPlayingInfoCenterManager.shared.updateNowPlayingInfo()


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
This works around the crash on source change, if the app was previously put in the background. The crash occurs on iOS >= 16 and I blame apple for this 😅. They seem to be adding some observer logic on the player instance, causing it to explode in mentioned scenario.
This might not be a super sophisticated solution, perhaps there is a better more granular way to handle this, but on another hand it's simple and works well.
### Motivation
Fix for https://github.com/TheWidlarzGroup/react-native-video/issues/3900
### Changes
- temporary disabled [feature that allows for copying texts/subjects out of a video frame](https://developer.apple.com/documentation/avkit/avplayerview/allowsvideoframeanalysis) in the conflicting code part
## Test plan
Author of the issue [provided a crash demo app](https://github.com/TheWidlarzGroup/react-native-video/issues/3900#issuecomment-2169703076). 
I was able to run it with:
```sh
yarn
(cd ios && pod update)
yarn ios --udid=<your_sim_udid>
```
Once succesfuly ran:
1. play video
2. go background
3. go foreground
4. change video
5. notice the crash
6. replace rn-video dependency with suggested change
7. test again