### PR TITLE
fix onAudioTracks : selected payload

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1607,7 +1607,7 @@ public class ReactExoplayerView extends FrameLayout implements
         if (format.sampleMimeType != null) track.setMimeType(format.sampleMimeType);
         if (format.language != null) track.setLanguage(format.language);
         if (format.label != null) track.setTitle(format.label);
-        track.setSelected(isTrackSelected(selection, group, trackIndex));
+        track.setSelected(isTrackSelected(selection, group, 0));
         return track;
     }
 


### PR DESCRIPTION

## Summary
Fix selected payload of onAudioTracks event

### Motivation
The selected payload of the onAudioTracks event was always coming as false, making it impossible to know which audio track is currently selected.

### Changes
change trackIndex to 0 for the isTrackSelected call

## Test plan