### PR TITLE
Allow overriding style on web

### DIFF
--- a/src/Video.web.tsx
+++ b/src/Video.web.tsx
@@ -7,7 +7,7 @@ import React, {
   type RefObject,
   useState,
 } from 'react';
-import type {VideoRef, ReactVideoProps, VideoMetadata} from './types';
+import type {VideoRef, WebReactVideoProps, VideoMetadata} from './types';
 
 // stolen from https://stackoverflow.com/a/77278013/21726244
 const isDeepEqual = <T,>(a: T, b: T): boolean => {
@@ -25,10 +25,11 @@ const isDeepEqual = <T,>(a: T, b: T): boolean => {
   );
 };
 
-const Video = forwardRef<VideoRef, ReactVideoProps>(
+const Video = forwardRef<VideoRef, WebReactVideoProps>(
   (
     {
       source,
+      style = videoStyle,
       paused,
       muted,
       volume,
@@ -127,7 +128,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
     const setFullScreen = useCallback(
       async (
         newVal: boolean,
-        orientation?: ReactVideoProps['fullscreenOrientation'],
+        orientation?: WebReactVideoProps['fullscreenOrientation'],
         autorotate?: boolean,
       ) => {
         orientation ??= fsPrefs.current.fullscreenOrientation;
@@ -359,7 +360,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           onVolumeChange?.({volume: nativeRef.current.volume});
         }}
         onEnded={onEnd}
-        style={videoStyle}
+        style={style}
       />
     );
   },

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -9,7 +9,7 @@ import type {
   ImageURISource,
   ImageStyle,
 } from 'react-native';
-import type {ReactNode} from 'react';
+import type {CSSProperties, ReactNode} from 'react';
 import type VideoResizeMode from './ResizeMode';
 import type FilterType from './FilterType';
 import type ViewType from './ViewType';
@@ -350,3 +350,9 @@ export interface ReactVideoProps extends ReactVideoEvents, ViewProps {
   allowsExternalPlayback?: boolean; // iOS
   controlsStyles?: ControlsStyles; // Android
 }
+
+export interface WebStyleProp {
+  style?: CSSProperties;
+}
+
+export type WebReactVideoProps = Omit<ReactVideoProps, 'style'> & WebStyleProp;


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
Allow overriding style on web

### Motivation
When overriding the `style` with `{}` we can allow the (web) video to resize to its real size without further effort.

### Changes
Sending `style` will now affect video on web.

## Test plan
I assume that if someone is already sending `style` this can affect them, however the release of the web support was quite recent so I'm not sure how risky this is; not sure how to test it though...