### PR TITLE
fix(iOS): Allow audio mixing if one of the video views require it

### DIFF
--- a/ios/Video/AudioSessionManager.swift
+++ b/ios/Video/AudioSessionManager.swift
@@ -139,7 +139,11 @@ class AudioSessionManager {
             return view._playInBackground
         }
 
-        let canAllowMixing = !anyPlayerShowNotificationControls && !anyPlayerNeedsBackgroundPlayback
+        let anyPlayerWantsMixing = videoViews.allObjects.contains { view in
+            return view._mixWithOthers == "mix" || view._mixWithOthers == "duck"
+        }
+
+        let canAllowMixing = anyPlayerWantsMixing || (!anyPlayerShowNotificationControls && !anyPlayerNeedsBackgroundPlayback)
 
         if isAudioSessionManagementDisabled {
             // AUDIO SESSION MANAGEMENT DISABLED BY USER


### PR DESCRIPTION
## Summary
After the PR https://github.com/TheWidlarzGroup/react-native-video/pull/4466, where the AudioSessionManager was introduced, background video audio would be stopped by external apps i.e. Spotify even if mixWithOthers is set to "mix".

### Motivation
The video audio should not be paused by external apps if mixWithOthers is set to "mix" or "duck".

### Changes
Check if one of the video views has mixWithOthers set to "mix" or "duck" and allow audio mixing.

## Test plan
Start playing react-native-video, put the react-native-video app to background, open Spotify, start playing music. Spotify music should mix with react-native-video.