### PR TITLE
feat(ios): allow to disable audio sessions management

### DIFF
--- a/docs/pages/component/props.mdx
+++ b/docs/pages/component/props.mdx
@@ -271,6 +271,20 @@ Determines if the player should throw an error when the network connection is lo
 
 ---
 
+### `disableAudioSessionManagement`
+
+<PlatformsList types={['iOS']} />
+
+Disable audio session management in library (for all views).
+
+- **true** - Disable audio session management in the library.
+- **false (default)** - Enable audio session management in the library.
+
+> ⚠️ This prop disables audio session management in the library. You only should use this prop if you are managing the audio session yourself.
+> You can encounter issues with other features, like background audio, if you don't properly manage the audio session.
+
+---
+
 ### `drm`
 
 > [!WARNING]
@@ -1180,20 +1194,6 @@ To customize the notification controls, you can use the `metadata` property in t
     </application>
 </manifest>
 ```
-
----
-
-### `disableAudioSessionManagement`
-
-<PlatformsList types={['iOS']} />
-
-Disable audio session management in library (for all views).
-
-- **true** - Disable audio session management in the library.
-- **false (default)** - Enable audio session management in the library.
-
-> ⚠️ This prop disables audio session management in the library. You only should use this prop if you are managing the audio session yourself.
-> You can encounter issues with other features, like background audio, if you don't properly manage the audio session.
 
 ---
 

--- a/docs/pages/component/props.mdx
+++ b/docs/pages/component/props.mdx
@@ -1182,6 +1182,21 @@ To customize the notification controls, you can use the `metadata` property in t
 ```
 
 ---
+
+### `disableAudioSessionManagement`
+
+<PlatformsList types={['iOS']} />
+
+Disable audio session management in library (for all views).
+
+- **true** - Disable audio session management in the library.
+- **false (default)** - Enable audio session management in the library.
+
+> ⚠️ This prop disables audio session management in the library. You only should use this prop if you are managing the audio session yourself.
+> You can encounter issues with other features, like background audio, if you don't properly manage the audio session.
+
+---
+
 ### `useSecureView`
 
 > [!WARNING]

--- a/ios/Video/AudioSessionManager.swift
+++ b/ios/Video/AudioSessionManager.swift
@@ -7,6 +7,12 @@ class AudioSessionManager {
     private var videoViews = NSHashTable<RCTVideo>.weakObjects()
     private var isAudioSessionActive = false
     private var remoteControlEventsActive = false
+    
+    private var isAudioSessionManagementDisabled: Bool {
+        return videoViews.allObjects.contains { view in
+            return view._disableAudioSessionManagement == true
+        }
+    }
 
     private init() {
         // Subscribe to audio interruption notifications
@@ -69,6 +75,11 @@ class AudioSessionManager {
 
     // Handle remote control events from NowPlayingInfoCenterManager
     func setRemoteControlEventsActive(_ active: Bool) {
+        if isAudioSessionManagementDisabled {
+            // AUDIO SESSION MANAGEMENT DISABLED BY USER
+            return
+        }
+        
         remoteControlEventsActive = active
 
         if active {
@@ -129,6 +140,11 @@ class AudioSessionManager {
         }
 
         let canAllowMixing = !anyPlayerShowNotificationControls && !anyPlayerNeedsBackgroundPlayback
+        
+        if isAudioSessionManagementDisabled {
+            // AUDIO SESSION MANAGEMENT DISABLED BY USER
+            return
+        }
 
         if canAllowMixing {
             let shouldEnableMixing = videoViews.allObjects.contains { view in

--- a/ios/Video/AudioSessionManager.swift
+++ b/ios/Video/AudioSessionManager.swift
@@ -7,7 +7,7 @@ class AudioSessionManager {
     private var videoViews = NSHashTable<RCTVideo>.weakObjects()
     private var isAudioSessionActive = false
     private var remoteControlEventsActive = false
-    
+
     private var isAudioSessionManagementDisabled: Bool {
         return videoViews.allObjects.contains { view in
             return view._disableAudioSessionManagement == true
@@ -79,7 +79,7 @@ class AudioSessionManager {
             // AUDIO SESSION MANAGEMENT DISABLED BY USER
             return
         }
-        
+
         remoteControlEventsActive = active
 
         if active {
@@ -140,7 +140,7 @@ class AudioSessionManager {
         }
 
         let canAllowMixing = !anyPlayerShowNotificationControls && !anyPlayerNeedsBackgroundPlayback
-        
+
         if isAudioSessionManagementDisabled {
             // AUDIO SESSION MANAGEMENT DISABLED BY USER
             return

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1225,7 +1225,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             NowPlayingInfoCenterManager.shared.removePlayer(player: player)
         }
     }
-    
+
     @objc
     func setDisableAudioSessionManagement(_ disableAudioSessionManagement: Bool) {
         _disableAudioSessionManagement = disableAudioSessionManagement

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -60,6 +60,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     private var _filterEnabled = false
     private var _presentingViewController: UIViewController?
     private var _startPosition: Float64 = -1
+    var _disableAudioSessionManagement: Bool = false
     var _showNotificationControls = false
     // Buffer last bitrate value received. Initialized to -2 to ensure -1 (sometimes reported by AVPlayer) is not missed
     private var _lastBitrate = -2.0
@@ -1223,6 +1224,11 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         } else {
             NowPlayingInfoCenterManager.shared.removePlayer(player: player)
         }
+    }
+    
+    @objc
+    func setDisableAudioSessionManagement(_ disableAudioSessionManagement: Bool) {
+        _disableAudioSessionManagement = disableAudioSessionManagement
     }
 
     @objc

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -37,6 +37,7 @@ RCT_EXPORT_VIEW_PROPERTY(restoreUserInterfaceForPIPStopCompletionHandler, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(localSourceEncryptionKeyScheme, NSString);
 RCT_EXPORT_VIEW_PROPERTY(subtitleStyle, NSDictionary);
 RCT_EXPORT_VIEW_PROPERTY(showNotificationControls, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(disableAudioSessionManagement, BOOL);
 /* Should support: onLoadStart, onLoad, and onError to stay consistent with Image */
 RCT_EXPORT_VIEW_PROPERTY(onVideoLoadStart, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoLoad, RCTDirectEventBlock);

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -369,6 +369,7 @@ export interface VideoNativeProps extends ViewProps {
   viewType?: Int32; // Android
   bufferingStrategy?: BufferingStrategyType; // Android
   controlsStyles?: ControlsStyles; // Android
+  disableAudioSessionManagement?: boolean; // iOS
   onControlsVisibilityChange?: DirectEventHandler<OnControlsVisibilityChange>;
   onVideoLoad?: DirectEventHandler<OnLoadData>;
   onVideoLoadStart?: DirectEventHandler<OnLoadStartData>;

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -349,4 +349,5 @@ export interface ReactVideoProps extends ReactVideoEvents, ViewProps {
   debug?: DebugConfig;
   allowsExternalPlayback?: boolean; // iOS
   controlsStyles?: ControlsStyles; // Android
+  disableAudioSessionManagement?: boolean; // iOS
 }


### PR DESCRIPTION
## Summary
Add prop `disableAudioSessionManagement` to allow to disable audio sessions management

### Motivation
resolves https://github.com/TheWidlarzGroup/react-native-video/issues/4475

### Changes
- Added new prop `disableAudioSessionManagement`
- Updated docs

## Test plan
- Run example
- Set`disableAudioSessionManagement` to `true`
- Audio session should not be updated  