### PR TITLE
fix(android): HLS DVR media should update playable duration in the background

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -923,7 +923,11 @@ public class ReactExoplayerView extends FrameLayout implements
         Intent intent = new Intent(themedReactContext, VideoPlaybackService.class);
         intent.setAction(MediaSessionService.SERVICE_INTERFACE);
 
-        themedReactContext.startService(intent);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            themedReactContext.startForegroundService(intent);
+        } else {
+            themedReactContext.startService(intent);
+        }
 
         int flags;
         if (Build.VERSION.SDK_INT >= 29) {

--- a/android/src/main/java/com/brentvatne/exoplayer/VideoPlaybackService.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/VideoPlaybackService.kt
@@ -63,6 +63,7 @@ class VideoPlaybackService : MediaSessionService() {
 
         mediaSessionsList[player] = mediaSession
         addSession(mediaSession)
+        startForeground(mediaSession.player.hashCode(), buildNotification(mediaSession))
     }
 
     fun unregisterPlayer(player: ExoPlayer) {
@@ -95,6 +96,10 @@ class VideoPlaybackService : MediaSessionService() {
 
     override fun onDestroy() {
         cleanup()
+        val notificationManager: NotificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            notificationManager.deleteNotificationChannel(NOTIFICATION_CHANEL_ID)
+        }
         super.onDestroy()
     }
 
@@ -209,9 +214,6 @@ class VideoPlaybackService : MediaSessionService() {
     private fun hideAllNotifications() {
         val notificationManager: NotificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.cancelAll()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            notificationManager.deleteNotificationChannel(NOTIFICATION_CHANEL_ID)
-        }
     }
 
     private fun cleanup() {


### PR DESCRIPTION
e.g. wait until onDestroy

When unmounting a component holding the the videoplayer from RNV component, I saw an error that crashed my app: deleting the notification channel while the foreground service is still running is not allowed.

## Summary
Use service starting methods properly. Remove notification channel properly.

### Motivation
The exploration started from looking in to #4039 which describes that HLS DVR streams stop loading playable duration when in the backgrond.
Add `startForegroundService` since the foreground service seemed to not be working correctly, warning logs I saw about buffer deallocations and windows closing and observations above in #4039, and  https://stackoverflow.com/questions/45525214/are-there-any-benefits-to-using-context-startforegroundserviceintent-instead-o. Add `startForeground` (required by using `startForegroundService`).

### Changes
See PR diff.

## Test plan
Test on physical android devices with the diff below and HLS DVR streams ("https://democracynow-hls.secdn.net/democracynow-live/play/democracynow.smil/playlist.m3u8", "https://5b44cf20b0388.streamlock.net:8443/dvr/dvr/playlist.m3u8?DVR").

Open the `examples/basic` videoplayer project, edit with this diff:
[background.patch](https://github.com/user-attachments/files/16692970/background.patch)
Also add HLS DVR streams to `general.ts` to view other than the HLS nonDVR redbull stream.