### PR TITLE
fix(RCTVideo.swift): add audiovisualBackgroundPlaybackPolicy when pla…

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -574,6 +574,14 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
             _player!.replaceCurrentItem(with: playerItem)
 
+            if #available(iOS 15.0, *) {
+                if _playInBackground {
+                    _player!.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
+                } else {
+                    _player!.audiovisualBackgroundPlaybackPolicy = .automatic
+                }
+            }
+
             if _showNotificationControls {
                 // We need to register player after we set current item and only for init
                 NowPlayingInfoCenterManager.shared.registerPlayer(player: _player!)
@@ -592,6 +600,14 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                     self._playerViewController?.allowsVideoFrameAnalysis = true
                 }
             #endif
+
+            if #available(iOS 15.0, *) {
+                if _playInBackground {
+                    _player!.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
+                } else {
+                    _player!.audiovisualBackgroundPlaybackPolicy = .automatic
+                }
+            }
             // later we can just call "updateNowPlayingInfo:
             NowPlayingInfoCenterManager.shared.updateNowPlayingInfo()
         }


### PR DESCRIPTION
### Summary of Changes

* **Fixed iOS background playback behavior**:
  Added logic to set `audiovisualBackgroundPlaybackPolicy` on the player instance to ensure video continues playing when the app goes into the background.

```swift
if (_playInBackground) {
    _player!.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
} else {
    _player!.audiovisualBackgroundPlaybackPolicy = .automatic
}
```

* Without this, iOS would consistently pause video playback when the app was backgrounded, even if background playback was expected.

---
How to test:

Just play any video with react-native-video player and go to background, video should pause
### Motivation

Video stopped playing in background mode even though playInBackground was set to true.