### PR TITLE
feat(web): allow styling overrides via the `style` prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "@release-it/conventional-changelog": "^7.0.2",
         "@types/jest": "^28.1.2",
         "@types/react": "~19.0.0",
+        "@types/react-native-web": "^0.19.1",
         "@typescript-eslint/eslint-plugin": "^6.7.4",
         "eslint": "^8.19.0",
         "eslint-plugin-jest": "^27.4.2",
@@ -27,6 +28,7 @@
         "prettier": "^2.4.1",
         "react": "18.2.0",
         "react-native": "0.78.2",
+        "react-native-web": "0.20.0",
         "react-native-windows": "^0.61.0-0",
         "release-it": "^16.2.1",
         "typescript": "5.1.6"

--- a/src/Video.web.tsx
+++ b/src/Video.web.tsx
@@ -6,8 +6,26 @@ import React, {
   useRef,
   useState,
   type RefObject,
+  type CSSProperties,
 } from 'react';
+import {StyleProp, ViewStyle} from 'react-native';
+import {unstable_createElement} from 'react-native-web';
 import type {ReactVideoProps, VideoMetadata, VideoRef} from './types';
+
+// Define a style prop that is accepted and transformed by React Native Web
+// for the native `video` element.
+interface WebVideoElementProps
+  extends Omit<React.ComponentProps<'video'>, 'style'> {
+  style?: StyleProp<ViewStyle | CSSProperties>;
+}
+
+// Wrap the native `video` element to accept both React Native styles and CSS
+// styles.
+//
+// See <https://necolas.github.io/react-native-web/docs/unstable-apis/#use-with-existing-react-dom-components>
+function WebVideo(props: WebVideoElementProps) {
+  return unstable_createElement('video', props);
+}
 
 // stolen from https://stackoverflow.com/a/77278013/21726244
 const isDeepEqual = <T,>(a: T, b: T): boolean => {
@@ -28,6 +46,7 @@ const isDeepEqual = <T,>(a: T, b: T): boolean => {
 const Video = forwardRef<VideoRef, ReactVideoProps>(
   (
     {
+      style,
       source,
       paused,
       muted,
@@ -306,7 +325,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
     useMediaSession(src?.metadata, nativeRef, showNotificationControls);
 
     return (
-      <video
+      <WebVideo
         ref={nativeRef}
         src={src?.uri as string | undefined}
         muted={muted}
@@ -410,7 +429,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           onVolumeChange?.({volume: nativeRef.current.volume});
         }}
         onEnded={onEnd}
-        style={videoStyle}
+        style={[videoStyle, style]}
       />
     );
   },


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary

The existing `videoStyle` style is retained, but users can now override that with their own `style` prop.

It uses the `unstable_createElement` API from react-native-web, which allows the resulting component to use React Native's accessibility and style properties.

<https://necolas.github.io/react-native-web/docs/unstable-apis/#use-with-existing-react-dom-components>

### Motivation

The `Video` component on web claims to accept `style` (the type allows it), but that prop is entirely disregarded and instead of a fixed style is applied to the native `video` element. This makes it hard to style the video to let the browser choose an acceptable size, or to apply any app-specific styling.

There is an PR https://github.com/TheWidlarzGroup/react-native-video/pull/4333 to make a similar change, but the author indicated they are not comfortable using `unstable_createElement`, and suggests creating a new PR to make that change. Additionally, the old `videoStyle` has been removed, which seems potentially breaking for any existing web code that was depending on that styling to be in place.

### Changes

- Use `unstable_createElement` in a new wrapper component, to create a `video` component that accepts both web and React Native `style`

## Test plan

- Existing React Native code using `Video` does not see any new type errors
- Existing (React Native) web code using `Video` does not see any new type errors, but will now honour the `style` prop