### PR TITLE
Resolves a retain cycle and memory leak involving the RCTVideo instance when using Google IMA ads in react-native-video.

### DIFF
--- a/ios/Video/Features/RCTIMAAdsManager.swift
+++ b/ios/Video/Features/RCTIMAAdsManager.swift
@@ -30,7 +30,7 @@
 
         func requestAds() {
             guard let _video else { return }
-            //fixes RCTVideo --> RCTIMAAdsManager --> IMAAdsLoader --> IMAAdDisplayContainer --> RCTVideo memory leak
+            // fixes RCTVideo --> RCTIMAAdsManager --> IMAAdsLoader --> IMAAdDisplayContainer --> RCTVideo memory leak.
             let adContainerView = UIView(frame: _video.bounds)
             adContainerView.backgroundColor = .clear
             _video.addSubview(adContainerView)

--- a/ios/Video/Features/RCTIMAAdsManager.swift
+++ b/ios/Video/Features/RCTIMAAdsManager.swift
@@ -30,8 +30,13 @@
 
         func requestAds() {
             guard let _video else { return }
+            //fixes RCTVideo --> RCTIMAAdsManager --> IMAAdsLoader --> IMAAdDisplayContainer --> RCTVideo memory leak
+            let adContainerView = UIView(frame: _video.bounds)
+            adContainerView.backgroundColor = .clear
+            _video.addSubview(adContainerView)
+
             // Create ad display container for ad rendering.
-            let adDisplayContainer = IMAAdDisplayContainer(adContainer: _video, viewController: _video.reactViewController())
+            let adDisplayContainer = IMAAdDisplayContainer(adContainer: adContainerView, viewController: _video.reactViewController())
 
             let adTagUrl = _video.getAdTagUrl()
             let contentPlayhead = _video.getContentPlayhead()


### PR DESCRIPTION

We now pass a new UIView (sized to match the video player) to IMAAdDisplayContainer instead of the original _video (RCTVideo) component.

🧠 Problem

The original code created a strong reference cycle:

RCTVideo
↓
RCTIMAAdsManager
↓
IMAAdsLoader
↓
IMAAdDisplayContainer
↓
RCTVideo

This prevented RCTVideo from being deallocated, resulting in a memory leak—especially noticeable when mounting/unmounting ad-enabled video components.

✅ Fix
• Created a new UIView instance as a lightweight container for IMAAdDisplayContainer
• Passed this view instead of _video to IMAAdsRequest
• Ensured the new view mimics _video’s size and remains visually embedded during ad playback