### PR TITLE
Set native playback speed controls to initial playback rate on iOS

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1164,6 +1164,14 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
         viewController.view.frame = self.bounds
         viewController.player = player
+
+        // Set the initial playback speed in controls to match playback rate
+        if #available(iOS 16.0, *) {
+            if let initialSpeed = viewController.speeds.first(where: { $0.rate == _rate }) {
+                viewController.selectSpeed(initialSpeed)
+            }
+        }
+
         if #available(iOS 9.0, tvOS 14.0, *) {
             viewController.allowsPictureInPicturePlayback = _enterPictureInPictureOnLeave
         }


### PR DESCRIPTION
Otherwise, the Video can be initiated with playback rate 0.5 and play correctly (slower), but in native playback speed controls 1.0 will be marked as current playback speed.

<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary

This fixes an issue where on iOS you would initiate the player with `rate={0.5}`, but native speed controls would show `1.0`, making it hard to change (you'd need to switch to something else before being able to select 1.0).

### Changes

Set the initial speed for the viewController that matches the initial playback rate.

## Test plan

You can reproduce this issue by setting the initial playback rate to `0.5` in line 44 of `BasicExample` (`const [rate, setRate] = useState(1);`) and running the app on iOS (simulator is enough). 
Once the video is running you'll notice that it's playing correctly (slower, at rate 0.5), but the native playback speed controls show 1.0 (normal) speed.

![CleanShot 2025-03-31 at 15 43 49@2x](https://github.com/user-attachments/assets/0a3519bd-a306-49e6-ac47-e008f97c8cbd)

After this change it shows the correct initial speed.