### PR TITLE
chore(ci): bump actions versions

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -17,7 +17,7 @@ runs:
     
     - name: Cache dependencies
       id: bun-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           **/node_modules

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -17,7 +17,7 @@ runs:
 
     - name: Cache dependencies
       id: yarn-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{ inputs.working-directory }}/node_modules

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -46,7 +46,7 @@ jobs:
           working-directory: examples/bare
 
       - name: Restore Gradle cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -84,7 +84,7 @@ jobs:
           working-directory: examples/bare
 
       - name: Restore Gradle cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -52,7 +52,7 @@ jobs:
           bundler-cache: true
 
       - name: Restore Pods cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             examples/bare/ios/Pods
@@ -116,7 +116,7 @@ jobs:
           bundler-cache: true
 
       - name: Restore Pods cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             examples/bare/ios/Pods
@@ -180,7 +180,7 @@ jobs:
           bundler-cache: true
 
       - name: Restore Pods cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             examples/bare/ios/Pods

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup
         uses: ./.github/actions/setup-bun
@@ -22,7 +22,7 @@ jobs:
           working-directory: ./docs
 
       - name: Cache build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             docs/.next/cache

--- a/.github/workflows/test-build-docs.yml
+++ b/.github/workflows/test-build-docs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup
         uses: ./.github/actions/setup-bun
@@ -20,7 +20,7 @@ jobs:
           working-directory: ./docs
 
       - name: Cache build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             docs/.next/cache

--- a/.github/workflows/validate-issue.yml
+++ b/.github/workflows/validate-issue.yml
@@ -8,7 +8,7 @@ jobs:
   validate-and-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Validate Issue Template and Add Labels
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
Updated actions used in workflows - Github will deprecate some apis, so in order to make sure that CI will work I have updated it