### PR TITLE
Fix NullPointerException in setEnterPictureInPictureOnLeave for unsupported Android versions

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/PictureInPictureUtil.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/PictureInPictureUtil.kt
@@ -91,26 +91,26 @@ object PictureInPictureUtil {
     @JvmStatic
     fun applyPlayingStatus(
         context: ThemedReactContext,
-        pipParamsBuilder: PictureInPictureParams.Builder,
+        pipParamsBuilder: PictureInPictureParams.Builder?,
         receiver: PictureInPictureReceiver,
         isPaused: Boolean
     ) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        if (pipParamsBuilder == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
         val actions = getPictureInPictureActions(context, isPaused, receiver)
         pipParamsBuilder.setActions(actions)
         updatePictureInPictureActions(context, pipParamsBuilder.build())
     }
 
     @JvmStatic
-    fun applyAutoEnterEnabled(context: ThemedReactContext, pipParamsBuilder: PictureInPictureParams.Builder, autoEnterEnabled: Boolean) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return
+    fun applyAutoEnterEnabled(context: ThemedReactContext, pipParamsBuilder: PictureInPictureParams.Builder?, autoEnterEnabled: Boolean) {
+        if (pipParamsBuilder == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return
         pipParamsBuilder.setAutoEnterEnabled(autoEnterEnabled)
         updatePictureInPictureActions(context, pipParamsBuilder.build())
     }
 
     @JvmStatic
-    fun applySourceRectHint(context: ThemedReactContext, pipParamsBuilder: PictureInPictureParams.Builder, playerView: ExoPlayerView) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+    fun applySourceRectHint(context: ThemedReactContext, pipParamsBuilder: PictureInPictureParams.Builder?, playerView: ExoPlayerView) {
+        if (pipParamsBuilder == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
         pipParamsBuilder.setSourceRectHint(calcRectHint(playerView))
         updatePictureInPictureActions(context, pipParamsBuilder.build())
     }


### PR DESCRIPTION
## Summary

A NullPointerException was occurring when calling setEnterPictureInPictureOnLeave on devices running Android versions below Build.VERSION_CODES.O. The issue was caused by the fact that `PictureInPictureUtil#applyAutoEnterEnabled` was being called even for unsupported Android versions, where pictureInPictureParamsBuilder might not be initialized, leading to a null parameter passed to the Kotlin function applyAutoEnterEnabled.

```java
public ReactExoplayerView(ThemedReactContext context, ReactExoplayerConfig config) {
  // ...
  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && pictureInPictureParamsBuilder == null) {
       this.pictureInPictureParamsBuilder = new PictureInPictureParams.Builder();
  }
  // ...
```

```
Fatal Exception: com.facebook.react.bridge.JSApplicationIllegalArgumentException
Error while updating property 'enterPictureInPictureOnLeave' of a view managed by: RCTVideo
          Caused by java.lang.NullPointerException: Parameter specified as non-null is null: method com.brentvatne.exoplayer.PictureInPictureUtil.applyAutoEnterEnabled, parameter pipParamsBuilder
       at com.brentvatne.exoplayer.PictureInPictureUtil.applyAutoEnterEnabled(PictureInPictureUtil.kt)
       at com.brentvatne.exoplayer.ReactExoplayerView.setEnterPictureInPictureOnLeave(ReactExoplayerView.java:2156)
       at com.brentvatne.exoplayer.ReactExoplayerViewManager.setEnterPictureInPictureOnLeave(ReactExoplayerViewManager.kt:169)
```