### PR TITLE
fix(infra): kotlin linter github action

### DIFF
--- a/.github/workflows/check-android.yml
+++ b/.github/workflows/check-android.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           report-path: ./android/build/*.xml
         continue-on-error: false
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ktlint-report
           path: ./android/build/*.xml


### PR DESCRIPTION
## Summary
Fix `check-android` action by bumping `actions/upload-artifact` to `v4`