### PR TITLE
Pause video on end reached, don't remove listeners

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1631,7 +1631,8 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                 }
             )
         } else {
-            _playerObserver.removePlayerTimeObserver()
+            _player?.pause()
+            _player?.rate = 0.0
         }
     }
 


### PR DESCRIPTION
## Problem

That issues exists on iOS only, on Android it behaves us expected.

When you play a video all the way till the end, `onEndReached` we'll remove the time observers that update the `onProgress` handlers. But, if the user just seeks back to the beginning of the video (or anywhere on the timeline), the video will keep playing (as it was never stopped), but no `onProgress` callbacks/events will be triggered.

## Solution

On reaching the end of the video (unless set to repeat) instead of removing the time observers we just pause it. This will stop the `onProgress` events firing after the video finished. If the user chooses to seek back on the timeline to replay the video, they'd have to press "play" and the video will start normally and the `onProgress` events will fire correctly.

## Test plan

This can be checked by running a simple player on iOS that is:
* not on repeat
* using built in `controls`
* with an `onProgress` callback (for example: `onProgress={() => { console.log('test') }}`)

And then watching (or seeking) all the way till the end and then (without pausing or resuming it) seeking back to the beginning.