### PR TITLE
feat(ios): forward real fullscreen events from `AVPlayer` instead of guessing

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -55,7 +55,6 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     private var _fullscreenAutorotate = true
     private var _fullscreenOrientation: String = "all"
     private var _fullscreenPlayerPresented = false
-    private var _fullscreenUncontrolPlayerPresented = false // to call events switching full screen mode from player controls
     private var _filterName: String!
     private var _filterEnabled = false
     private var _presentingViewController: UIViewController?
@@ -1682,30 +1681,27 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         guard let bounds = RCTVideoUtils.getCurrentWindow()?.bounds else { return }
 
         if !oldRect!.equalTo(newRect!) {
-            // https://github.com/TheWidlarzGroup/react-native-video/issues/3085#issuecomment-1557293391
-            if newRect!.equalTo(bounds) {
-                RCTLog("in fullscreen")
-                if !_fullscreenUncontrolPlayerPresented {
-                    _fullscreenUncontrolPlayerPresented = true
-
-                    self.onVideoFullscreenPlayerWillPresent?(["target": self.reactTag as Any])
-                    self.onVideoFullscreenPlayerDidPresent?(["target": self.reactTag as Any])
-                }
-            } else {
-                NSLog("not fullscreen")
-                if _fullscreenUncontrolPlayerPresented {
-                    _fullscreenUncontrolPlayerPresented = false
-
-                    self.onVideoFullscreenPlayerWillDismiss?(["target": self.reactTag as Any])
-                    self.onVideoFullscreenPlayerDidDismiss?(["target": self.reactTag as Any])
-                }
-            }
-
             if let reactVC = self.reactViewController() {
                 reactVC.view.frame = bounds
                 reactVC.view.setNeedsLayout()
             }
         }
+    }
+
+    func handleWillEnterFullScreen() {
+        self.onVideoFullscreenPlayerWillPresent?(["target": self.reactTag as Any])
+    }
+
+    func handleDidEnterFullScreen() {
+        self.onVideoFullscreenPlayerDidPresent?(["target": self.reactTag as Any])
+    }
+
+    func handleWillExitFullScreen() {
+        self.onVideoFullscreenPlayerWillDismiss?(["target": self.reactTag as Any])
+    }
+
+    func handleDidExitFullScreen() {
+        self.onVideoFullscreenPlayerDidDismiss?(["target": self.reactTag as Any])
     }
 
     @objc


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
This PR switches the mechanism to trigger the fullscreen will/did enter/exit callbacks from guessing based on the size of the player relative to the size of the screen to forwarding actual events from the native side.

### Motivation

The previous implementation only worked in some cases. In particular, the issues I encountered were:
* We'd get fullscreen enter/exit triggers launched on device orientation change
* The behaviour would be different when the player takes the whole size of the screen (not in fullscreen mode) and different if we (for example) limit its height

In contrast, the AVPlayer events are exactly what we want, no need to reinvent the wheel with custom implementation based on view frame changes.

### Changes

* Removes the logic that triggers fullscreen callbacks based on view frame changes
* Observe (and pass along) the fullscreen events coming from AVPlayer

## Test plan

You can use my work branch: https://github.com/brains-and-beards/react-native-video/commits/fix-fullscreen-handlers/ to observe the issue with the previous implementation and with the new one:
* This commit: https://github.com/brains-and-beards/react-native-video/commit/c6fbdf38ee2a59fb468e452ff42de0180dd00a86 contains the modified example (I was using examples/expo) to easily observe the issues. You can just run the app and rotate the screen to see fullscreen handlers being triggered
* The last commit: https://github.com/brains-and-beards/react-native-video/commit/9e95e88b47e695d671abf7ec9b457a48405fb02b contains this fix, you can run it to see the behaviour when it's applied