### PR TITLE
fix(android): ensure maxBitrate & selectedVideoTrack interact correctly

### DIFF
--- a/docs/pages/component/props.mdx
+++ b/docs/pages/component/props.mdx
@@ -357,6 +357,9 @@ Sets the desired limit, in bits per second, of network bandwidth consumption whe
 
 Default: 0. Don't limit the maxBitRate.
 
+Note: This property can interact with selectedVideoTrack.
+To use `maxBitrate`, selectedVideoTrack shall be undefined or `{type: SelectedVideoTrackType.AUTO}`.
+
 Example:
 
 ```javascript


### PR DESCRIPTION
## Summary
Fix interaction between selectedVideoTrack and maxBitrate.
Before this change, maxBitrate was not taken into account if user provide selectedVideoTrack to <Video player

### Motivation
fix: https://github.com/TheWidlarzGroup/react-native-video/issues/3121
and clarify behavior when both selectedVideoTrack and maxBitrate are used

### Changes
Apply in trackSelector maxBitrate or selectedVideoTrack, but not both

## Test plan
can be tested with sample.
Add a maxBitrate value
play with Video selection on sample
see the result in the logcat, here is an exemple of maxBitrate selected:

09-09 23:25:16.292 27526 27526 D RNVExoplayer: tracks [eventTime=21.19, mediaPos=28.65, window=0, period=0
09-09 23:25:16.292 27526 27526 D RNVExoplayer:   group [
09-09 23:25:16.292 27526 27526 D RNVExoplayer:     [X] Track:0, id=0, mimeType=video/avc, container=application/x-mpegURL, bitrate=258157, codecs=avc1.4d400d, res=422x180, supported=YES
09-09 23:25:16.292 27526 27526 D RNVExoplayer:     [X] Track:1, id=1, mimeType=video/avc, container=application/x-mpegURL, bitrate=520929, codecs=avc1.4d4015, res=638x272, supported=YES
09-09 23:25:16.292 27526 27526 D RNVExoplayer:     [X] Track:2, id=2, mimeType=video/avc, container=application/x-mpegURL, bitrate=831270, codecs=avc1.4d4015, res=638x272, supported=YES
09-09 23:25:16.292 27526 27526 D RNVExoplayer:     [X] Track:3, id=3, mimeType=video/avc, container=application/x-mpegURL, bitrate=1144430, codecs=avc1.4d401f, res=958x408, supported=YES
09-09 23:25:16.292 27526 27526 D RNVExoplayer:     [ ] Track:4, id=4, mimeType=video/avc, container=application/x-mpegURL, bitrate=1558322, codecs=avc1.4d401f, res=1277x554, supported=YES
09-09 23:25:16.292 27526 27526 D RNVExoplayer:     [ ] Track:5, id=5, mimeType=video/avc, container=application/x-mpegURL, bitrate=4149264, codecs=avc1.4d4028, res=1921x818, supported=YES
09-09 23:25:16.292 27526 27526 D RNVExoplayer:     [ ] Track:6, id=6, mimeType=video/avc, container=application/x-mpegURL, bitrate=6214307, codecs=avc1.4d4028, res=1921x818, supported=YES
09-09 23:25:16.292 27526 27526 D RNVExoplayer:     [ ] Track:7, id=7, mimeType=video/avc, container=application/x-mpegURL, bitrate=10285391, codecs=avc1.4d4033, res=4096x1744, supported=NO_EXCEEDS_CAPABILITIES
09-09 23:25:16.292 27526 27526 D RNVExoplayer:   ]
