### PR TITLE
fix: iOS constraints when controls are enabled and video is inside a ScrollView

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -311,7 +311,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     @objc
     func handleRotation() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.setNeedsLayout()
             self.layoutIfNeeded()

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1158,6 +1158,21 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             if _controls {
                 self.removePlayerLayer()
                 self.usePlayerViewController()
+
+                // Safely unwrap _playerViewController before applying constraints
+                if let playerViewController = _playerViewController, let playerView = playerViewController.view {
+                    playerView.translatesAutoresizingMaskIntoConstraints = false
+                    self.addSubview(playerView) // Ensure it's added to the hierarchy
+
+                    NSLayoutConstraint.activate([
+                        playerView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+                        playerView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+                        playerView.topAnchor.constraint(equalTo: self.topAnchor),
+                        playerView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+                    ])
+                } else {
+                    print("Error: _playerViewController or its view is nil")
+                }
             } else {
                 _playerViewController?.view.removeFromSuperview()
                 _playerViewController?.removeFromParent()

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1103,6 +1103,13 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             let viewController: UIViewController! = self.reactViewController()
             viewController?.addChild(_playerViewController)
             self.addSubview(_playerViewController.view)
+
+            NSLayoutConstraint.activate([
+                _playerViewController.view.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+                _playerViewController.view.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+                _playerViewController.view.topAnchor.constraint(equalTo: self.topAnchor),
+                _playerViewController.view.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+           ])
         }
 
         _playerObserver.playerViewController = _playerViewController
@@ -1158,21 +1165,6 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             if _controls {
                 self.removePlayerLayer()
                 self.usePlayerViewController()
-
-                // Safely unwrap _playerViewController before applying constraints
-                if let playerViewController = _playerViewController, let playerView = playerViewController.view {
-                    playerView.translatesAutoresizingMaskIntoConstraints = false
-                    self.addSubview(playerView) // Ensure it's added to the hierarchy
-
-                    NSLayoutConstraint.activate([
-                        playerView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-                        playerView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-                        playerView.topAnchor.constraint(equalTo: self.topAnchor),
-                        playerView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-                    ])
-                } else {
-                    print("Error: _playerViewController or its view is nil")
-                }
             } else {
                 _playerViewController?.view.removeFromSuperview()
                 _playerViewController?.removeFromParent()

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1168,7 +1168,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                         playerView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
                         playerView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
                         playerView.topAnchor.constraint(equalTo: self.topAnchor),
-                        playerView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+                        playerView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
                     ])
                 } else {
                     print("Error: _playerViewController or its view is nil")

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1165,6 +1165,21 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             if _controls {
                 self.removePlayerLayer()
                 self.usePlayerViewController()
+
+                // Safely unwrap _playerViewController before applying constraints
+                if let playerViewController = _playerViewController, let playerView = playerViewController.view {
+                    playerView.translatesAutoresizingMaskIntoConstraints = false
+                    self.addSubview(playerView) // Ensure it's added to the hierarchy
+
+                    NSLayoutConstraint.activate([
+                        playerView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+                        playerView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+                        playerView.topAnchor.constraint(equalTo: self.topAnchor),
+                        playerView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+                    ])
+                } else {
+                    print("Error: _playerViewController or its view is nil")
+                }
             } else {
                 _playerViewController?.view.removeFromSuperview()
                 _playerViewController?.removeFromParent()

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1109,7 +1109,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                 _playerViewController.view.trailingAnchor.constraint(equalTo: self.trailingAnchor),
                 _playerViewController.view.topAnchor.constraint(equalTo: self.topAnchor),
                 _playerViewController.view.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-           ])
+            ])
         }
 
         _playerObserver.playerViewController = _playerViewController

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1175,7 +1175,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                         playerView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
                         playerView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
                         playerView.topAnchor.constraint(equalTo: self.topAnchor),
-                        playerView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+                        playerView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
                     ])
                 } else {
                     print("Error: _playerViewController or its view is nil")


### PR DESCRIPTION
Fixes:

* https://github.com/TheWidlarzGroup/react-native-video/issues/4091

## Summary
It seems that going from AVPlayerLayer to AVPlayerViewController when controls are enabled breaks the layout. By manually setting the constraints it keeps the size/position intact.
