### PR TITLE
Don't try to modify React view after unmount

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1679,8 +1679,10 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                 }
             }
 
-            self.reactViewController().view.frame = bounds
-            self.reactViewController().view.setNeedsLayout()
+            if let reactVC = self.reactViewController() {
+                reactVC.view.frame = bounds
+                reactVC.view.setNeedsLayout()
+            }
         }
     }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->

## Summary
Simple check that prevents trying to modify a `nil` React view. It seems that the handler might be called when the view is already gone.

### Motivation
We've experienced crashes in the iOS app crashed when leaving a screen where the player is mounted.

### Changes
- Simple check that prevents trying to modify a `nil` React view.

## Test plan
Reproduction steps that worked for me (both on simulator and on real device) to reproduce the issue in our app:

* Open a screen with the video player on iOS
* Switch to fullscreen
* Rotate the screen sidewise to see the video better
* Skip forward to a couple seconds away from the end
* Let the video finish playing
* Leave fullscreen
* Go back in navigation to exit the screen where the video player is mounted
* Turn the phone back to portrait
* CRASH
