### PR TITLE
fix: component linking method

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,7 +49,7 @@
     },
     "example": {
       "name": "react-native-video-example",
-      "version": "7.0.0-alpha.0",
+      "version": "7.0.0-alpha.1",
       "dependencies": {
         "@react-native-community/slider": "^4.5.6",
         "react": "18.3.1",
@@ -78,7 +78,7 @@
     },
     "packages/react-native-video": {
       "name": "react-native-video",
-      "version": "7.0.0-alpha.0",
+      "version": "7.0.0-alpha.1",
       "devDependencies": {
         "@expo/config-plugins": "^10.0.2",
         "@react-native/eslint-config": "^0.77.0",

--- a/packages/react-native-video/src/core/video-view/NativeVideoView.tsx
+++ b/packages/react-native-video/src/core/video-view/NativeVideoView.tsx
@@ -11,7 +11,7 @@ const LINKING_ERROR =
 const ComponentName = 'VideoView';
 
 export const NativeVideoView =
-  UIManager.getViewManagerConfig(ComponentName) != null
+  UIManager.hasViewManagerConfig(ComponentName) != null
     ? VideoViewNativeComponent
     : () => {
         throw new Error(LINKING_ERROR);


### PR DESCRIPTION
## Summary
Fix `VideoView` component linking method

### Motivation
Fixes https://github.com/TheWidlarzGroup/react-native-video/discussions/4595#discussioncomment-13722358 

### Changes
- replaced `getViewManagerConfig` with `hasViewManagerConfig `