### PR TITLE
fix: refactor side loaded text tracks management

### DIFF
--- a/android/src/main/java/com/brentvatne/common/api/SideLoadedTextTrackList.kt
+++ b/android/src/main/java/com/brentvatne/common/api/SideLoadedTextTrackList.kt
@@ -11,12 +11,18 @@ import com.facebook.react.bridge.ReadableMap
 class SideLoadedTextTrackList {
     var tracks = ArrayList<SideLoadedTextTrack>()
 
+    /** return true if this and src are equals  */
+    override fun equals(other: Any?): Boolean {
+        if (other == null || other !is SideLoadedTextTrackList) return false
+        return tracks == other.tracks
+    }
+
     companion object {
         fun parse(src: ReadableArray?): SideLoadedTextTrackList? {
             if (src == null) {
                 return null
             }
-            var sideLoadedTextTrackList = SideLoadedTextTrackList()
+            val sideLoadedTextTrackList = SideLoadedTextTrackList()
             for (i in 0 until src.size()) {
                 val textTrack: ReadableMap = src.getMap(i)
                 sideLoadedTextTrackList.tracks.add(SideLoadedTextTrack.parse(textTrack))

--- a/android/src/main/java/com/brentvatne/common/api/Source.kt
+++ b/android/src/main/java/com/brentvatne/common/api/Source.kt
@@ -62,6 +62,11 @@ class Source {
      */
     var cmcdProps: CMCDProps? = null
 
+    /**
+     * The list of sideLoaded text tracks
+     */
+    var sideLoadedTextTracks: SideLoadedTextTrackList? = null
+
     override fun hashCode(): Int = Objects.hash(uriString, uri, startPositionMs, cropStartMs, cropEndMs, extension, metadata, headers)
 
     /** return true if this and src are equals  */
@@ -74,7 +79,8 @@ class Source {
                 startPositionMs == other.startPositionMs &&
                 extension == other.extension &&
                 drmProps == other.drmProps &&
-                cmcdProps == other.cmcdProps
+                cmcdProps == other.cmcdProps &&
+                sideLoadedTextTracks == other.sideLoadedTextTracks
             )
     }
 
@@ -139,6 +145,7 @@ class Source {
         private const val PROP_SRC_DRM = "drm"
         private const val PROP_SRC_CMCD = "cmcd"
         private const val PROP_SRC_TEXT_TRACKS_ALLOW_CHUNKLESS_PREPARATION = "textTracksAllowChunklessPreparation"
+        private const val PROP_SRC_TEXT_TRACKS = "textTracks"
 
         @SuppressLint("DiscouragedApi")
         private fun getUriFromAssetId(context: Context, uriString: String): Uri? {
@@ -198,6 +205,7 @@ class Source {
                 source.drmProps = parse(safeGetMap(src, PROP_SRC_DRM))
                 source.cmcdProps = CMCDProps.parse(safeGetMap(src, PROP_SRC_CMCD))
                 source.textTracksAllowChunklessPreparation = safeGetBool(src, PROP_SRC_TEXT_TRACKS_ALLOW_CHUNKLESS_PREPARATION, true)
+                source.sideLoadedTextTracks = SideLoadedTextTrackList.parse(safeGetArray(src, PROP_SRC_TEXT_TRACKS))
 
                 val propSrcHeadersArray = safeGetArray(src, PROP_SRC_HEADERS)
                 if (propSrcHeadersArray != null) {

--- a/android/src/main/java/com/brentvatne/common/toolbox/ReactBridgeUtils.kt
+++ b/android/src/main/java/com/brentvatne/common/toolbox/ReactBridgeUtils.kt
@@ -59,10 +59,11 @@ object ReactBridgeUtils {
         }
         return try {
             value.toInt()
-        } catch (e:java.lang.Exception) {
+        } catch (e: java.lang.Exception) {
             default
         }
     }
+
     /**
      * toStringMap converts a [ReadableMap] into a HashMap.
      *

--- a/android/src/main/java/com/brentvatne/common/toolbox/ReactBridgeUtils.kt
+++ b/android/src/main/java/com/brentvatne/common/toolbox/ReactBridgeUtils.kt
@@ -3,7 +3,6 @@ package com.brentvatne.common.toolbox
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
-import java.util.HashMap
 
 /*
 * Toolbox to safe parsing of <Video props
@@ -54,6 +53,16 @@ object ReactBridgeUtils {
 
     @JvmStatic fun safeGetFloat(map: ReadableMap?, key: String?): Float = safeGetFloat(map, key, 0.0f)
 
+    @JvmStatic fun safeParseInt(value: String?, default: Int): Int {
+        if (value == null) {
+            return default
+        }
+        return try {
+            value.toInt()
+        } catch (e:java.lang.Exception) {
+            default
+        }
+    }
     /**
      * toStringMap converts a [ReadableMap] into a HashMap.
      *

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.kt
@@ -8,7 +8,6 @@ import com.brentvatne.common.api.BufferConfig
 import com.brentvatne.common.api.BufferingStrategy
 import com.brentvatne.common.api.ControlsConfig
 import com.brentvatne.common.api.ResizeMode
-import com.brentvatne.common.api.SideLoadedTextTrackList
 import com.brentvatne.common.api.Source
 import com.brentvatne.common.api.SubtitleStyle
 import com.brentvatne.common.api.ViewType
@@ -16,7 +15,6 @@ import com.brentvatne.common.react.EventTypes
 import com.brentvatne.common.toolbox.DebugLog
 import com.brentvatne.common.toolbox.ReactBridgeUtils
 import com.brentvatne.react.ReactNativeVideoManager
-import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.kt
@@ -38,7 +38,6 @@ class ReactExoplayerViewManager(private val config: ReactExoplayerConfig) : View
         private const val PROP_SELECTED_TEXT_TRACK = "selectedTextTrack"
         private const val PROP_SELECTED_TEXT_TRACK_TYPE = "type"
         private const val PROP_SELECTED_TEXT_TRACK_VALUE = "value"
-        private const val PROP_TEXT_TRACKS = "textTracks"
         private const val PROP_PAUSED = "paused"
         private const val PROP_MUTED = "muted"
         private const val PROP_AUDIO_OUTPUT = "audioOutput"
@@ -178,12 +177,6 @@ class ReactExoplayerViewManager(private val config: ReactExoplayerConfig) : View
             value = ReactBridgeUtils.safeGetString(selectedTextTrack, PROP_SELECTED_TEXT_TRACK_VALUE)
         }
         videoView.setSelectedTextTrack(typeString, value)
-    }
-
-    @ReactProp(name = PROP_TEXT_TRACKS)
-    fun setTextTracks(videoView: ReactExoplayerView, textTracks: ReadableArray?) {
-        val sideLoadedTextTracks = SideLoadedTextTrackList.parse(textTracks)
-        videoView.setTextTracks(sideLoadedTextTracks)
     }
 
     @ReactProp(name = PROP_PAUSED, defaultBoolean = false)

--- a/docs/pages/component/props.mdx
+++ b/docs/pages/component/props.mdx
@@ -848,6 +848,46 @@ source={{
   }}
 ```
 
+#### `textTracks`
+
+<PlatformsList types={['Android', 'iOS', 'visionOS']} />
+
+Load one or more "sidecar" text tracks. This takes an array of objects representing each track. Each object should have the format:
+
+> ⚠️ This feature does not work with HLS playlists (e.g m3u8) on iOS
+
+| Property | Description                                                                                                                                                                      |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| title    | Descriptive name for the track                                                                                                                                                   |
+| language | 2 letter [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) representing the language                                                                       |
+| type     | Mime type of the track _ TextTrackType.SRT - SubRip (.srt) _ TextTrackType.TTML - TTML (.ttml) \* TextTrackType.VTT - WebVTT (.vtt)iOS only supports VTT, Android supports all 3 |
+| uri      | URL for the text track. Currently, only tracks hosted on a webserver are supported                                                                                               |
+
+On iOS, sidecar text tracks are only supported for individual files, not HLS playlists. For HLS, you should include the text tracks as part of the playlist.
+
+Note: Due to iOS limitations, sidecar text tracks are not compatible with Airplay. If textTracks are specified, AirPlay support will be automatically disabled.
+
+Example:
+
+```javascript
+import { TextTrackType }, Video from 'react-native-video';
+
+textTracks={[
+  {
+    title: "English CC",
+    language: "en",
+    type: TextTrackType.VTT, // "text/vtt"
+    uri: "https://bitdash-a.akamaihd.net/content/sintel/subtitles/subtitles_en.vtt"
+  },
+  {
+    title: "Spanish Subtitles",
+    language: "es",
+    type: TextTrackType.SRT, // "application/x-subrip"
+    uri: "https://durian.blender.org/wp-content/content/subtitles/sintel_es.srt"
+  }
+]}
+```
+
 ### `subtitleStyle`
 
 <PlatformsList types={['Android', 'iOS']} />
@@ -891,6 +931,9 @@ It means that if the video is displayed out of screen, the subtitles may also be
 This prop can be changed on runtime.
 
 ### `textTracks`
+
+> [!WARNING]
+> deprecated, use source.textTracks instead. changing text tracks will restart playback
 
 <PlatformsList types={['Android', 'iOS', 'visionOS']} />
 

--- a/examples/basic/src/VideoPlayer.tsx
+++ b/examples/basic/src/VideoPlayer.tsx
@@ -241,7 +241,6 @@ const VideoPlayer: FC<Props> = ({}) => {
             showNotificationControls={showNotificationControls}
             ref={videoRef}
             source={currentSrc as ReactVideoSource}
-            textTracks={additional?.textTracks}
             adTagUrl={additional?.adTagUrl}
             drm={additional?.drm}
             style={viewStyle}

--- a/ios/Video/DataStructures/SelectedTrackCriteria.swift
+++ b/ios/Video/DataStructures/SelectedTrackCriteria.swift
@@ -15,4 +15,8 @@ struct SelectedTrackCriteria {
         self.type = json["type"] as? String ?? ""
         self.value = json["value"] as? String
     }
+
+    static func none() -> SelectedTrackCriteria {
+        return SelectedTrackCriteria(["type": "none", "value": ""])
+    }
 }

--- a/ios/Video/DataStructures/VideoSource.swift
+++ b/ios/Video/DataStructures/VideoSource.swift
@@ -11,6 +11,7 @@ struct VideoSource {
     let customMetadata: CustomMetadata?
     /* DRM */
     let drm: DRMParams?
+    var textTracks: [TextTrack] = []
 
     let json: NSDictionary?
 
@@ -52,5 +53,8 @@ struct VideoSource {
         self.cropEnd = (json["cropEnd"] as? Float64).flatMap { Int64(round($0)) }
         self.customMetadata = CustomMetadata(json["metadata"] as? NSDictionary)
         self.drm = DRMParams(json["drm"] as? NSDictionary)
+        self.textTracks = (json["textTracks"] as? NSArray)?.map { trackDict in
+            return TextTrack(trackDict as? NSDictionary)
+        } ?? []
     }
 }

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -453,8 +453,8 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         }
 
         #if USE_VIDEO_CACHING
-            if _videoCache.shouldCache(source: source, textTracks: _textTracks) {
-                return try await _videoCache.playerItemForSourceUsingCache(uri: source.uri, assetOptions: assetOptions)
+            if _videoCache.shouldCache(source: source) {
+                return try await _videoCache.playerItemForSourceUsingCache(source: source, assetOptions: assetOptions)
             }
         #endif
 

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -166,6 +166,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       );
 
       const selectedDrm = source.drm || drm;
+      const _textTracks = source.textTracks || textTracks;
       const _drm = !selectedDrm
         ? undefined
         : {
@@ -218,10 +219,11 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         metadata: resolvedSource.metadata,
         drm: _drm,
         cmcd: _cmcd,
+        textTracks: _textTracks,
         textTracksAllowChunklessPreparation:
           resolvedSource.textTracksAllowChunklessPreparation,
       };
-    }, [drm, source]);
+    }, [drm, source, textTracks]);
 
     const _selectedTextTrack = useMemo(() => {
       if (!selectedTextTrack) {
@@ -727,7 +729,6 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           restoreUserInterfaceForPIPStopCompletionHandler={
             _restoreUserInterfaceForPIPStopCompletionHandler
           }
-          textTracks={textTracks}
           selectedTextTrack={_selectedTextTrack}
           selectedAudioTrack={_selectedAudioTrack}
           selectedVideoTrack={_selectedVideoTrack}

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -42,6 +42,7 @@ export type VideoSrc = Readonly<{
   drm?: Drm;
   cmcd?: NativeCmcdConfiguration; // android
   textTracksAllowChunklessPreparation?: boolean; // android
+  textTracks?: TextTracks;
 }>;
 
 type DRMType = WithDefault<string, 'widevine'>;
@@ -317,7 +318,6 @@ export interface VideoNativeProps extends ViewProps {
   automaticallyWaitsToMinimizeStalling?: boolean;
   shutterColor?: Int32;
   audioOutput?: WithDefault<string, 'speaker'>;
-  textTracks?: TextTracks;
   selectedTextTrack?: SelectedTextTrack;
   selectedAudioTrack?: SelectedAudioTrack;
   selectedVideoTrack?: SelectedVideoTrack; // android

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -35,6 +35,7 @@ export type ReactVideoSourceProperties = {
   drm?: Drm;
   cmcd?: Cmcd; // android
   textTracksAllowChunklessPreparation?: boolean;
+  textTracks?: TextTracks;
 };
 
 export type ReactVideoSource = Readonly<
@@ -254,7 +255,7 @@ export type ControlsStyles = {
 
 export interface ReactVideoProps extends ReactVideoEvents, ViewProps {
   source?: ReactVideoSource;
-  /** @deprecated */
+  /** @deprecated Use source.drm */
   drm?: Drm;
   style?: StyleProp<ViewStyle>;
   adTagUrl?: string;
@@ -302,12 +303,13 @@ export interface ReactVideoProps extends ReactVideoEvents, ViewProps {
   selectedVideoTrack?: SelectedVideoTrack; // android
   subtitleStyle?: SubtitleStyle; // android
   shutterColor?: string; // Android
+  /** @deprecated Use source.textTracks */
   textTracks?: TextTracks;
   testID?: string;
   viewType?: ViewType;
-  /** @deprecated */
+  /** @deprecated Use viewType */
   useTextureView?: boolean; // Android
-  /** @deprecated */
+  /** @deprecated Use viewType*/
   useSecureView?: boolean; // Android
   volume?: number;
   localSourceEncryptionKeyScheme?: string;


### PR DESCRIPTION
## Summary
fix: refactor side loaded text tracks management

### Motivation
Clarify behavior for: https://github.com/TheWidlarzGroup/react-native-video/issues/3665 (mainly doc)
Continue on ticket: https://github.com/TheWidlarzGroup/react-native-video/issues/2693

### Changes
More textTracks in source.
android/ios: ensure text tracks are not selected by default android/ios make textTrack field not nullable
clean up doc
check compatibility with the old api
Add comments on deprecated JS apis
Apply API change on basic sample

## Test plan
Can still be tested with the sample app