### PR TITLE
chore: move minLoadRetryCount into source property

### DIFF
--- a/android/src/main/java/com/brentvatne/common/api/Source.kt
+++ b/android/src/main/java/com/brentvatne/common/api/Source.kt
@@ -48,6 +48,9 @@ class Source {
     /** Metadata to display in notification */
     var metadata: Metadata? = null
 
+    /** Allowed reload before failure notification */
+    var minLoadRetryCount = 3
+
     /** http header list */
     val headers: MutableMap<String, String> = HashMap()
 
@@ -91,7 +94,8 @@ class Source {
                 contentStartTime == other.contentStartTime &&
                 cmcdProps == other.cmcdProps &&
                 sideLoadedTextTracks == other.sideLoadedTextTracks &&
-                adsProps == other.adsProps
+                adsProps == other.adsProps &&
+                minLoadRetryCount == other.minLoadRetryCount
             )
     }
 
@@ -159,6 +163,7 @@ class Source {
         private const val PROP_SRC_ADS = "ad"
         private const val PROP_SRC_TEXT_TRACKS_ALLOW_CHUNKLESS_PREPARATION = "textTracksAllowChunklessPreparation"
         private const val PROP_SRC_TEXT_TRACKS = "textTracks"
+        private const val PROP_SRC_MIN_LOAD_RETRY_COUNT = "minLoadRetryCount"
 
         @SuppressLint("DiscouragedApi")
         private fun getUriFromAssetId(context: Context, uriString: String): Uri? {
@@ -223,7 +228,7 @@ class Source {
                 }
                 source.textTracksAllowChunklessPreparation = safeGetBool(src, PROP_SRC_TEXT_TRACKS_ALLOW_CHUNKLESS_PREPARATION, true)
                 source.sideLoadedTextTracks = SideLoadedTextTrackList.parse(safeGetArray(src, PROP_SRC_TEXT_TRACKS))
-
+                source.minLoadRetryCount = safeGetInt(src, PROP_SRC_MIN_LOAD_RETRY_COUNT, 3)
                 val propSrcHeadersArray = safeGetArray(src, PROP_SRC_HEADERS)
                 if (propSrcHeadersArray != null) {
                     if (propSrcHeadersArray.size() > 0) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -207,7 +207,6 @@ public class ReactExoplayerView extends FrameLayout implements
     private float rate = 1f;
     private AudioOutput audioOutput = AudioOutput.SPEAKER;
     private float audioVolume = 1f;
-    private int minLoadRetryCount = 3;
     private BufferConfig bufferConfig = new BufferConfig();
     private int maxBitRate = 0;
     private boolean hasDrmFailed = false;
@@ -1209,7 +1208,7 @@ public class ReactExoplayerView extends FrameLayout implements
         MediaSource mediaSource = mediaSourceFactory
                 .setDrmSessionManagerProvider(drmProvider)
                 .setLoadErrorHandlingPolicy(
-                        config.buildLoadErrorHandlingPolicy(minLoadRetryCount)
+                        config.buildLoadErrorHandlingPolicy(source.getMinLoadRetryCount())
                 )
                 .createMediaSource(mediaItem);
 
@@ -2274,12 +2273,6 @@ public class ReactExoplayerView extends FrameLayout implements
             trackSelector.setParameters(trackSelector.buildUponParameters()
                     .setMaxVideoBitrate(maxBitRate == 0 ? Integer.MAX_VALUE : maxBitRate));
         }
-    }
-
-    public void setMinLoadRetryCountModifier(int newMinLoadRetryCount) {
-        minLoadRetryCount = newMinLoadRetryCount;
-        releasePlayer();
-        initializePlayer();
     }
 
     public void setPlayInBackground(boolean playInBackground) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.kt
@@ -42,7 +42,6 @@ class ReactExoplayerViewManager(private val config: ReactExoplayerConfig) : View
         private const val PROP_PROGRESS_UPDATE_INTERVAL = "progressUpdateInterval"
         private const val PROP_REPORT_BANDWIDTH = "reportBandwidth"
         private const val PROP_RATE = "rate"
-        private const val PROP_MIN_LOAD_RETRY_COUNT = "minLoadRetryCount"
         private const val PROP_MAXIMUM_BIT_RATE = "maxBitRate"
         private const val PROP_PLAY_IN_BACKGROUND = "playInBackground"
         private const val PROP_DISABLE_FOCUS = "disableFocus"
@@ -185,11 +184,6 @@ class ReactExoplayerViewManager(private val config: ReactExoplayerConfig) : View
     @ReactProp(name = PROP_MAXIMUM_BIT_RATE)
     fun setMaxBitRate(videoView: ReactExoplayerView, maxBitRate: Float) {
         videoView.setMaxBitRateModifier(maxBitRate.toInt())
-    }
-
-    @ReactProp(name = PROP_MIN_LOAD_RETRY_COUNT)
-    fun setMinLoadRetryCount(videoView: ReactExoplayerView, minLoadRetryCount: Int) {
-        videoView.setMinLoadRetryCountModifier(minLoadRetryCount)
     }
 
     @ReactProp(name = PROP_PLAY_IN_BACKGROUND, defaultBoolean = false)

--- a/docs/pages/component/props.mdx
+++ b/docs/pages/component/props.mdx
@@ -379,6 +379,8 @@ maxBitRate={2000000} // 2 megabits
 ```
 
 ### `minLoadRetryCount`
+> [!WARNING]
+> deprecated, use `source.minLoadRetryCount` key instead
 
 <PlatformsList types={['Android']} />
 
@@ -901,6 +903,23 @@ source={{
     uri: 'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
     textTracksAllowChunklessPreparation: false,
   }}
+```
+
+#### `minLoadRetryCount`
+
+<PlatformsList types={['Android']} />
+
+Sets the minimum number of times to retry loading data before failing and reporting an error to the application. Useful to recover from transient internet failures.
+
+Default: 3. Retry 3 times.
+
+Example:
+
+```javascript
+source={{
+  uri: 'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
+  minLoadRetryCount={5} // retry 5 times
+}}
 ```
 
 #### `textTracks`

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -124,6 +124,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       onVideoTracks,
       onAspectRatio,
       localSourceEncryptionKeyScheme,
+      minLoadRetryCount,
       ...rest
     },
     ref,
