### PR TITLE
chore: Add react compiler workaround

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,5 @@ import Video from './Video';
 export {VideoDecoderProperties} from './VideoDecoderProperties';
 export * from './types';
 export type {VideoRef} from './Video';
+export {Video};
 export default Video;


### PR DESCRIPTION
## Summary
Export Video Element as none default

### Motivation
Workaround for react compiler
fix: https://github.com/TheWidlarzGroup/react-native-video/issues/4222

### Changes
Just export Video Element

## Test plan
can be tested with the sample app from linked ticket