### PR TITLE
fix(ios): ensure we don't disable tracks when not necessary

### DIFF
--- a/ios/Video/Features/RCTPlayerOperations.swift
+++ b/ios/Video/Features/RCTPlayerOperations.swift
@@ -15,10 +15,14 @@ enum RCTPlayerOperations {
         let trackCount: Int! = player?.currentItem?.tracks.count ?? 0
 
         // The first few tracks will be audio & video track
-        var firstTextIndex = 0
+        var firstTextIndex = -1
         for i in 0 ..< trackCount where player?.currentItem?.tracks[i].assetTrack?.hasMediaCharacteristic(.legible) ?? false {
             firstTextIndex = i
             break
+        }
+        if firstTextIndex == -1 {
+            // no sideLoaded text track available (can happen with invalid vtt url)
+            return
         }
 
         var selectedTrackIndex: Int = RCTVideoUnset

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -612,6 +612,10 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             textTracks: self._textTracks
         )
 
+        if validTextTracks.isEmpty {
+            DebugLog("Strange state, not valid textTrack")
+        }
+
         if validTextTracks.count != self._textTracks?.count {
             self.setTextTracks(validTextTracks)
         }


### PR DESCRIPTION
## Summary
fix(ios): ensure we don't disable tracks when not necessary (causing black screen because all tracks because disable)

### Motivation
fix: https://github.com/TheWidlarzGroup/react-native-video/issues/4037

### Changes
There was an index management issue.
When track cannot be loaded, the first track is not available but we anyway consider first track as -1

## Test plan
Can be tested with sample by putting an invalid textTrack url