### PR TITLE
feat(android): bump androidx.activity default version from v1.8.2 to v1.9.3

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -11,5 +11,5 @@ RNVideo_useExoplayerSmoothStreaming=true
 RNVideo_useExoplayerDash=true
 RNVideo_useExoplayerHls=true
 RNVideo_androidxCoreVersion=1.13.1
-RNVideo_androidxActivityVersion=1.8.2
+RNVideo_androidxActivityVersion=1.9.3
 RNVideo_buildFromMedia3Source=false


### PR DESCRIPTION
## Summary
- Bump default `androidx.activity:activity-ktx` version from v1.8.2 to v1.9.3

### Motivation
- Starting in v1.9.0, callback of `onUserLeaveHint` can be used without an implementation of MainActivity. This feature makes it possible to remove some of tricky implementation within PR #3385 .
- fyi) [1.9.0 release note](https://developer.android.com/jetpack/androidx/releases/activity?_gl=1*mchr5e*_up*MQ..*_ga*MTI5MzI4Mzg4LjE3MzI5MDE2NjQ.*_ga_6HH9YJMN9M*MTczMjkwMTY2NC4xLjAuMTczMjkwMTY2NC4wLjAuMTE3Njk1NzE2OA..#1.9.0)

### Changes
- Currently, the only place we use it is in the `OnBackPressedCallback` of `FullScreenPlayerView.kt`, and this feature works properly. However, users who have been forcing legacy version instead of the default may have issues.

## Test plan