### PR TITLE
fix(android): ensure pause is well tken in account after onEnd

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1261,10 +1261,7 @@ public class ReactExoplayerView extends FrameLayout implements
                 player.setPlayWhenReady(true);
             }
         } else {
-            // ensure playback is not ENDED, else it will trigger another ended event
-            if (player.getPlaybackState() != Player.STATE_ENDED) {
-                player.setPlayWhenReady(false);
-            }
+            player.setPlayWhenReady(false);
         }
     }
 


### PR DESCRIPTION
## Summary
fix(android): ensure pause is well tken in account after onEnd

### Motivation
fix: https://github.com/TheWidlarzGroup/react-native-video/issues/4146

### Changes
Issue linked to: https://github.com/TheWidlarzGroup/react-native-video/issues/2690
revert this patch, original issue not reproduced ...

## Test plan
see ticket, need a small patch in sample