### PR TITLE
feat: Correct isBehindLiveWindow Error Handling

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1742,7 +1742,8 @@ public class ReactExoplayerView extends FrameLayout implements
         playerNeedsSource = true;
         if (isBehindLiveWindow(e)) {
             clearResumePosition();
-            initializePlayer();
+            player?.seekToDefaultPosition();
+            player?.prepare();
         } else {
             updateResumePosition();
         }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1742,8 +1742,10 @@ public class ReactExoplayerView extends FrameLayout implements
         playerNeedsSource = true;
         if (isBehindLiveWindow(e)) {
             clearResumePosition();
-            player?.seekToDefaultPosition();
-            player?.prepare();
+            if (player != null) {
+                player.seekToDefaultPosition();
+                player.prepare();
+            }
         } else {
             updateResumePosition();
         }


### PR DESCRIPTION

## Summary
```
@Override
    public void onPlayerError(@NonNull PlaybackException e) {
        String errorString = "ExoPlaybackException: " + PlaybackException.getErrorCodeName(e.errorCode);
        String errorCode = "2" + e.errorCode;
        switch(e.errorCode) {
            case PlaybackException.ERROR_CODE_DRM_DEVICE_REVOKED:
            case PlaybackException.ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED:
            case PlaybackException.ERROR_CODE_DRM_PROVISIONING_FAILED:
            case PlaybackException.ERROR_CODE_DRM_SYSTEM_ERROR:
            case PlaybackException.ERROR_CODE_DRM_UNSPECIFIED:
                if (!hasDrmFailed) {
                    // When DRM fails to reach the app level certificate server it will fail with a source error so we assume that it is DRM related and try one more time
                    hasDrmFailed = true;
                    playerNeedsSource = true;
                    updateResumePosition();
                    initializePlayer();
                    setPlayWhenReady(true);
                    return;
                }
                break;
            default:
                break;
        }
        eventEmitter.onVideoError.invoke(errorString, e, errorCode);
        playerNeedsSource = true;
        if (isBehindLiveWindow(e)) {
            clearResumePosition();
            initializePlayer();
        } else {
            updateResumePosition();
        }
    }
```

Currently, when the isBehindLiveWindow error (ERROR_CODE_BEHIND_LIVE_WINDOW) occurs in onPlayerError, initializePlayer is executed. However, when initializePlayer is executed, the player is reinitialized, causing it to reload, which results in flickering and feels unnatural.

I believe this error may occur frequently in 3G environments or when the network is poor. In such cases, it would be better to resume playback from the latest live position rather than reinitializing the player.


### Motivation

### Changes
Then, instead of initializePlayer(), I will execute player?.prepare() and player?.seekToDefaultPosition() to resume the live stream.

## Test plan
This is an issue that occurs when playing HLS live streaming in low network mode on Android.