### PR TITLE
Fix: call startForeground() immediately to prevent ForegroundServiceDidNotStartInTimeException

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/VideoPlaybackService.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/VideoPlaybackService.kt
@@ -241,8 +241,8 @@ class VideoPlaybackService : MediaSessionService() {
 
         return NotificationCompat.Builder(this, NOTIFICATION_CHANEL_ID)
             .setSmallIcon(androidx.media3.session.R.drawable.media3_icon_circular_play)
-            .setContentTitle(R.string.media_playback_notification_title)
-            .setContentText(R.string.media_playback_notification_text)
+            .setContentTitle(getString(R.string.media_playback_notification_title))
+            .setContentText(getString(R.string.media_playback_notification_text))
             .build()
     }
 

--- a/android/src/main/java/com/brentvatne/exoplayer/VideoPlaybackService.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/VideoPlaybackService.kt
@@ -20,7 +20,7 @@ import androidx.media3.session.MediaSessionService
 import androidx.media3.session.MediaStyleNotificationHelper
 import androidx.media3.session.SessionCommand
 import com.brentvatne.common.toolbox.DebugLog
-import com.brentvatne.react.R;
+import com.brentvatne.react.R
 import okhttp3.internal.immutableListOf
 
 class PlaybackServiceBinder(val service: VideoPlaybackService) : Binder()

--- a/android/src/main/java/com/brentvatne/exoplayer/VideoPlaybackService.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/VideoPlaybackService.kt
@@ -20,6 +20,7 @@ import androidx.media3.session.MediaSessionService
 import androidx.media3.session.MediaStyleNotificationHelper
 import androidx.media3.session.SessionCommand
 import com.brentvatne.common.toolbox.DebugLog
+import com.brentvatne.react.R;
 import okhttp3.internal.immutableListOf
 
 class PlaybackServiceBinder(val service: VideoPlaybackService) : Binder()

--- a/android/src/main/java/com/brentvatne/exoplayer/VideoPlaybackService.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/VideoPlaybackService.kt
@@ -227,7 +227,6 @@ class VideoPlaybackService : MediaSessionService() {
     }
 
     private fun createPlaceholderNotification(): Notification {
-        // Create a notification channel if needed
         val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             notificationManager.createNotificationChannel(
@@ -239,11 +238,10 @@ class VideoPlaybackService : MediaSessionService() {
             )
         }
 
-        // Return a minimal notification
         return NotificationCompat.Builder(this, NOTIFICATION_CHANEL_ID)
             .setSmallIcon(androidx.media3.session.R.drawable.media3_icon_circular_play)
-            .setContentTitle("Media playback")
-            .setContentText("Preparing playback...")
+            .setContentTitle(R.string.media_playback_notification_title)
+            .setContentText(R.string.media_playback_notification_text)
             .build()
     }
 

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -22,4 +22,8 @@
   <string name="playback_speed">Playback Speed</string>
 
   <string name="select_playback_speed">Select Playback Speed</string>
+
+  <string name="media_playback_notification_title">Media playback</string>
+
+  <string name="media_playback_notification_text">Preparing playback</string>
 </resources>


### PR DESCRIPTION
## Summary

This PR addresses a crash happening in the `VideoPlaybackService` when the app is offline and you switch between screens, resulting in the `ForegroundServiceDidNotStartInTimeException` error.

ADB logs:

```
02-25 14:52:37.242 31539 31539 E AndroidRuntime: FATAL EXCEPTION: main
02-25 14:52:37.242 31539 31539 E AndroidRuntime: Process: com.app.xyz, PID: 31539
02-25 14:52:37.242 31539 31539 E AndroidRuntime: android.app.ForegroundServiceDidNotStartInTimeException: Context.startForegroundService() did not then call Service.startForeground(): ServiceRecord{35eeb1f u0 com.app.xyz/com.brentvatne.exoplayer.VideoPlaybackService}
```

### Motivation

Android requires that any service started with `startForegroundService()` must call `startForeground()` within a limited short time frame. Previously, the implementation only called `startForeground()` when a player was successfully registered, which could be delayed or fail when the device was offline.

### Changes

- added an immediate call to `startForeground()` right in the `onStartCommand()` method using a placeholder notification
- created a placeholder notification for when the service starts up
- added a constant for the placeholder notification ID
- the original notification for the player still updates when a player registers

## Test Plan

1. Put the device in airplane mode (or turn off WiFi and mobile data).
2. Open the app and go to a screen with the video player.
3. Go back.
4. Check that the app doesn't crash with `ForegroundServiceDidNotStartInTimeException`.

Before this fix, the crash would happen every time the device was offline.