### PR TITLE
chore: cleanup `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,5 @@
         "!**/*.tsbuildinfo",
         "!docs",
         "!examples"
-    ],
-    "resolutions": {
-        "react-native-test-app": "4.3.8"
-    }
+    ]
 }


### PR DESCRIPTION
## Summary
Removed `resolutions.react-native-test-app` from library  `package.json` file as it's not good practice (introduced in https://github.com/TheWidlarzGroup/react-native-video/pull/4521)
