### PR TITLE
Render the metadata title in Android player controls

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -563,7 +563,7 @@ public class ReactExoplayerView extends FrameLayout implements
     private void refreshControlsStyles() {
         if (playerControlView == null || player == null || !controls) return;
 
-        // FORK: Set title
+        // Update to the title provided by the source metadata object
         Source.Metadata metadata = source.getMetadata();
         String title = (metadata != null && metadata.getTitle() != null) ? metadata.getTitle() : "";
         TextView titleText = playerControlView.findViewById(R.id.exo_controller_title);

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -562,6 +562,13 @@ public class ReactExoplayerView extends FrameLayout implements
 
     private void refreshControlsStyles() {
         if (playerControlView == null || player == null || !controls) return;
+
+        // FORK: Set title
+        Source.Metadata metadata = source.getMetadata();
+        String title = (metadata != null && metadata.getTitle() != null) ? metadata.getTitle() : "";
+        TextView titleText = playerControlView.findViewById(R.id.exo_controller_title);
+        titleText.setText(title);
+
         updateLiveContent();
         updatePlayPauseButtons();
         updateButtonVisibility(controlsConfig.getHideForward(), R.id.exo_ffwd);

--- a/android/src/main/res/layout/exo_legacy_player_control_view.xml
+++ b/android/src/main/res/layout/exo_legacy_player_control_view.xml
@@ -6,6 +6,15 @@
     android:background="@color/midnight_black"
     android:orientation="vertical">
 
+    <TextView android:id="@+id/exo_controller_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/position_duration_text_size"
+        android:textStyle="bold"
+        android:includeFontPadding="false"
+        android:textColor="@color/white"
+        />
+
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/android/src/main/res/values/ids.xml
+++ b/android/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="exo_controller_title" type="id" />
+</resources>


### PR DESCRIPTION
## Summary
Integrates the video title into the Android player controls. This is already automatically handled by iOS through the `source.metadata.title` prop.

### Note:
- We only use the title for our TV project so the styling may not be great for Android phones.