### PR TITLE
fix(ios): fix onBandwidth update event (old ios api is deprecated and doesn't work)

### DIFF
--- a/examples/basic/src/VideoPlayer.tsx
+++ b/examples/basic/src/VideoPlayer.tsx
@@ -30,6 +30,7 @@ import Video, {
   type SelectedTrack,
   type SelectedVideoTrack,
   type EnumValues,
+  OnBandwidthUpdateData,
 } from 'react-native-video';
 import styles from './styles';
 import {type AdditionalSourceInfo} from './types';
@@ -214,6 +215,10 @@ const VideoPlayer: FC<Props> = ({}) => {
     console.log('onPlaybackStateChanged', data);
   };
 
+  const onVideoBandwidthUpdate = (data: OnBandwidthUpdateData) => {
+    console.log('onVideoBandwidthUpdate', data);
+  }
+
   const onFullScreenExit = () => {
     // iOS pauses video on exit from full screen
     Platform.OS === 'ios' && setPaused(true);
@@ -253,6 +258,7 @@ const VideoPlayer: FC<Props> = ({}) => {
             onAspectRatio={onAspectRatio}
             onReadyForDisplay={onReadyForDisplay}
             onBuffer={onVideoBuffer}
+            onBandwidthUpdate={onVideoBandwidthUpdate}
             onSeek={onSeek}
             repeat={repeat}
             selectedTextTrack={selectedTextTrack}

--- a/ios/Video/Features/RCTPlayerObserver.swift
+++ b/ios/Video/Features/RCTPlayerObserver.swift
@@ -284,11 +284,11 @@ class RCTPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate, AVPla
                                                name: NSNotification.Name.AVPlayerItemFailedToPlayToEndTime,
                                                object: nil)
 
-        NotificationCenter.default.removeObserver(_handlers, name: NSNotification.Name.AVPlayerItemNewAccessLogEntry, object: player?.currentItem)
+        NotificationCenter.default.removeObserver(_handlers, name: AVPlayerItem.newAccessLogEntryNotification, object: player?.currentItem)
 
         NotificationCenter.default.addObserver(_handlers,
                                                selector: #selector(RCTPlayerObserverHandlerObjc.handleAVPlayerAccess(notification:)),
-                                               name: NSNotification.Name.AVPlayerItemNewAccessLogEntry,
+                                               name: AVPlayerItem.newAccessLogEntryNotification,
                                                object: player?.currentItem)
     }
 

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1661,7 +1661,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         }
 
         guard let lastEvent = accessLog.events.last else { return }
-        onVideoBandwidthUpdate?(["bitrate": lastEvent.observedBitrate, "target": reactTag])
+        onVideoBandwidthUpdate?(["bitrate": lastEvent.indicatedBitrate, "target": reactTag])
     }
 
     func handleTracksChange(playerItem _: AVPlayerItem, change _: NSKeyValueObservedChange<[AVPlayerItemTrack]>) {


### PR DESCRIPTION
## Summary
fix(ios): fix onBandwidth update event (old ios api is deprecated and doesn't work)

### Motivation
fix: https://github.com/TheWidlarzGroup/react-native-video/issues/4139

### Changes
change the way we receive notification of bandwidth update. The old api is no more working ...

## Test plan
I add the event catching in the sample