### PR TITLE
fix(android): check for valid width and height on video format data

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.kt
@@ -288,7 +288,9 @@ class ExoPlayerView(private val context: Context) :
             if (group.type == C.TRACK_TYPE_VIDEO && group.length > 0) {
                 // get the first track of the group to identify aspect ratio
                 val format = group.getTrackFormat(0)
-                layout.updateAspectRatio(format)
+                if (format.width > 0 || format.height > 0) {
+                    layout.updateAspectRatio(format)
+                }
                 return
             }
         }


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->

## Summary
Check for a valid width or height on video format's track data

### Motivation
Fix unwanted behavior for video urls with no valid width and height (width=-1 or height=-1).

fix : [#4282](https://github.com/TheWidlarzGroup/react-native-video/issues/4282#issue-2646420204)

Check this if needed: [related comment](https://github.com/TheWidlarzGroup/react-native-video/issues/4282#issuecomment-2602164317)

### Changes
`ExoPlayerView.kt` file:
Add an `if` to check the `width` and `height` of the format data

```kotlin
      if (format.width > 0 || format.height > 0) { 
              layout.updateAspectRatio(format)  // Proceed only if width/height are valid
      }
```