### PR TITLE
fix(ios): allow audio mixing when none of the players are playing

### DIFF
--- a/ios/Video/AudioSessionManager.swift
+++ b/ios/Video/AudioSessionManager.swift
@@ -139,6 +139,10 @@ class AudioSessionManager {
             return view._playInBackground
         }
 
+        let anyPlayerPlaying = videoViews.allObjects.contains { view in
+            return !view.isMuted() && view._player != nil && view._player?.rate != 0
+        }
+
         let anyPlayerWantsMixing = videoViews.allObjects.contains { view in
             return view._mixWithOthers == "mix" || view._mixWithOthers == "duck"
         }
@@ -150,7 +154,9 @@ class AudioSessionManager {
             return
         }
 
-        if canAllowMixing {
+        if !anyPlayerPlaying {
+            options.insert(.mixWithOthers)
+        } else if canAllowMixing {
             let shouldEnableMixing = videoViews.allObjects.contains { view in
                 return view._mixWithOthers == "mix"
             }

--- a/ios/Video/AudioSessionManager.swift
+++ b/ios/Video/AudioSessionManager.swift
@@ -205,7 +205,7 @@ class AudioSessionManager {
 
         do {
             try audioSession.setCategory(
-                category, mode: .moviePlayback, options: canAllowMixing ? options : []
+                category, mode: .moviePlayback, options: options
             )
 
             // Configure audio port


### PR DESCRIPTION
## Summary
Noticing that on video component mount if mixWithOthers is set to default value "inherit", the external app (i.e. Spotify) audio gets paused even if the video is not playing. I feel like the pausing of external app audio should happen only when the video starts playing. At least this is what I would expect and see in other apps like Messenger.

### Changes
Default to audio mixing if none of the players are playing.