### PR TITLE
fix: avoid memory leak on iOS

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -256,7 +256,6 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        ReactNativeVideoManager.shared.registerView(newInstance: self)
         #if USE_GOOGLE_IMA
             _imaAdsManager = RCTIMAAdsManager(video: self, pipEnabled: isPipEnabled)
         #endif

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -256,6 +256,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+        ReactNativeVideoManager.shared.registerView(newInstance: self)
         #if USE_GOOGLE_IMA
             _imaAdsManager = RCTIMAAdsManager(video: self, pipEnabled: isPipEnabled)
         #endif

--- a/ios/Video/ReactNativeVideoManager.swift
+++ b/ios/Video/ReactNativeVideoManager.swift
@@ -17,9 +17,9 @@ public class ReactNativeVideoManager: RNVPlugin {
     private var pluginList: [RNVPlugin] = Array()
 
     /**
-      * register a new view
+     * register a new view
      */
-    func registerView(newInstance: RCTVideo) {
+    func registerView(newInstance _: RCTVideo) {
         if instanceCount > expectedMaxVideoCount {
             DebugLog("multiple Video displayed ?")
         }
@@ -29,7 +29,7 @@ public class ReactNativeVideoManager: RNVPlugin {
     /**
      * unregister existing view
      */
-    func unregisterView(newInstance: RCTVideo) {
+    func unregisterView(newInstance _: RCTVideo) {
         instanceCount -= 1
     }
 

--- a/ios/Video/ReactNativeVideoManager.swift
+++ b/ios/Video/ReactNativeVideoManager.swift
@@ -6,33 +6,31 @@
 import Foundation
 
 public class ReactNativeVideoManager: RNVPlugin {
-    private let expectedMaxVideoCount = 10
+    private let expectedMaxVideoCount = 2
 
     // create a private initializer
     private init() {}
 
     public static let shared: ReactNativeVideoManager = .init()
 
-    var instanceList: [RCTVideo] = Array()
-    var pluginList: [RNVPlugin] = Array()
+    private var instanceCount = 0
+    private var pluginList: [RNVPlugin] = Array()
 
     /**
-      * register a new ReactExoplayerViewManager in the managed list
+      * register a new view
      */
     func registerView(newInstance: RCTVideo) {
-        if instanceList.count > expectedMaxVideoCount {
+        if instanceCount > expectedMaxVideoCount {
             DebugLog("multiple Video displayed ?")
         }
-        instanceList.append(newInstance)
+        instanceCount += 1
     }
 
     /**
-     * unregister existing ReactExoplayerViewManager in the managed list
+     * unregister existing view
      */
     func unregisterView(newInstance: RCTVideo) {
-        if let i = instanceList.firstIndex(of: newInstance) {
-            instanceList.remove(at: i)
-        }
+        instanceCount -= 1
     }
 
     /**


### PR DESCRIPTION
## Summary

The PR fixes memory leaks on iOS. 

<img width="237" alt="Screenshot 2024-12-31 at 10 19 08" src="https://github.com/user-attachments/assets/8376a1e5-529e-458c-a386-cdf5e45c2397" />

The `RCTVideo` and `ReactNativeVideoManager` create a reference cycle because `ReactNativeVideoManager` retains the views but never release them.

### Motivation

Reducing the memory usage in the apps.

### Changes

Removes redundant `instanceList` in `ReactNativeVideoManager` but keep the counter logic. React Native retain the view references so no need to have an extra list.

## Test plan

1. In the basic app, push and pop the video screen 8 times. 
2. Check `RCTVideo` instances in the memory graph.

**Expected result**: only a single `RCTVideo` instance is presented.

<img width="235" alt="Screenshot 2024-12-31 at 10 29 33" src="https://github.com/user-attachments/assets/b488bf41-cf27-440a-b9e2-4034b3c47606" />

<br><br>

> ⚠️ *In the sample app, the `CLANG_ADDRESS_SANITIZER` is enabled in debug. So Xcode doesn't show a proper object list. I had to remove `Yes` value for test purposes.* <img width="489" alt="Screenshot 2024-12-31 at 10 41 01" src="https://github.com/user-attachments/assets/ca12fb5b-138a-41bd-a7cc-cde86842045f" />

