### PR TITLE
feat: Attach Java stacktrace in ExtendedError interface

### DIFF
--- a/android/src/main/java/com/brentvatne/common/react/VideoEventEmitter.kt
+++ b/android/src/main/java/com/brentvatne/common/react/VideoEventEmitter.kt
@@ -140,6 +140,22 @@ class VideoEventEmitter {
                             putString("errorException", exception.toString())
                             putString("errorCode", errorCode)
                             putString("errorStackTrace", stackTrace)
+
+                            // https://github.com/facebook/react-native/blob/v0.80.2/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp#L465
+                            putMap("cause", Arguments.createMap().apply {
+                                putString("name", exception.javaClass.simpleName)
+                                exception.message?.let { putString("message", it) }
+                                putArray("stackElements", Arguments.createArray().apply {
+                                    exception.stackTrace.forEach { element ->
+                                        pushMap(Arguments.createMap().apply {
+                                            putString("className", element.className)
+                                            putString("fileName", element.fileName)
+                                            putInt("lineNumber", element.lineNumber)
+                                            putString("methodName", element.methodName)
+                                        })
+                                    }
+                                })
+                            })
                         }
                     )
                 }

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -298,6 +298,7 @@ export type OnVideoErrorData = Readonly<{
     localizedRecoverySuggestion?: string; // ios
     domain?: string; // ios
   }>;
+  cause?: object; // React Native convertThrowableToJSError/convertNSExceptionToJSError
   target?: Int32; // ios
 }>;
 


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
This PR adds the ablity to use the `cause` property as defined by React Native Core, ExtendedError: https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Core/ExtendedError.js

The iOS wil not receive these changes due to the lack of good stack trace information on NSError objects.

### Motivation

Allow Sentry to report full Java stack trace in case of playback error.

### Changes

Add `cause` property as defined in the upstream.

## Test plan