### PR TITLE
fix: add extra checks to determine if a file is local

### DIFF
--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -154,7 +154,12 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
 
         const isLocalAssetFile =
           typeof _source === 'number' ||
-          ('uri' in _source && typeof _source.uri === 'number');
+          ('uri' in _source && typeof _source.uri === 'number') ||
+          ('uri' in _source &&
+            typeof _source.uri === 'string' &&
+            (_source.uri.startsWith('file://') ||
+              _source.uri.startsWith('content://') ||
+              _source.uri.startsWith('./')));
 
         const resolvedSource = resolveAssetSourceForVideo(_source);
         let uri = resolvedSource.uri || '';

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -159,7 +159,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
             typeof _source.uri === 'string' &&
             (_source.uri.startsWith('file://') ||
               _source.uri.startsWith('content://') ||
-              _source.uri.startsWith('./')));
+              _source.uri.startsWith('.')));
 
         const resolvedSource = resolveAssetSourceForVideo(_source);
         let uri = resolvedSource.uri || '';

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -173,7 +173,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
         const isAsset = !!(
           uri &&
           uri.match(
-            /^(assets-library|ipod-library|file|content|ms-appx|ms-appdata):/,
+            /^(assets-library|ipod-library|file|content|ms-appx|ms-appdata|asset):/,
           )
         );
 


### PR DESCRIPTION
## Summary
Add extra checks to determine if a file is local.

```js
source={{ uri: 'file:///path/to/video.mp4' }}   // File system
source={{ uri: 'content://media/video.mp4' }}   // Android content
source={{ uri: './media/video.mp4' }}           // Relative path
source={{ uri: 'asset:///sintel.mp4' }}         // Asset directory
source={require('./video.mp4')}                 // Bundled asset

```

### Motivation
https://github.com/TheWidlarzGroup/react-native-video/issues/4460

### Changes
- Added `file://`, `content://` and `./` to `isLocalAssetFile` check.
- Added `asset://` to `isAsset` check. 

## Test plan
- Load video files in various ways.
