### PR TITLE
fix default cropStart fallback

### DIFF
--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -243,7 +243,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           patchVer: resolvedSource.patchVer || 0,
           requestHeaders: generateHeaderForNative(resolvedSource.headers),
           startPosition: resolvedSource.startPosition ?? -1,
-          cropStart: resolvedSource.cropStart || 0,
+          cropStart: resolvedSource.cropStart,
           cropEnd: resolvedSource.cropEnd,
           contentStartTime: selectedContentStartTime,
           metadata: resolvedSource.metadata,


### PR DESCRIPTION
## Summary

Fixes a bug where switching to a new live stream while paused causes playback to incorrectly start from 0 instead of the current live position.

### Motivation

When a live stream is paused and the user switches to another live source, the player sets `cropStart` to `0` due to the fallback logic (`cropStart || 0`). This results in the new stream starting at the beginning rather than the current live point. For live streams, this is incorrect behavior, as the player should ideally seek to the live edge.

### Changes

```ts
- cropStart: resolvedSource.cropStart || 0,
+ cropStart: resolvedSource.cropStart,
