### PR TITLE
fix(windows): event name not matches with SPEC

### DIFF
--- a/windows/ReactNativeVideoCPP/ReactVideoView.cpp
+++ b/windows/ReactNativeVideoCPP/ReactVideoView.cpp
@@ -75,7 +75,7 @@ ReactVideoView::ReactVideoView(winrt::Microsoft::ReactNative::IReactContext cons
           auto currentTimeInSeconds = mediaPlayer.PlaybackSession().Position().count() / 10000000;
           self->m_reactContext.DispatchEvent(
               *self,
-              L"topProgress",
+              L"topVideoProgress",
               [&](winrt::Microsoft::ReactNative::IJSValueWriter const &eventDataWriter) noexcept {
                 eventDataWriter.WriteObjectBegin();
                 {
@@ -102,7 +102,7 @@ void ReactVideoView::OnMediaOpened(IInspectable const &, IInspectable const &) {
 
         strong_this->m_reactContext.DispatchEvent(
             *strong_this,
-            L"topLoad",
+            L"topVideoLoad",
             [&](winrt::Microsoft::ReactNative::IJSValueWriter const &eventDataWriter) noexcept {
               eventDataWriter.WriteObjectBegin();
               {
@@ -135,7 +135,7 @@ void ReactVideoView::OnMediaOpened(IInspectable const &, IInspectable const &) {
 void ReactVideoView::OnMediaFailed(IInspectable const &, IInspectable const &) {
   runOnQueue([weak_this{get_weak()}]() {
     if (auto strong_this{weak_this.get()}) {
-      strong_this->m_reactContext.DispatchEvent(*strong_this, L"topError", nullptr);
+      strong_this->m_reactContext.DispatchEvent(*strong_this, L"topVideoError", nullptr);
     }
   });
 }
@@ -143,7 +143,7 @@ void ReactVideoView::OnMediaFailed(IInspectable const &, IInspectable const &) {
 void ReactVideoView::OnMediaEnded(IInspectable const &, IInspectable const &) {
   runOnQueue([weak_this{get_weak()}]() {
     if (auto strong_this{weak_this.get()}) {
-      strong_this->m_reactContext.DispatchEvent(*strong_this, L"topEnd", nullptr);
+      strong_this->m_reactContext.DispatchEvent(*strong_this, L"topVideoEnd", nullptr);
     }
   });
 }
@@ -155,7 +155,7 @@ void ReactVideoView::OnBufferingEnded(IInspectable const &, IInspectable const &
 void ReactVideoView::OnSeekCompleted(IInspectable const &, IInspectable const &) {
   runOnQueue([weak_this{get_weak()}]() {
     if (auto strong_this{weak_this.get()}) {
-      strong_this->m_reactContext.DispatchEvent(*strong_this, L"topSeek", nullptr);
+      strong_this->m_reactContext.DispatchEvent(*strong_this, L"topVideoSeek", nullptr);
     }
   });
 }

--- a/windows/ReactNativeVideoCPP/ReactVideoViewManager.cpp
+++ b/windows/ReactNativeVideoCPP/ReactVideoViewManager.cpp
@@ -112,10 +112,11 @@ ConstantProviderDelegate ReactVideoViewManager::ExportedCustomBubblingEventTypeC
 
 ConstantProviderDelegate ReactVideoViewManager::ExportedCustomDirectEventTypeConstants() noexcept {
   return [](winrt::Microsoft::ReactNative::IJSValueWriter const &constantWriter) {
-    WriteCustomDirectEventTypeConstant(constantWriter, "Load");
-    WriteCustomDirectEventTypeConstant(constantWriter, "End");
-    WriteCustomDirectEventTypeConstant(constantWriter, "Seek");
-    WriteCustomDirectEventTypeConstant(constantWriter, "Progress");
+    WriteCustomDirectEventTypeConstant(constantWriter, "VideoLoad");
+    WriteCustomDirectEventTypeConstant(constantWriter, "VideoEnd");
+    WriteCustomDirectEventTypeConstant(constantWriter, "VideoSeek");
+    WriteCustomDirectEventTypeConstant(constantWriter, "VideoProgress");
+    WriteCustomDirectEventTypeConstant(constantWriter, "VideoError");
   };
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary

Event name in native module (topLoad, etc.) is not matches with src\specs\VideoNativeComponent.ts (onVideoLoad, etc.) and need to update.

### Motivation

The Windows platform code lacks maintenance. This pull request ensures that the onXXX event functions correctly on the Windows platform.

### Changes

Only rename "topXX" to "topVideoXX" and add missing "VideoError" DirectEvent.

## Test plan

Test whether the event was successfully delivered.

```tsx
<Video
  onLoad={() => console.log('onLoad')}
  onEnd={() => console.log('onEnd')}
  onSeek={() => console.log('onSeek')}
  onProgress={() => console.log('onProgress')}
  onError={() => console.log('onError')}
/>
```