### PR TITLE
fix(android): remove transparent black overlay on android default controls

### DIFF
--- a/android/src/main/res/layout/exo_legacy_player_control_view.xml
+++ b/android/src/main/res/layout/exo_legacy_player_control_view.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layoutDirection="ltr"
-    android:background="@color/midnight_black"
+    android:background="@color/player_overlay_color"
     android:orientation="vertical">
 
     <LinearLayout

--- a/android/src/main/res/values/colors.xml
+++ b/android/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="silver_gray">#FFBEBEBE</color>
-    <color name="midnight_black">#CC000000</color>
+    <color name="player_overlay_color">#00000000</color>
     <color name="white">#FFFFFF</color>
     <color name="red">#FF0000</color>
 </resources>


### PR DESCRIPTION
## Summary
Remove black overlay with controls on android

### Motivation
Keep android and ios behavior coherent

The color can be restored if need by overriding `<color name="player_overlay_color">#00000000</color>` to `<color name="player_overlay_color">#CC000000</color>` in application resources.

fix: https://github.com/TheWidlarzGroup/react-native-video/issues/4384

### Changes
rename color in android resources 
