### PR TITLE
chore(android): add null check for id of videoFormat

### DIFF
--- a/android/src/main/java/com/brentvatne/common/react/VideoEventEmitter.kt
+++ b/android/src/main/java/com/brentvatne/common/react/VideoEventEmitter.kt
@@ -355,5 +355,4 @@ class VideoEventEmitter {
 
             putString("orientation", orientation)
         }
-
 }

--- a/android/src/main/java/com/brentvatne/common/react/VideoEventEmitter.kt
+++ b/android/src/main/java/com/brentvatne/common/react/VideoEventEmitter.kt
@@ -64,11 +64,11 @@ class VideoEventEmitter {
         audioTracks: ArrayList<Track>,
         textTracks: ArrayList<Track>,
         videoTracks: ArrayList<VideoTrack>,
-        trackId: String
+        trackId: String?
     ) -> Unit
     lateinit var onVideoError: (errorString: String, exception: Exception, errorCode: String) -> Unit
     lateinit var onVideoProgress: (currentPosition: Long, bufferedDuration: Long, seekableDuration: Long, currentPlaybackTime: Double) -> Unit
-    lateinit var onVideoBandwidthUpdate: (bitRateEstimate: Long, height: Int, width: Int, trackId: String) -> Unit
+    lateinit var onVideoBandwidthUpdate: (bitRateEstimate: Long, height: Int, width: Int, trackId: String?) -> Unit
     lateinit var onVideoPlaybackStateChanged: (isPlaying: Boolean, isSeeking: Boolean) -> Unit
     lateinit var onVideoSeek: (currentPosition: Long, seekTime: Long) -> Unit
     lateinit var onVideoEnd: () -> Unit
