### PR TITLE
fix(iOS): handle allowsPictureInPicturePlayback for tvOS

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -65,16 +65,18 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     private var _lastBitrate = -2.0
     private var _enterPictureInPictureOnLeave = false {
         didSet {
-            #if os(iOS)
-                if isPictureInPictureActive() { return }
-                if _enterPictureInPictureOnLeave {
-                    initPictureinPicture()
+            if isPictureInPictureActive() { return }
+            if _enterPictureInPictureOnLeave {
+                initPictureinPicture()
+                if #available(iOS 9.0, tvOS 14.0, *) {
                     _playerViewController?.allowsPictureInPicturePlayback = true
-                } else {
-                    _pip?.deinitPipController()
+                }
+            } else {
+                _pip?.deinitPipController()
+                if #available(iOS 9.0, tvOS 14.0, *) {
                     _playerViewController?.allowsPictureInPicturePlayback = false
                 }
-            #endif
+            }
         }
     }
 
@@ -1177,12 +1179,9 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
         viewController.view.frame = self.bounds
         viewController.player = player
-        if #available(tvOS 14.0, *) {
+        if #available(iOS 9.0, tvOS 14.0, *) {
             viewController.allowsPictureInPicturePlayback = _enterPictureInPictureOnLeave
         }
-        #if os(iOS)
-            viewController.allowsPictureInPicturePlayback = _enterPictureInPictureOnLeave
-        #endif
         return viewController
     }
 
@@ -1789,7 +1788,9 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     func enterPictureInPicture() {
         if _pip?._pipController == nil {
             initPictureinPicture()
-            _playerViewController?.allowsPictureInPicturePlayback = true
+            if #available(iOS 9.0, tvOS 14.0, *) {
+                _playerViewController?.allowsPictureInPicturePlayback = true
+            }
         }
         _pip?.enterPictureInPicture()
     }
@@ -1799,15 +1800,17 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         guard isPictureInPictureActive() else { return }
 
         _pip?.exitPictureInPicture()
-        #if os(iOS)
-            if _enterPictureInPictureOnLeave {
-                initPictureinPicture()
+        if _enterPictureInPictureOnLeave {
+            initPictureinPicture()
+            if #available(iOS 9.0, tvOS 14.0, *) {
                 _playerViewController?.allowsPictureInPicturePlayback = true
-            } else {
-                _pip?.deinitPipController()
+            }
+        } else {
+            _pip?.deinitPipController()
+            if #available(iOS 9.0, tvOS 14.0, *) {
                 _playerViewController?.allowsPictureInPicturePlayback = false
             }
-        #endif
+        }
     }
 
     // Workaround for #3418 - https://github.com/TheWidlarzGroup/react-native-video/issues/3418#issuecomment-2043508862


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
handle allowsPictureInPicturePlayback for tvOS

### Motivation
the tvOS builds are failing on versions below 14.0

### Changes
surround allowsPictureInPicturePlayback with `#available` with the corresponding iOS tvOS versions

## Test plan
1. build the test app on tvOS
2. Expected: it should build the app w/o errors