### PR TITLE
fix(android): disable caching on local asset files

### DIFF
--- a/android/src/main/java/com/brentvatne/common/api/Source.kt
+++ b/android/src/main/java/com/brentvatne/common/api/Source.kt
@@ -30,6 +30,12 @@ class Source {
     /** Parsed value of source to playback */
     var uri: Uri? = null
 
+    /** True if source is a local JS asset */
+    var isLocalAssetFile: Boolean = false
+
+    /** True if source is a local file asset://, ... */
+    var isAsset: Boolean = false
+
     /** Start position of playback used to resume playback */
     var startPositionMs: Int = -1
 
@@ -101,6 +107,8 @@ class Source {
                 sideLoadedTextTracks == other.sideLoadedTextTracks &&
                 adsProps == other.adsProps &&
                 minLoadRetryCount == other.minLoadRetryCount &&
+                isLocalAssetFile == other.isLocalAssetFile &&
+                isAsset == other.isAsset &&
                 bufferConfig == other.bufferConfig
             )
     }
@@ -157,6 +165,8 @@ class Source {
     companion object {
         private const val TAG = "Source"
         private const val PROP_SRC_URI = "uri"
+        private const val PROP_SRC_IS_LOCAL_ASSET_FILE = "isLocalAssetFile"
+        private const val PROP_SRC_IS_ASSET = "isAsset"
         private const val PROP_SRC_START_POSITION = "startPosition"
         private const val PROP_SRC_CROP_START = "cropStart"
         private const val PROP_SRC_CROP_END = "cropEnd"
@@ -223,6 +233,8 @@ class Source {
                 }
                 source.uriString = uriString
                 source.uri = uri
+                source.isLocalAssetFile = safeGetBool(src, PROP_SRC_IS_LOCAL_ASSET_FILE, false)
+                source.isAsset = safeGetBool(src, PROP_SRC_IS_ASSET, false)
                 source.startPositionMs = safeGetInt(src, PROP_SRC_START_POSITION, -1)
                 source.cropStartMs = safeGetInt(src, PROP_SRC_CROP_START, -1)
                 source.cropEndMs = safeGetInt(src, PROP_SRC_CROP_END, -1)

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -747,7 +747,7 @@ public class ReactExoplayerView extends FrameLayout implements
                     // Initialize core configuration and listeners
                     initializePlayerCore(self);
                 }
-                if (source.getBufferConfig().getCacheSize() > 0) {
+                if (!source.isLocalAssetFile() && !source.isAsset() && source.getBufferConfig().getCacheSize() > 0) {
                     RNVSimpleCache.INSTANCE.setSimpleCache(
                             this.getContext(),
                             source.getBufferConfig().getCacheSize()
@@ -1186,7 +1186,7 @@ public class ReactExoplayerView extends FrameLayout implements
                         DataSource.Factory assetDataSourceFactory = DataSourceUtil.buildAssetDataSourceFactory(themedReactContext, uri);
                         mediaSourceFactory = new ProgressiveMediaSource.Factory(assetDataSourceFactory);
                     } catch (Exception e) {
-                        throw new IllegalStateException("cannot open input file" + uri);
+                        throw new IllegalStateException("cannot open input file:" + uri);
                     }
                 } else if ("file".equals(uri.getScheme()) ||
                         !useCache) {

--- a/examples/expo/package.json
+++ b/examples/expo/package.json
@@ -7,6 +7,8 @@
     "start:tv": "EXPO_TV=1 expo start",
     "android:tv": "EXPO_TV=1 expo run:android",
     "android": "EXPO_TV=0 expo run:android",
+    "release:android": "cd android && EXPO_TV=0 ./gradlew assembleRelease && cd -",
+    "release:android:tv": "cd android && EXPO_TV=1 ./gradlew assembleRelease && cd -",
     "ios:tv": "EXPO_TV=1 expo run:ios",
     "ios": "EXPO_TV=0 expo run:ios",
     "web": "expo start --web",

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -151,6 +151,11 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         if (!_source) {
           return undefined;
         }
+
+        const isLocalAssetFile =
+          typeof _source === 'number' ||
+          ('uri' in _source && typeof _source.uri === 'number');
+
         const resolvedSource = resolveAssetSourceForVideo(_source);
         let uri = resolvedSource.uri || '';
         if (uri && uri.match(/^\//)) {
@@ -226,6 +231,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           uri,
           isNetwork,
           isAsset,
+          isLocalAssetFile,
           shouldCache: resolvedSource.shouldCache || false,
           type: resolvedSource.type || '',
           mainVer: resolvedSource.mainVer || 0,

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -35,6 +35,7 @@ export type VideoSrc = Readonly<{
   uri?: string;
   isNetwork?: boolean;
   isAsset?: boolean;
+  isLocalAssetFile?: boolean;
   shouldCache?: boolean;
   type?: string;
   mainVer?: Int32;

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -24,6 +24,7 @@ export type ReactVideoSourceProperties = {
   uri?: string;
   isNetwork?: boolean;
   isAsset?: boolean;
+  isLocalAssetFile?: boolean;
   shouldCache?: boolean;
   type?: string;
   mainVer?: number;


### PR DESCRIPTION
## Summary
Disable caching on android local files

### Motivation
fix: https://github.com/TheWidlarzGroup/react-native-video/issues/4243

### Changes
add a flag indicating we are streaming a local asset file and disable caching in that case (which doesn't make sens)

## Test plan
can be tested in sample expo app. I add a script to build in release mode in the same time