### PR TITLE
[Feat] Added additional buttons for contextual actions

### DIFF
--- a/ios/Video/DataStructures/ContextualActionData.swift
+++ b/ios/Video/DataStructures/ContextualActionData.swift
@@ -1,0 +1,20 @@
+//
+//  ContextualActionData.swift
+//  react-native-video
+//
+//  Created by Eduard Mazur on 14.01.2025.
+//
+
+import Foundation
+
+struct ContextualActionData {
+    let action: String
+    let startAt: Double
+    let endAt: Double?
+}
+
+public enum ContextualButtonState {
+    case none
+    case skipIntro
+    case nextEpisode
+}

--- a/ios/Video/RCTVideo+ContextualActions.swift
+++ b/ios/Video/RCTVideo+ContextualActions.swift
@@ -1,0 +1,88 @@
+//
+//  RCTVideo+ContextualActions.swift
+//  react-native-video
+//
+//  Created by Eduard Mazur on 14.01.2025.
+//
+
+import AVKit
+
+@available(tvOS 15.0, *)
+extension RCTVideo {
+    func configureContextualActions() {
+        guard let player = playerForContextualActions else {
+            print("Player is not initialized.")
+            return
+        }
+
+        let interval = CMTime(seconds: 0.5, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
+
+        timeObserverToken = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self] currentTime in
+            self?.updateContextualActions(currentTime: currentTime)
+        }
+    }
+
+    func removeContextualActionsTimeObserver() {
+        guard let player = playerForContextualActions, let token = timeObserverToken else { return }
+        player.removeTimeObserver(token)
+        timeObserverToken = nil
+    }
+
+    func updateContextualActions(currentTime: CMTime) {
+        let currentSeconds = CMTimeGetSeconds(currentTime)
+
+        guard let playerViewController = playerViewControllerForContextualActions else {
+            return
+        }
+        
+        for actionData in contextualActionData {
+            if currentSeconds >= actionData.startAt,
+               let endAt = actionData.endAt, currentSeconds < endAt {
+                handleAction(actionData, playerViewController: playerViewController)
+                return
+            } else if currentSeconds >= actionData.startAt, actionData.endAt == nil {
+                handleAction(actionData, playerViewController: playerViewController)
+                return
+            }
+        }
+
+        if currentContextualState != .none {
+            playerViewController.contextualActions = []
+            currentContextualState = .none
+        }
+    }
+
+    func handleAction(_ actionData: ContextualActionData, playerViewController: AVPlayerViewController) {
+        switch actionData.action {
+        case "SkipIntro":
+            if currentContextualState != .skipIntro {
+                let skipIntroAction = UIAction(title: "Skip Intro") { [weak self] _ in
+                    self?.handleSkipIntro()
+                }
+                playerViewController.contextualActions = [skipIntroAction]
+                currentContextualState = .skipIntro
+            }
+        case "NextEpisode":
+            if currentContextualState != .nextEpisode {
+                let nextEpisodeAction = UIAction(title: "Next Episode") { [weak self] _ in
+                    self?.handleNextEpisode()
+                }
+                playerViewController.contextualActions = [nextEpisodeAction]
+                currentContextualState = .nextEpisode
+            }
+        default:
+            break
+        }
+    }
+    
+    func handleSkipIntro() {
+            onSkipIntro?(["message": "Skip Intro triggered"])
+            let skipTime = CMTime(seconds: 120, preferredTimescale: 1)
+            playerForContextualActions?.seek(to: skipTime, toleranceBefore: .zero, toleranceAfter: .zero)
+        }
+
+    func handleNextEpisode() {
+        onNextEpisode?(["message": "Next Episode triggered"])
+        print("Next episode triggered")
+    }
+}

--- a/ios/Video/RCTVideo-Bridging-Header.h
+++ b/ios/Video/RCTVideo-Bridging-Header.h
@@ -1,6 +1,6 @@
 #import "RCTVideoSwiftLog.h"
 #import <React/RCTViewManager.h>
-
+#import <React/RCTEventDispatcher.h>
 #if __has_include(<react-native-video/RCTVideoCache.h>)
 #import "RCTVideoCache.h"
 #endif

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -87,4 +87,8 @@ RCT_EXTERN_METHOD(getCurrentPosition
                   : (RCTPromiseResolveBlock)resolve reject
                   : (RCTPromiseRejectBlock)reject)
 
