### PR TITLE
fix(android): crash in pip with old android version

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/PictureInPictureUtil.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/PictureInPictureUtil.kt
@@ -153,6 +153,10 @@ object PictureInPictureUtil {
     @JvmStatic
     @RequiresApi(Build.VERSION_CODES.O)
     fun calcPictureInPictureAspectRatio(player: ExoPlayer): Rational {
+        if (player.videoSize.width == 0 || player.videoSize.height == 0) {
+            return Rational(16, 9)
+        }
+
         var aspectRatio = Rational(player.videoSize.width, player.videoSize.height)
         // AspectRatio for the activity in picture-in-picture, must be between 2.39:1 and 1:2.39 (inclusive).
         // https://developer.android.com/reference/android/app/PictureInPictureParams.Builder#setAspectRatio(android.util.Rational)

--- a/android/src/main/java/com/brentvatne/exoplayer/PictureInPictureUtil.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/PictureInPictureUtil.kt
@@ -74,6 +74,15 @@ object PictureInPictureUtil {
         if (!isSupportPictureInPicture(context)) return
         if (isSupportPictureInPictureAction() && pictureInPictureParams != null) {
             try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    pictureInPictureParams.aspectRatio?.let {
+                        val ratio = it.toFloat()
+                        if (ratio < 0.418410 || ratio > 2.39) {
+                            DebugLog.e(TAG, "Aspect ratio out of range: $ratio. Skipping PiP mode.")
+                            return
+                        }
+                    }
+                }
                 context.findActivity().enterPictureInPictureMode(pictureInPictureParams)
             } catch (e: IllegalStateException) {
                 DebugLog.e(TAG, e.toString())

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -2290,15 +2290,30 @@ public class ReactExoplayerView extends FrameLayout implements
     }
 
     public void enterPictureInPictureMode() {
-        PictureInPictureParams _pipParams = null;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            ArrayList<RemoteAction> actions = PictureInPictureUtil.getPictureInPictureActions(themedReactContext, isPaused, pictureInPictureReceiver);
-            pictureInPictureParamsBuilder.setActions(actions);
-            _pipParams = pictureInPictureParamsBuilder
-                    .setAspectRatio(PictureInPictureUtil.calcPictureInPictureAspectRatio(player))
-                    .build();
+        if (!isSupportPictureInPicture(context)) return
+        if (isSupportPictureInPictureAction() && pictureInPictureParams != null) {
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    pictureInPictureParams.aspectRatio?.let {
+                        val ratio = it.toFloat()
+                        if (ratio < 0.418410 || ratio > 2.39) {
+                            DebugLog.e(TAG, "Aspect ratio out of range: $ratio. Skipping PiP mode.")
+                            return
+                        }
+                    }
+                }
+                context.findActivity().enterPictureInPictureMode(pictureInPictureParams)
+            } catch (e: IllegalStateException) {
+                DebugLog.e(TAG, e.toString())
+            }
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            try {
+                @Suppress("DEPRECATION")
+                context.findActivity().enterPictureInPictureMode()
+            } catch (e: IllegalStateException) {
+                DebugLog.e(TAG, e.toString())
+            }
         }
-        PictureInPictureUtil.enterPictureInPictureMode(themedReactContext, _pipParams);
     }
 
     public void exitPictureInPictureMode() {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -2290,30 +2290,15 @@ public class ReactExoplayerView extends FrameLayout implements
     }
 
     public void enterPictureInPictureMode() {
-        if (!isSupportPictureInPicture(context)) return
-        if (isSupportPictureInPictureAction() && pictureInPictureParams != null) {
-            try {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    pictureInPictureParams.aspectRatio?.let {
-                        val ratio = it.toFloat()
-                        if (ratio < 0.418410 || ratio > 2.39) {
-                            DebugLog.e(TAG, "Aspect ratio out of range: $ratio. Skipping PiP mode.")
-                            return
-                        }
-                    }
-                }
-                context.findActivity().enterPictureInPictureMode(pictureInPictureParams)
-            } catch (e: IllegalStateException) {
-                DebugLog.e(TAG, e.toString())
-            }
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            try {
-                @Suppress("DEPRECATION")
-                context.findActivity().enterPictureInPictureMode()
-            } catch (e: IllegalStateException) {
-                DebugLog.e(TAG, e.toString())
-            }
+        PictureInPictureParams _pipParams = null;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            ArrayList<RemoteAction> actions = PictureInPictureUtil.getPictureInPictureActions(themedReactContext, isPaused, pictureInPictureReceiver);
+            pictureInPictureParamsBuilder.setActions(actions);
+            _pipParams = pictureInPictureParamsBuilder
+                    .setAspectRatio(PictureInPictureUtil.calcPictureInPictureAspectRatio(player))
+                    .build();
         }
+        PictureInPictureUtil.enterPictureInPictureMode(themedReactContext, _pipParams);
     }
 
     public void exitPictureInPictureMode() {


### PR DESCRIPTION
## Summary
Ensure correct that pip is supported on old android version

### Motivation
fix: https://github.com/TheWidlarzGroup/react-native-video/issues/4436

### Changes
Safety check on behavior and ensure video size is correct before enabling pip 
