### PR TITLE
fix(android): bad rotation handling

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -275,6 +275,7 @@ public final class ExoPlayerView extends FrameLayout implements AdViewProvider {
                     case 90:
                     case 270:
                         layout.setVideoAspectRatio(format.width == 0 ? 1 : (format.height * format.pixelWidthHeightRatio) / format.width);
+                        break;
                     default:
                         layout.setVideoAspectRatio(format.height == 0 ? 1 : (format.width * format.pixelWidthHeightRatio) / format.height);
                 }

--- a/examples/basic/src/constants/general.ts
+++ b/examples/basic/src/constants/general.ts
@@ -32,6 +32,10 @@ export const srcAllPlatformList = [
     cropEnd: 10000,
   },
   {
+    description: 'video with 90° rotation',
+    uri: 'https://bn-dev.fra1.digitaloceanspaces.com/km-tournament/uploads/rn_image_picker_lib_temp_2ee86a27_9312_4548_84af_7fd75d9ad4dd_ad8b20587a.mp4',
+  },
+  {
     description: 'local file portrait',
     uri: localeVideo.portrait,
     metadata: {


### PR DESCRIPTION
## Summary
Bad rotation handling due to missing break

### Motivation
fix https://github.com/TheWidlarzGroup/react-native-video/issues/4187

### Changes
Just add a break in a switch case
Add sample video with 90° rotation

## Test plan
can be tested with the sample now