### PR TITLE
fix(expo-plugin): add check for existing service in AndroidManifest for notification controls 

### DIFF
--- a/src/expo-plugins/withNotificationControls.ts
+++ b/src/expo-plugins/withNotificationControls.ts
@@ -23,7 +23,10 @@ export const withNotificationControls: ConfigPlugin<boolean> = (
       if (!application.service) {
         application.service = [];
       }
-
+// We check if the VideoPlaybackService is already defined in the AndroidManifest.xml
+// to prevent adding duplicate service entries. If the service exists, we will remove 
+// it before adding the updated configuration to ensure there are no conflicts or redundant
+// service declarations in the manifest.
       const existingServiceIndex = application.service.findIndex(
         (service) =>
           service?.$?.['android:name'] ===

--- a/src/expo-plugins/withNotificationControls.ts
+++ b/src/expo-plugins/withNotificationControls.ts
@@ -24,6 +24,15 @@ export const withNotificationControls: ConfigPlugin<boolean> = (
         application.service = [];
       }
 
+      const existingServiceIndex = application.service.findIndex(
+        (service) =>
+          service?.$?.['android:name'] ===
+          'com.brentvatne.exoplayer.VideoPlaybackService',
+      );
+      if (existingServiceIndex !== -1) {
+        application.service.splice(existingServiceIndex, 1);
+      }
+
       application.service.push({
         $: {
           'android:name': 'com.brentvatne.exoplayer.VideoPlaybackService',

--- a/src/expo-plugins/withNotificationControls.ts
+++ b/src/expo-plugins/withNotificationControls.ts
@@ -23,10 +23,11 @@ export const withNotificationControls: ConfigPlugin<boolean> = (
       if (!application.service) {
         application.service = [];
       }
-// We check if the VideoPlaybackService is already defined in the AndroidManifest.xml
-// to prevent adding duplicate service entries. If the service exists, we will remove 
-// it before adding the updated configuration to ensure there are no conflicts or redundant
-// service declarations in the manifest.
+
+      // We check if the VideoPlaybackService is already defined in the AndroidManifest.xml
+      // to prevent adding duplicate service entries. If the service exists, we will remove
+      // it before adding the updated configuration to ensure there are no conflicts or redundant
+      // service declarations in the manifest.
       const existingServiceIndex = application.service.findIndex(
         (service) =>
           service?.$?.['android:name'] ===


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
This PR fixes a minor issue with Expo Config Plugins (the one related to notification controls) that caused having duplicate `<service>` tags in the generated `AndroidManifest.xml` file when running non-cleaning `npx expo prebuild` multiple times.

### Motivation
Fix this issue: #4167 

### Changes
 I added a check in `withNotificationControls.ts` file for existing service in to avoid having duplicate code in `AndroidManifest.xml`.

## Test plan