### PR TITLE
fix(ios): ensure behavior is correct with empty text track list

### DIFF
--- a/examples/basic/src/constants/general.ts
+++ b/examples/basic/src/constants/general.ts
@@ -79,6 +79,11 @@ export const srcAllPlatformList = [
     startPosition: 50000,
   },
   {
+    description: 'mp3 with texttrack',
+    uri: 'https://traffic.libsyn.com/democracynow/wx2024-0702_SOT_DeadCalm-LucileSmith-FULL-V2.mxf-audio.mp3', // an mp3 file
+    textTracks: [], // empty text track list
+  },
+  {
     description: 'BigBugBunny sideLoaded subtitles',
     // sideloaded subtitles wont work for streaming like HLS on ios
     // mp4

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -979,7 +979,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     }
 
     func setTextTracks(_ textTracks: [TextTrack]?) {
-        if (textTracks == nil) {
+        if textTracks == nil {
             _textTracks = []
         } else {
             _textTracks = textTracks!


### PR DESCRIPTION
## Summary
Ensure textTracks list behavior is correct when the list is empty 

### Motivation
fix: https://github.com/TheWidlarzGroup/react-native-video/issues/4044

### Changes
To fix the issue, I rework external tracks list management to ensure is it never null:
- It simplify the code (avoid ?.)
- it simplify tests to check if app should handle external tracks (just need to check if it is empty instead of != nill && !empty) 

## Test plan
Can be tested with sample, I added the mp3 track.
important to test: you need to comment: export const textTracksSelectionBy = 'index';
as selection by index doesn't work on sideLoaded tracks