@@ -233,6 +234,8 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
             ? {adTagUrl: adTagUrl, adLanguage: adLanguage}
             : undefined);
 
+        const _minLoadRetryCount =
+          _source.minLoadRetryCount || minLoadRetryCount;
         return {
           uri,
           isNetwork,
@@ -253,6 +256,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           textTracks: _textTracks,
           textTracksAllowChunklessPreparation:
             resolvedSource.textTracksAllowChunklessPreparation,
+          minLoadRetryCount: _minLoadRetryCount,
         };
       },
       [
@@ -261,6 +265,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         contentStartTime,
         drm,
         localSourceEncryptionKeyScheme,
+        minLoadRetryCount,
         source?.cmcd,
         textTracks,
       ],

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -50,6 +50,7 @@ export type VideoSrc = Readonly<{
   textTracksAllowChunklessPreparation?: boolean; // android
   textTracks?: TextTracks;
   ad?: AdsConfig;
+  minLoadRetryCount?: Int32; // Android
 }>;
 
 type DRMType = WithDefault<string, 'widevine'>;
@@ -362,7 +363,6 @@ export interface VideoNativeProps extends ViewProps {
   disableDisconnectError?: boolean; // Android
   focusable?: boolean; // Android
   hideShutterView?: boolean; //	Android
-  minLoadRetryCount?: Int32; // Android
   reportBandwidth?: boolean; //Android
   subtitleStyle?: SubtitleStyle; // android
   viewType?: Int32; // Android

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -39,6 +39,7 @@ export type ReactVideoSourceProperties = {
   textTracksAllowChunklessPreparation?: boolean;
   textTracks?: TextTracks;
   ad?: AdConfig;
+  minLoadRetryCount?: number; // Android
 };
 
 export type ReactVideoSource = Readonly<
@@ -305,6 +306,7 @@ export interface ReactVideoProps extends ReactVideoEvents, ViewProps {
   fullscreenOrientation?: EnumValues<FullscreenOrientationType>; // iOS
   hideShutterView?: boolean; //	Android
   ignoreSilentSwitch?: EnumValues<IgnoreSilentSwitchType>; // iOS
+  /** @deprecated Use source.minLoadRetryCount */
   minLoadRetryCount?: number; // Android
   maxBitRate?: number;
   mixWithOthers?: EnumValues<MixWithOthersType>; // iOS


### PR DESCRIPTION
## Summary
chore: move minLoadRetryCount into source property

### Motivation
clean startup process (see: https://github.com/TheWidlarzGroup/react-native-video/issues/2693)

### Changes
deprecate root property to move it into source

## Test plan
Can be tested with sample by adding the property