### PR TITLE
fix(android): prevent ratio calculations before loading video

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -2294,9 +2294,10 @@ public class ReactExoplayerView extends FrameLayout implements
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             ArrayList<RemoteAction> actions = PictureInPictureUtil.getPictureInPictureActions(themedReactContext, isPaused, pictureInPictureReceiver);
             pictureInPictureParamsBuilder.setActions(actions);
-            _pipParams = pictureInPictureParamsBuilder
-                    .setAspectRatio(PictureInPictureUtil.calcPictureInPictureAspectRatio(player))
-                    .build();
+            if (player.getPlaybackState() == Player.STATE_READY) {
+                pictureInPictureParamsBuilder.setAspectRatio(PictureInPictureUtil.calcPictureInPictureAspectRatio(player));
+            }
+            _pipParams = pictureInPictureParamsBuilder.build();
         }
         PictureInPictureUtil.enterPictureInPictureMode(themedReactContext, _pipParams);
     }


### PR DESCRIPTION
## Summary
fix(android): prevent ratio calculations before loading video

### Motivation
User can enter PIP with only player before video loads.
However, in this case, width and height are treated as 0, and `Rational(0,0).toFloat()` has a NaN value.
This causes following error
```
Fatal Exception: java.lang.IllegalArgumentException
enterPictureInPictureMode: Aspect ratio is too extreme (must be between 0.418410 and 2.390000).
```

### Changes
Modify to only calculate video ratio if source is loaded before entering the PIP.

## Test plan
Mount `<Video/>` component that plays streaming resources on offline.
And verify PIP correctly work.