@@ -108,7 +108,7 @@ class VideoEventEmitter {
 
                     val naturalSize: WritableMap = aspectRatioToNaturalSize(videoWidth, videoHeight)
                     putMap("naturalSize", naturalSize)
-                    putString("trackId", trackId)
+                    trackId?.let { putString("trackId", it) }
                     putArray("videoTracks", videoTracksToArray(videoTracks))
                     putArray("audioTracks", audioTracksToArray(audioTracks))
                     putArray("textTracks", textTracksToArray(textTracks))
@@ -153,9 +153,13 @@ class VideoEventEmitter {
             onVideoBandwidthUpdate = { bitRateEstimate, height, width, trackId ->
                 event.dispatch(EventTypes.EVENT_BANDWIDTH) {
                     putDouble("bitrate", bitRateEstimate.toDouble())
-                    putInt("width", width)
-                    putInt("height", height)
-                    putString("trackId", trackId)
+                    if (width > 0) {
+                        putInt("width", width)
+                    }
+                    if (height > 0) {
+                        putInt("height", height)
+                    }
+                    trackId?.let { putString("trackId", it) }
                 }
             }
             onVideoPlaybackStateChanged = { isPlaying, isSeeking ->
@@ -336,15 +340,20 @@ class VideoEventEmitter {
 
     private fun aspectRatioToNaturalSize(videoWidth: Int, videoHeight: Int): WritableMap =
         Arguments.createMap().apply {
-            putInt("width", videoWidth)
-            putInt("height", videoHeight)
-            val orientation = if (videoWidth > videoHeight) {
-                "landscape"
-            } else if (videoWidth < videoHeight) {
-                "portrait"
-            } else {
-                "square"
+            if (videoWidth > 0) {
+                putInt("width", videoWidth)
             }
+            if (videoHeight > 0) {
+                putInt("height", videoHeight)
+            }
+
+            val orientation = when {
+                videoWidth > videoHeight -> "landscape"
+                videoWidth < videoHeight -> "portrait"
+                else -> "square"
+            }
+
             putString("orientation", orientation)
         }
+
 }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -139,7 +139,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -390,7 +389,7 @@ public class ReactExoplayerView extends FrameLayout implements
                 Format videoFormat = player.getVideoFormat();
                 int width = videoFormat != null ? videoFormat.width : 0;
                 int height = videoFormat != null ? videoFormat.height : 0;
-                String trackId = videoFormat != null ? videoFormat.id : "-1";
+                String trackId = videoFormat != null && videoFormat.id != null ? videoFormat.id : "-1";
                 eventEmitter.onVideoBandwidthUpdate.invoke(bitrate, height, width, trackId);
             }
         }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -384,13 +384,13 @@ public class ReactExoplayerView extends FrameLayout implements
     public void onBandwidthSample(int elapsedMs, long bytes, long bitrate) {
         if (mReportBandwidth) {
             if (player == null) {
-                eventEmitter.onVideoBandwidthUpdate.invoke(bitrate, 0, 0, "-1");
+                eventEmitter.onVideoBandwidthUpdate.invoke(bitrate, 0, 0, null);
             } else {
                 Format videoFormat = player.getVideoFormat();
                 boolean isRotatedContent = videoFormat != null && (videoFormat.rotationDegrees == 90 || videoFormat.rotationDegrees == 270);
                 int width = videoFormat != null ? (isRotatedContent ? videoFormat.height : videoFormat.width) : 0;
                 int height = videoFormat != null ? (isRotatedContent ? videoFormat.width : videoFormat.height) : 0;
-                String trackId = videoFormat != null ? videoFormat.id : "-1";
+                String trackId = videoFormat != null ? videoFormat.id : null;
                 eventEmitter.onVideoBandwidthUpdate.invoke(bitrate, height, width, trackId);
             }
         }
@@ -1427,7 +1427,7 @@ public class ReactExoplayerView extends FrameLayout implements
             boolean isRotatedContent = videoFormat != null && (videoFormat.rotationDegrees == 90 || videoFormat.rotationDegrees == 270);
             int width = videoFormat != null ? (isRotatedContent ? videoFormat.height : videoFormat.width) : 0;
             int height = videoFormat != null ? (isRotatedContent ? videoFormat.width : videoFormat.height) : 0;
-            String trackId = videoFormat != null ? videoFormat.id : "-1";
+            String trackId = videoFormat != null ? videoFormat.id : null;
 
             // Properties that must be accessed on the main thread
             long duration = player.getDuration();

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1427,7 +1427,7 @@ public class ReactExoplayerView extends FrameLayout implements
             boolean isRotatedContent = videoFormat != null && (videoFormat.rotationDegrees == 90 || videoFormat.rotationDegrees == 270);
             int width = videoFormat != null ? (isRotatedContent ? videoFormat.height : videoFormat.width) : 0;
             int height = videoFormat != null ? (isRotatedContent ? videoFormat.width : videoFormat.height) : 0;
-            String trackId = videoFormat != null ? videoFormat.id : "-1";
+            String trackId = videoFormat != null && videoFormat.id != null ? videoFormat.id : "-1";
 
             // Properties that must be accessed on the main thread
             long duration = player.getDuration();

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -387,9 +387,10 @@ public class ReactExoplayerView extends FrameLayout implements
                 eventEmitter.onVideoBandwidthUpdate.invoke(bitrate, 0, 0, "-1");
             } else {
                 Format videoFormat = player.getVideoFormat();
-                int width = videoFormat != null ? videoFormat.width : 0;
-                int height = videoFormat != null ? videoFormat.height : 0;
-                String trackId = videoFormat != null && videoFormat.id != null ? videoFormat.id : "-1";
+                boolean isRotatedContent = videoFormat != null && (videoFormat.rotationDegrees == 90 || videoFormat.rotationDegrees == 270);
+                int width = videoFormat != null ? (isRotatedContent ? videoFormat.height : videoFormat.width) : 0;
+                int height = videoFormat != null ? (isRotatedContent ? videoFormat.width : videoFormat.height) : 0;
+                String trackId = videoFormat != null ? videoFormat.id : "-1";
                 eventEmitter.onVideoBandwidthUpdate.invoke(bitrate, height, width, trackId);
             }
         }
@@ -1426,7 +1427,7 @@ public class ReactExoplayerView extends FrameLayout implements
             boolean isRotatedContent = videoFormat != null && (videoFormat.rotationDegrees == 90 || videoFormat.rotationDegrees == 270);
             int width = videoFormat != null ? (isRotatedContent ? videoFormat.height : videoFormat.width) : 0;
             int height = videoFormat != null ? (isRotatedContent ? videoFormat.width : videoFormat.height) : 0;
-            String trackId = videoFormat != null && videoFormat.id != null ? videoFormat.id : "-1";
+            String trackId = videoFormat != null ? videoFormat.id : "-1";
 
             // Properties that must be accessed on the main thread
             long duration = player.getDuration();

--- a/docs/pages/component/events.mdx
+++ b/docs/pages/component/events.mdx
@@ -222,13 +222,14 @@ Callback function that is called when the media is loaded and ready to play.
 Payload:
 
 | Property    | Type   | Description                                                                                                                                                                                                                                                                                                                                                        |
-| ----------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|-------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | currentTime | number | Time in seconds where the media will start                                                                                                                                                                                                                                                                                                                         |
 | duration    | number | Length of the media in seconds                                                                                                                                                                                                                                                                                                                                     |
 | naturalSize | object | Properties:<br/> _ width - Width in pixels that the video was encoded at<br/> _ height - Height in pixels that the video was encoded at<br/> \* orientation - "portrait", "landscape" or "square"                                                                                                                                                                  |
 | audioTracks | array  | An array of audio track info objects with the following properties:<br/> _ index - Index number<br/> _ title - Description of the track<br/> _ language - 2 letter [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) or 3 letter [ISO639-2](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) language code<br/> _ type - Mime type of track |
 | textTracks  | array  | An array of text track info objects with the following properties:<br/> _ index - Index number<br/> _ title - Description of the track<br/> _ language - 2 letter [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) or 3 letter [ISO 639-2](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) language code<br/> _ type - Mime type of track |
 | videoTracks | array  | An array of video track info objects with the following properties:<br/> _ trackId - ID for the track<br/> _ bitrate - Bit rate in bits per second<br/> _ codecs - Comma separated list of codecs<br/> _ height - Height of the video<br/> \* width - Width of the video                                                                                           |
+| trackId     | string | Provide key information about the video track, typically including: `Resolution`, `Bitrate`.                                                                                                                                                                                                                                                                                                                                                |
 
 Example:
 
@@ -260,7 +261,8 @@ Example:
     { index: 0, bitrate: 3987904, codecs: "avc1.640028", height: 720, trackId: "f1-v1-x3", width: 1280 },
     { index: 1, bitrate: 7981888, codecs: "avc1.640028", height: 1080, trackId: "f2-v1-x3", width: 1920 },
     { index: 2, bitrate: 1994979, codecs: "avc1.4d401f", height: 480, trackId: "f3-v1-x3", width: 848 }
-  ]
+  ],
+  trackId: "720p 2400kbps"
 }
 ```
 


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
Add a null check for `videoFormat.id`.

### Motivation
Fix a potential issue where `videoFormat.id` could be null.

### Changes

## Test plan
The sample app should no longer crash when playing RTSP video types.