### PR TITLE
fix(ios): build fail due to an unwrapped value

### DIFF
--- a/ios/Video/Features/RCTVideoUtils.swift
+++ b/ios/Video/Features/RCTVideoUtils.swift
@@ -9,6 +9,7 @@ enum RCTVideoAssetsUtils {
         for mediaCharacteristic: AVMediaCharacteristic
     ) async -> AVMediaSelectionGroup? {
         if #available(iOS 15, tvOS 15, visionOS 1.0, *) {
+            // swiftlint:disable shorthand_optional_binding
             guard let asset = asset else {
                 return nil
             }
@@ -17,6 +18,7 @@ enum RCTVideoAssetsUtils {
             } else {
                 return nil
             }
+            // swiftlint:enable shorthand_optional_binding
         } else {
             #if !os(visionOS)
                 return asset?.mediaSelectionGroup(forMediaCharacteristic: mediaCharacteristic)

--- a/ios/Video/Features/RCTVideoUtils.swift
+++ b/ios/Video/Features/RCTVideoUtils.swift
@@ -9,20 +9,30 @@ enum RCTVideoAssetsUtils {
         for mediaCharacteristic: AVMediaCharacteristic
     ) async -> AVMediaSelectionGroup? {
         if #available(iOS 15, tvOS 15, visionOS 1.0, *) {
-            return try? await asset?.loadMediaSelectionGroup(for: mediaCharacteristic)
+            guard let asset = asset else {
+                return nil
+            }
+            return try? await asset.loadMediaSelectionGroup(for: mediaCharacteristic)
         } else {
             #if !os(visionOS)
                 return asset?.mediaSelectionGroup(forMediaCharacteristic: mediaCharacteristic)
+            #else
+                return nil
             #endif
         }
     }
 
     static func getTracks(asset: AVAsset, withMediaType: AVMediaType) async -> [AVAssetTrack]? {
         if #available(iOS 15, tvOS 15, visionOS 1.0, *) {
+            guard let asset = asset else {
+                return nil
+            }
             return try? await asset.loadTracks(withMediaType: withMediaType)
         } else {
             #if !os(visionOS)
                 return asset.tracks(withMediaType: withMediaType)
+            #else
+                return nil
             #endif
         }
     }

--- a/ios/Video/Features/RCTVideoUtils.swift
+++ b/ios/Video/Features/RCTVideoUtils.swift
@@ -12,27 +12,24 @@ enum RCTVideoAssetsUtils {
             guard let asset = asset else {
                 return nil
             }
-            return try? await asset.loadMediaSelectionGroup(for: mediaCharacteristic)
+            if let mediaSelectionGroup = try? await asset.loadMediaSelectionGroup(for: mediaCharacteristic) {
+                return mediaSelectionGroup
+            } else {
+                return nil
+            }
         } else {
             #if !os(visionOS)
                 return asset?.mediaSelectionGroup(forMediaCharacteristic: mediaCharacteristic)
-            #else
-                return nil
             #endif
         }
     }
 
     static func getTracks(asset: AVAsset, withMediaType: AVMediaType) async -> [AVAssetTrack]? {
         if #available(iOS 15, tvOS 15, visionOS 1.0, *) {
-            guard let asset = asset else {
-                return nil
-            }
             return try? await asset.loadTracks(withMediaType: withMediaType)
         } else {
             #if !os(visionOS)
                 return asset.tracks(withMediaType: withMediaType)
-            #else
-                return nil
             #endif
         }
     }

--- a/ios/Video/Features/RCTVideoUtils.swift
+++ b/ios/Video/Features/RCTVideoUtils.swift
@@ -9,16 +9,15 @@ enum RCTVideoAssetsUtils {
         for mediaCharacteristic: AVMediaCharacteristic
     ) async -> AVMediaSelectionGroup? {
         if #available(iOS 15, tvOS 15, visionOS 1.0, *) {
-            // swiftlint:disable shorthand_optional_binding
-            guard let asset = asset else {
+            do {
+                guard let asset else {
+                    return nil
+                }
+
+                return try await asset.loadMediaSelectionGroup(for: mediaCharacteristic)
+            } catch {
                 return nil
             }
-            if let mediaSelectionGroup = try? await asset.loadMediaSelectionGroup(for: mediaCharacteristic) {
-                return mediaSelectionGroup
-            } else {
-                return nil
-            }
-            // swiftlint:enable shorthand_optional_binding
         } else {
             #if !os(visionOS)
                 return asset?.mediaSelectionGroup(forMediaCharacteristic: mediaCharacteristic)


### PR DESCRIPTION
Fixes #4099

iOS builds were failing because of AVMediaSelectionGroup's value not being unwrapped.

We first have to check if `asset` is nil before proceeding to call its methods.