### PR TITLE
fix(ios): the video has no audio by default

### DIFF
--- a/ios/Video/Features/RCTPlayerOperations.swift
+++ b/ios/Video/Features/RCTPlayerOperations.swift
@@ -27,7 +27,7 @@ enum RCTPlayerOperations {
 
         var selectedTrackIndex: Int = RCTVideoUnset
 
-        if (type == "disabled") || (type == "none") || (type == "") {
+        if type == "disabled" {
             // Select the last text index which is the disabled text track
             selectedTrackIndex = trackCount - firstTextIndex
         } else if type == "language" {
@@ -92,7 +92,7 @@ enum RCTPlayerOperations {
             return
         }
 
-        if (type == "disabled") || (type == "none") || (type == "") {
+        if type == "disabled" {
             // Do nothing. We want to ensure option is nil
         } else if (type == "language") || (type == "title") {
             let value = criteria?.value as? String


### PR DESCRIPTION
This reverts the change in https://github.com/TheWidlarzGroup/react-native-video/pull/4319, I don't think that change is correct.

According to [docs](https://docs.thewidlarzgroup.com/react-native-video/component/props#selectedtexttrack) the default value for `selectedTextTrack.type` is "system" which means the video should respect user's preference in Settings > Accesibility > Subtitles & Captioning > Closed Captions + SDH. And this is exactly what happens by default without the changes in that PR. I think the author of that PR had this setting on, that's why it was showing the subtitles without setting something for `selectedTextTrack`, which IMO is the expected result. In order to explicitly turn off subtitles you have to set `selectedTextTrack={{ type: 'disabled' }}`. I tested it with this video and the settings option on and it works (disables the subtitles) -> https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8

![IMG_0443](https://github.com/user-attachments/assets/f14a14e0-6d82-432a-8f6c-28d4934a2d26)

Another reason why I think it should be reverted is because it also affects `selectedAudioTrack`. By default it should also have 'system' type according to [docs](https://docs.thewidlarzgroup.com/react-native-video/component/props#selectedaudiotrack), which means "Play the audio track that matches the system language. If none match, play the first track.", but the change in that PR turns the audio off by default unless you explicitly turn it on with `selectedAudioTrack={{ type: 'system' }}`.

Fixes #4400