### PR TITLE
fix(expo-plugin) adding bg mode if none exist yet

### DIFF
--- a/src/expo-plugins/withBackgroundAudio.ts
+++ b/src/expo-plugins/withBackgroundAudio.ts
@@ -13,7 +13,7 @@ export const withBackgroundAudio: ConfigPlugin<boolean> = (
 
     if (enableBackgroundAudio) {
       if (!modes.includes('audio')) {
-        modes.push('audio');
+        config.modResults.UIBackgroundModes = [...modes, 'audio'];
       }
     } else {
       config.modResults.UIBackgroundModes = modes.filter(


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary

A simple fix. If the app happen to have empty "background modes" list, resulting in `config.modResults.UIBackgroundModes` to be `undefined`, the plugin tried to add `audio` mode to the fallback array that is not used anywhere, later on.

### Motivation

Fix for https://github.com/TheWidlarzGroup/react-native-video/issues/4125

### Changes

- push `audio` mode to `UIBackgroundModes` instead of unused fallback array

## Test plan

1. build the app with [enableBackgroundAudio](https://arc.net/l/quote/ftdtpzek) expo plugin flag set to true
2. Notice the generated Info.plist (or in Xcode UI) doesn't contain `UIBackgroundModes` entry
3. apply the fix and repeat