### PR TITLE
Add support for HLS videos caching on android

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1169,7 +1169,8 @@ public class ReactExoplayerView extends FrameLayout implements
 
                 mediaSourceFactory = new HlsMediaSource.Factory(
                         dataSourceFactory
-                ).setAllowChunklessPreparation(source.getTextTracksAllowChunklessPreparation());                break;
+                ).setAllowChunklessPreparation(source.getTextTracksAllowChunklessPreparation());
+                break;
             case CONTENT_TYPE_OTHER:
                 if ("asset".equals(uri.getScheme())) {
                     try {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1161,10 +1161,15 @@ public class ReactExoplayerView extends FrameLayout implements
                     throw new IllegalStateException("HLS is not enabled!");
                 }
 
+                DataSource.Factory dataSourceFactory = mediaDataSourceFactory;
+
+                if (useCache) {
+                    dataSourceFactory = RNVSimpleCache.INSTANCE.getCacheFactory(buildHttpDataSourceFactory(true));
+                }
+
                 mediaSourceFactory = new HlsMediaSource.Factory(
-                        mediaDataSourceFactory
-                ).setAllowChunklessPreparation(source.getTextTracksAllowChunklessPreparation());
-                break;
+                        dataSourceFactory
+                ).setAllowChunklessPreparation(source.getTextTracksAllowChunklessPreparation());                break;
             case CONTENT_TYPE_OTHER:
                 if ("asset".equals(uri.getScheme())) {
                     try {


### PR DESCRIPTION
## Summary
This PR adds a conditional check whether to include HLS video caching or not for Android devices. We already have a **bufferConfig** prop that enables caching in most cases, but we don't utilise the **useCache** variable in case of HLS video streaming.

### Motivation
Every time the same HLS video is being played - it gets loaded again and again which is counter-efficient.

### Changes

- Added a conditional check with **useCache** to whether enable HLS video caching or not.

## Test plan
Open App Inspector in Android Studio (or proxyman or any other sniffing tool) and check whether HLS videos are getting downloaded with and without **bufferConfig** prop.