+// Should support contextual actions
+RCT_EXPORT_VIEW_PROPERTY(contextualActions, NSArray);
+RCT_EXPORT_VIEW_PROPERTY(onSkipIntro, RCTDirectEventBlock); 
+RCT_EXPORT_VIEW_PROPERTY(onNextEpisode, RCTDirectEventBlock);
 @end

--- a/ios/Video/RCTVideoManager.swift
+++ b/ios/Video/RCTVideoManager.swift
@@ -72,6 +72,7 @@ class RCTVideoManager: RCTViewManager {
         })
     }
 
+    @available(tvOS 14.0, *)
     @objc(enterPictureInPictureCmd:)
     func enterPictureInPictureCmd(_ reactTag: NSNumber) {
         performOnVideoView(withReactTag: reactTag, callback: { videoView in

--- a/ios/Video/ReactNativeVideoManager.swift
+++ b/ios/Video/ReactNativeVideoManager.swift
@@ -6,31 +6,33 @@
 import Foundation
 
 public class ReactNativeVideoManager: RNVPlugin {
-    private let expectedMaxVideoCount = 2
+    private let expectedMaxVideoCount = 10
 
     // create a private initializer
     private init() {}
 
     public static let shared: ReactNativeVideoManager = .init()
 
-    private var instanceCount = 0
-    private var pluginList: [RNVPlugin] = Array()
+    var instanceList: [RCTVideo] = Array()
+    var pluginList: [RNVPlugin] = Array()
 
     /**
-     * register a new view
+      * register a new ReactExoplayerViewManager in the managed list
      */
-    func registerView(newInstance _: RCTVideo) {
-        if instanceCount > expectedMaxVideoCount {
+    func registerView(newInstance: RCTVideo) {
+        if instanceList.count > expectedMaxVideoCount {
             DebugLog("multiple Video displayed ?")
         }
-        instanceCount += 1
+        instanceList.append(newInstance)
     }
 
     /**
-     * unregister existing view
+     * unregister existing ReactExoplayerViewManager in the managed list
      */
-    func unregisterView(newInstance _: RCTVideo) {
-        instanceCount -= 1
+    func unregisterView(newInstance: RCTVideo) {
+        if let i = instanceList.firstIndex(of: newInstance) {
+            instanceList.remove(at: i)
+        }
     }
 
     /**

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -267,4 +267,6 @@ export interface ReactVideoEvents {
   onTextTrackDataChanged?: (e: OnTextTrackDataChangedData) => void; // iOS
   onVideoTracks?: (e: OnVideoTracksData) => void; //Android
   onAspectRatio?: (e: OnVideoAspectRatioData) => void;
+  onSkipIntro?: () => void; // The logic for skipping the intro is in the Swift file no need to pass seek or onSeek
+  onNextEpisode?: () => void;
 }

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -274,6 +274,16 @@ export type ControlsStyles = {
   liveLabel?: string;
 };
 
+export declare enum ContextualAction {
+  SKIP_INTRO = 'SkipIntro',
+  NEXT_EPISODE = 'NextEpisode',
+}
+export type ContextualActions = {
+  action: ContextualAction;
+  startAt?: number;
+  endAt?: number;
+}
+
 export interface ReactVideoRenderLoaderProps {
   source?: ReactVideoSource;
   style?: StyleProp<ImageStyle>;
@@ -349,4 +359,5 @@ export interface ReactVideoProps extends ReactVideoEvents, ViewProps {
   debug?: DebugConfig;
   allowsExternalPlayback?: boolean; // iOS
   controlsStyles?: ControlsStyles; // Android
+  contextualActions?: ContextualActions[];
 }


### PR DESCRIPTION
![Screenshot 2025-01-14 at 02 48 38](https://github.com/user-attachments/assets/7f734700-5414-484a-aa20-c09f7512a0aa)

I added functionality for apple tv player, where contextual actions are used to add control buttons, 2 new buttons were added skip intro and next episode

If you need any additional information, let me know, there was no time to prepare everything.

Example use:

 <VideoPlayer
        ref={playerRef}
        style={StyleSheet.absoluteFillObject}
        source={{
          ...videoConfig.source,
          startPosition: Platform.OS === 'android' ? startPosition * 1000 : undefined,
        }}
        controls={true}
        contextualActions={contextualActions}
        onSkipIntro={() => console.log('Skip Intro triggered')}
        onNextEpisode={onNextEpisode}
/>