### PR TITLE
fix: _paused is updated when video playback pause

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1508,6 +1508,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
         guard _isPlaying != isPlaying else { return }
         _isPlaying = isPlaying
+        _paused = !isPlaying
         onVideoPlaybackStateChanged?(["isPlaying": isPlaying, "isSeeking": self._pendingSeek == true, "target": reactTag as Any])
     }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
Keep paused state in sync with playing state.

### Motivation
I found that the video resumes from being paused automatically when foregrounding the app, which is an unexpected behavior. I wanted the playback state from the background, whether playing or paused, to persist from background to foreground to create a better experience for the users of my app.

Also a fix for #4321

### Changes
Update `_paused` on RCTVideo alongside `_isPlaying` when the video playback (or time control status) changes.

I found that this was behavior was due to `_paused` on RCTVideo not being updated when the video is paused with native controls, as it is only updated by the `setPause()` method. The consequences of this are that `setPause()` is called within `applyModifiers()` which is called within `applicationWillEnterForeground().` This call uses the current value of `_paused` (`setPause(_paused)`), which is false, and `setPause()` will play the video if the value given to it is false.

Updating `_paused` alongside `_isPlaying` keeps it update with the state of the player and fixes the issue.

## Test plan
1. Open Video
2. Pause Video
3. Background App
4. Foreground App
5. Video should remain paused (or whatever it's background state was when backgrounded)