### PR TITLE
Examples README: correct Expo heading link

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -87,7 +87,7 @@ yarn start
 > [!TIP]
 > Make sure you've already downloaded the simulator on which you want to launch the app.
 
-## [Expo](https://github.com/TheWidlarzGroup/react-native-video/tree/master/examples/bare)
+## [Expo](https://github.com/TheWidlarzGroup/react-native-video/tree/master/examples/expo)
 
 ### Configuration
 


### PR DESCRIPTION
This corrects a typo in the examples README.