### PR TITLE
Only set _isBuffering = true if newValue is also true

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1604,8 +1604,8 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         )
     }
 
-    func handlePlaybackBufferKeyEmpty(playerItem _: AVPlayerItem, change _: NSKeyValueObservedChange<Bool>) {
-        if !_isBuffering {
+    func handlePlaybackBufferKeyEmpty(playerItem _: AVPlayerItem, change: NSKeyValueObservedChange<Bool>) {
+        if !_isBuffering && change.newValue == true {
             _isBuffering = true
         }
     }


### PR DESCRIPTION
## Summary

Within `RCTVideo.swift` and `func handlePlaybackBufferKeyEmpty`, if that handler is called with a new value of `false`, and `_isBuffering` is already `false`, it will be erroneously set to `true` instead of the new value. 

This can happen when `handlePlaybackLikelyToKeepUp` has already set it to `false` and then `handlePlaybackBufferKeyEmpty` is also called with `false`.

I could implement this more directly so that it’s just `_isBuffering = change.newValue` , but I’m not sure if there would be unwanted side effects when the `_isBuffering didSet { }` closure is called in the `false` case. So this is a slightly more conservative fix.

### Motivation

This addresses the bug reported [here](https://github.com/TheWidlarzGroup/react-native-video/issues/4463#issuecomment-2715136394).

### Changes

This adds a conditional check that `change.newValue` is actually `true` before setting `_isBuffering = true`.

## Test plan

I'm not sure, but it seems that the problematic `handlePlaybackBufferKeyEmpty` call with `false` happens when the video isn't yet cached by the app.

