### PR TITLE
feat(windows): add topSeek event params as mentioned in docs

### DIFF
--- a/windows/ReactNativeVideoCPP/ReactVideoView.cpp
+++ b/windows/ReactNativeVideoCPP/ReactVideoView.cpp
@@ -88,6 +88,14 @@ ReactVideoView::ReactVideoView(winrt::Microsoft::ReactNative::IReactContext cons
       }
     }
   });
+
+  m_positionChangedToken = m_player.PlaybackSession().PositionChanged(
+      winrt::auto_revoke, [ref = get_weak()](auto const& sender, auto const& args) {
+        if (auto self = ref.get()) {
+          auto newPosition = sender.Position().count();
+          self->m_mediaPlayerPosition = newPosition;
+        }
+      });
 }
 
 void ReactVideoView::OnMediaOpened(IInspectable const &, IInspectable const &) {
@@ -155,7 +163,22 @@ void ReactVideoView::OnBufferingEnded(IInspectable const &, IInspectable const &
 void ReactVideoView::OnSeekCompleted(IInspectable const &, IInspectable const &) {
   runOnQueue([weak_this{get_weak()}]() {
     if (auto strong_this{weak_this.get()}) {
-      strong_this->m_reactContext.DispatchEvent(*strong_this, L"topSeek", nullptr);
+      if (auto mediaPlayer = strong_this->m_player) {
+        auto currentTimeInSeconds = mediaPlayer.PlaybackSession().Position().count() / 10000000;
+        auto seekTimeInSeconds = strong_this->m_mediaPlayerPosition / 10000000;
+
+        strong_this->m_reactContext.DispatchEvent(
+          *strong_this,
+          L"topSeek",
+          [&](winrt::Microsoft::ReactNative::IJSValueWriter const &eventDataWriter) noexcept {
+            eventDataWriter.WriteObjectBegin();
+            {
+              WriteProperty(eventDataWriter, L"currentTime", currentTimeInSeconds);
+              WriteProperty(eventDataWriter, L"seekTime", seekTimeInSeconds);
+            }
+            eventDataWriter.WriteObjectEnd();
+          });
+      }
     }
   });
 }

--- a/windows/ReactNativeVideoCPP/ReactVideoView.h
+++ b/windows/ReactNativeVideoCPP/ReactVideoView.h
@@ -29,6 +29,7 @@ struct ReactVideoView : ReactVideoViewT<ReactVideoView> {
   bool m_fullScreen = false;
   double m_volume = 0;
   double m_position = 0;
+  double m_mediaPlayerPosition = 0;
   Windows::UI::Xaml::DispatcherTimer m_timer;
   Windows::Media::Playback::MediaPlayer m_player = nullptr;
   Windows::UI::Core::CoreDispatcher m_uiDispatcher = nullptr;
@@ -40,6 +41,7 @@ struct ReactVideoView : ReactVideoViewT<ReactVideoView> {
   Windows::Media::Playback::MediaPlaybackSession::BufferingStarted_revoker m_bufferingStartedToken{};
   Windows::Media::Playback::MediaPlaybackSession::BufferingEnded_revoker m_bufferingEndedToken{};
   Windows::Media::Playback::MediaPlaybackSession::SeekCompleted_revoker m_seekCompletedToken{};
+  Windows::Media::Playback::MediaPlaybackSession::PositionChanged_revoker m_positionChangedToken{};
 
   bool IsPlaying(Windows::Media::Playback::MediaPlaybackState currentState);
   void OnMediaOpened(IInspectable const &sender, IInspectable const &args);


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary

The seek event on the Windows platform does not include the parameters mentioned in the doc when dispatched; these need to be added.

[Doc:onSeek](https://docs.thewidlarzgroup.com/react-native-video/component/events#onseek)

### Motivation

Improve the platform code.

### Changes

When dispatching the topSeek event, write the params currentTime and seekTime.

CurrentTime is current playback progress of the media.

SeekTime indicates the progress of the media when the seek event is triggered, and its value is derived from the progress of PositionChanged.

## Test plan

1. Case 1. Using the ```videoRef.current.seek(seconds);``` function.
2. Case 2. Dragging the native Windows control component.

**Expect**: onSeek work fine.

```tsx
<Video
  ref={videoRef}
  controls={true}
  onSeek={(e: onSeekData) => console.log(`currentTime=${e.currentTime} and seekTime=${seekTime}`)}
/>
```