### PR TITLE
fix(sample): remove warning on ios with NavigationBar

### DIFF
--- a/examples/basic/src/VideoPlayer.tsx
+++ b/examples/basic/src/VideoPlayer.tsx
@@ -34,7 +34,7 @@ import Video, {
 } from 'react-native-video';
 import styles from './styles';
 import {type AdditionalSourceInfo} from './types';
-import {bufferConfig, srcList, textTracksSelectionBy} from './constants';
+import {bufferConfig, isAndroid, srcList, textTracksSelectionBy} from './constants';
 import {Overlay, toast, VideoLoader} from './components';
 import * as NavigationBar from 'expo-navigation-bar';
 
@@ -106,7 +106,7 @@ const VideoPlayer: FC<Props> = ({}) => {
   }, [goToChannel, srcListId]);
 
   useEffect(() => {
-    if (Platform.OS === 'android') {
+    if (isAndroid) {
       NavigationBar.setVisibilityAsync('visible');
     }
   }, []);

--- a/examples/basic/src/VideoPlayer.tsx
+++ b/examples/basic/src/VideoPlayer.tsx
@@ -106,7 +106,9 @@ const VideoPlayer: FC<Props> = ({}) => {
   }, [goToChannel, srcListId]);
 
   useEffect(() => {
-    NavigationBar.setVisibilityAsync('visible');
+    if (Platform.OS === 'android') {
+      NavigationBar.setVisibilityAsync('visible');
+    }
   }, []);
 
   const onAudioTracks = (data: OnAudioTracksData) => {


### PR DESCRIPTION
## Summary
fix(sample): remove warning on ios with NavigationBar, It is not defined in ios

### Motivation
Keep sample clean without warning

### Changes
call the function only on android

## Test plan
launch ios sample