### PR TITLE
feat(iOS): add handler for Apple Earpods play/pause command

### DIFF
--- a/ios/Video/NowPlayingInfoCenterManager.swift
+++ b/ios/Video/NowPlayingInfoCenterManager.swift
@@ -18,6 +18,7 @@ class NowPlayingInfoCenterManager {
     private var skipBackwardTarget: Any?
     private var playbackPositionTarget: Any?
     private var seekTarget: Any?
+    private var togglePlayPauseTarget: Any?
 
     private let remoteCommandCenter = MPRemoteCommandCenter.shared()
 
@@ -176,6 +177,21 @@ class NowPlayingInfoCenterManager {
             }
             return .commandFailed
         }
+
+        // Handler for togglePlayPauseCommand, sent by Apple's Earpods wired headphones
+        togglePlayPauseTarget = remoteCommandCenter.togglePlayPauseCommand.addTarget { [weak self] _ in
+            guard let self, let player = self.currentPlayer else {
+                return .commandFailed
+            }
+
+            if player.rate == 0 {
+                player.play()
+            } else {
+                player.pause()
+            }
+
+            return .success
+        }
     }
 
     private func invalidateCommandTargets() {
@@ -184,6 +200,7 @@ class NowPlayingInfoCenterManager {
         remoteCommandCenter.skipForwardCommand.removeTarget(skipForwardTarget)
         remoteCommandCenter.skipBackwardCommand.removeTarget(skipBackwardTarget)
         remoteCommandCenter.changePlaybackPositionCommand.removeTarget(playbackPositionTarget)
+        remoteCommandCenter.togglePlayPauseCommand.removeTarget(togglePlayPauseTarget)
     }
 
     public func updateMetadata() {


### PR DESCRIPTION
## Summary

This adds a new InfoCenterManager command that handles custom behaviour of Apple's wired earphones.

### Motivation

Our customers reported that using [Apple Earpods](https://www.apple.com/shop/product/MWTY3AM/A/earpods-lightning-connector) they can only adjust the volume, but not play/pause the video.

Apple Earpods also allow to skip to next/previous track, but as this concept (playlists) is more complicated I've decided not to add any behaviour for that commands.

### Changes

* Added a `togglePlayPauseCommand` sent by Apple Earpods that resumes or pauses the video based on its state.

## Test plan

Play a video with Apple Earpods plugged in and use the play/pause button to stop and resume playback.

If you don't have access to this hardware, I can provide a video of the behaviour before and after the change.