### PR TITLE
fix(ios): handle async player access in text track selection

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -964,13 +964,13 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     func setSelectedTextTrack(_ selectedTextTrack: SelectedTrackCriteria?) {
         _selectedTextTrackCriteria = selectedTextTrack ?? SelectedTrackCriteria.none()
-        guard let source = _source else { return }
+        guard let source else { return }
         if !source.textTracks.isEmpty { // sideloaded text tracks
             RCTPlayerOperations.setSideloadedText(player: _player, textTracks: source.textTracks, criteria: _selectedTextTrackCriteria)
-        } else { // text tracks included in the HLS playlist§
+        } else { // text tracks included in the HLS playlist
             Task { [weak self] in
-                guard let self = self,
-                      let player = self._player else { return }
+                guard let self,
+                    let player = self._player else { return }
 
                 await RCTPlayerOperations.setMediaSelectionTrackForCharacteristic(
                     player: player,

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -968,9 +968,15 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         if !source.textTracks.isEmpty { // sideloaded text tracks
             RCTPlayerOperations.setSideloadedText(player: _player, textTracks: source.textTracks, criteria: _selectedTextTrackCriteria)
         } else { // text tracks included in the HLS playlist§
-            Task {
-                await RCTPlayerOperations.setMediaSelectionTrackForCharacteristic(player: _player, characteristic: AVMediaCharacteristic.legible,
-                                                                                  criteria: _selectedTextTrackCriteria)
+            Task { [weak self] in
+                guard let self = self,
+                      let player = self._player else { return }
+
+                await RCTPlayerOperations.setMediaSelectionTrackForCharacteristic(
+                    player: player,
+                    characteristic: .legible,
+                    criteria: self._selectedTextTrackCriteria
+                )
             }
         }
     }

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -964,7 +964,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     func setSelectedTextTrack(_ selectedTextTrack: SelectedTrackCriteria?) {
         _selectedTextTrackCriteria = selectedTextTrack ?? SelectedTrackCriteria.none()
-        guard let source else { return }
+        guard let source = _source else { return }
         if !source.textTracks.isEmpty { // sideloaded text tracks
             RCTPlayerOperations.setSideloadedText(player: _player, textTracks: source.textTracks, criteria: _selectedTextTrackCriteria)
         } else { // text tracks included in the HLS playlist

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -964,12 +964,12 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     func setSelectedTextTrack(_ selectedTextTrack: SelectedTrackCriteria?) {
         _selectedTextTrackCriteria = selectedTextTrack ?? SelectedTrackCriteria.none()
-        guard let source = _source, let player = _player else { return }
+        guard let source = _source else { return }
         if !source.textTracks.isEmpty { // sideloaded text tracks
-            RCTPlayerOperations.setSideloadedText(player: player, textTracks: source.textTracks, criteria: _selectedTextTrackCriteria)
+            RCTPlayerOperations.setSideloadedText(player: _player, textTracks: source.textTracks, criteria: _selectedTextTrackCriteria)
         } else { // text tracks included in the HLS playlist§
             Task {
-                await RCTPlayerOperations.setMediaSelectionTrackForCharacteristic(player: player, characteristic: AVMediaCharacteristic.legible,
+                await RCTPlayerOperations.setMediaSelectionTrackForCharacteristic(player: _player, characteristic: AVMediaCharacteristic.legible,
                                                                                   criteria: _selectedTextTrackCriteria)
             }
         }

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -970,7 +970,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         } else { // text tracks included in the HLS playlist
             Task { [weak self] in
                 guard let self,
-                    let player = self._player else { return }
+                      let player = self._player else { return }
 
                 await RCTPlayerOperations.setMediaSelectionTrackForCharacteristic(
                     player: player,

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -964,12 +964,12 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     func setSelectedTextTrack(_ selectedTextTrack: SelectedTrackCriteria?) {
         _selectedTextTrackCriteria = selectedTextTrack ?? SelectedTrackCriteria.none()
-        guard let source = _source else { return }
+        guard let source = _source, let player = _player else { return }
         if !source.textTracks.isEmpty { // sideloaded text tracks
-            RCTPlayerOperations.setSideloadedText(player: _player, textTracks: source.textTracks, criteria: _selectedTextTrackCriteria)
+            RCTPlayerOperations.setSideloadedText(player: player, textTracks: source.textTracks, criteria: _selectedTextTrackCriteria)
         } else { // text tracks included in the HLS playlist§
             Task {
-                await RCTPlayerOperations.setMediaSelectionTrackForCharacteristic(player: _player, characteristic: AVMediaCharacteristic.legible,
+                await RCTPlayerOperations.setMediaSelectionTrackForCharacteristic(player: player, characteristic: AVMediaCharacteristic.legible,
                                                                                   criteria: _selectedTextTrackCriteria)
             }
         }


### PR DESCRIPTION
# Fix Potential Race Condition in Video Player Text Track Selection

## Description
Potentially fixed a crash that happens when text tracks get selected while the player is being destroyed. Super hard to reproduce but shows up in crash logs. Basically the player exists when we start the async operation but might be gone by the time we try to use it.

## Changes
- Added weak self in async block
- Added guard check for player instance
- Made sure we have strong reference to player during async operation

## Steps to Maybe Reproduce
Really hard to get this consistently, but here's what might trigger it:
1. Switch videos really fast
2. Change text tracks while video is loading
3. Background the app during text track changes


## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing functionality)

## Screenshots
<img width="872" alt="ios-rctvideo-crash" src="https://github.com/user-attachments/assets/6200f66d-6f02-4da5-a6e1-e4815d4da2bd">



## Checklist
- [x] Code follows project style guidelines
- [x] Edge cases tested where possible
- [x] No new warnings introduced