### PR TITLE
Support pictureInPictureResizeMode to avoid white bars in PiP on Android

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/PictureInPictureUtil.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/PictureInPictureUtil.kt
@@ -43,6 +43,7 @@ object PictureInPictureUtil {
 
         val onPictureInPictureModeChanged = Consumer<PictureInPictureModeChangedInfo> { info ->
             view.setIsInPictureInPicture(info.isInPictureInPictureMode)
+            view.setPictureInPictureMode(info.isInPictureInPictureMode)
             if (!info.isInPictureInPictureMode && activity.lifecycle.currentState == Lifecycle.State.CREATED) {
                 // when user click close button of PIP
                 if (!view.playInBackground) view.setPausedModifier(true)

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -246,6 +246,7 @@ public class ReactExoplayerView extends FrameLayout implements
     protected boolean playInBackground = false;
     private boolean mReportBandwidth = false;
     private boolean controls = false;
+    private int pictureInPictureResizeMode = -1;
 
     private boolean showNotificationControls = false;
     // \ End props
@@ -2508,6 +2509,16 @@ public class ReactExoplayerView extends FrameLayout implements
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && currentActivity.isInPictureInPictureMode()) {
             currentActivity.moveTaskToBack(false);
+        }
+    }
+
+    public void setPictureInPictureResizeModeModifier(@ResizeMode.Mode int resizeMode) {
+        this.pictureInPictureResizeMode = resizeMode;
+    }
+
+    public void setPictureInPictureMode(boolean isInPiP) {
+        if (exoPlayerView != null && isInPiP && pictureInPictureResizeMode != -1) {
+            exoPlayerView.setResizeMode(pictureInPictureResizeMode);
         }
     }
 

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.kt
@@ -58,6 +58,7 @@ class ReactExoplayerViewManager(private val config: ReactExoplayerConfig) : View
         private const val PROP_SHOW_NOTIFICATION_CONTROLS = "showNotificationControls"
         private const val PROP_DEBUG = "debug"
         private const val PROP_CONTROLS_STYLES = "controlsStyles"
+        private const val PROP_PICTURE_IN_PICTURE_RESIZE_MODE = "pictureInPictureResizeMode"
     }
 
     override fun getName(): String = REACT_CLASS
@@ -258,9 +259,21 @@ class ReactExoplayerViewManager(private val config: ReactExoplayerConfig) : View
         videoView.setDebug(enableDebug)
     }
 
-    @ReactProp(name = PROP_CONTROLS_STYLES)
-    fun setControlsStyles(videoView: ReactExoplayerView, controlsStyles: ReadableMap?) {
-        val controlsConfig = ControlsConfig.parse(controlsStyles)
-        videoView.setControlsStyles(controlsConfig)
+    @ReactProp(name = PROP_PICTURE_IN_PICTURE_RESIZE_MODE)
+    fun setPictureInPictureResizeMode(videoView: ReactExoplayerView, resizeMode: String?) {
+        val mode = when (resizeMode) {
+            "none", "contain" -> ResizeMode.RESIZE_MODE_FIT
+            "cover" -> ResizeMode.RESIZE_MODE_CENTER_CROP
+            "stretch" -> ResizeMode.RESIZE_MODE_FILL
+            else -> {
+                if (resizeMode != null) {
+                    DebugLog.w(TAG, "Unsupported PiP resize mode: $resizeMode - falling back to fit")
+                }
+                ResizeMode.RESIZE_MODE_FIT
+            }
+        }
+
+        videoView.setPictureInPictureResizeModeModifier(mode)
     }
+
 }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.kt
@@ -276,4 +276,10 @@ class ReactExoplayerViewManager(private val config: ReactExoplayerConfig) : View
         videoView.setPictureInPictureResizeModeModifier(mode)
     }
 
+    @ReactProp(name = PROP_CONTROLS_STYLES)
+    fun setControlsStyles(videoView: ReactExoplayerView, controlsStyles: ReadableMap?) {
+        val controlsConfig = ControlsConfig.parse(controlsStyles)
+        videoView.setControlsStyles(controlsConfig)
+    }
+
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "@react-native/eslint-config": "^0.72.2",
         "@release-it/conventional-changelog": "^7.0.2",
         "@types/jest": "^28.1.2",
+        "@types/node": "^24.3.0",
         "@types/react": "~19.0.0",
         "@types/react-native-web": "^0.19.1",
         "@typescript-eslint/eslint-plugin": "^6.7.4",
@@ -67,5 +68,6 @@
         "!**/*.tsbuildinfo",
         "!docs",
         "!examples"
-    ]
+    ],
+    "packageManager": "yarn@4.1.1+sha512.ec40d0639bb307441b945d9467139cbb88d14394baac760b52eca038b330d16542d66fef61574271534ace5a200518dabf3b53a85f1f9e4bfa37141b538a9590"
 }

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -109,6 +109,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       localSourceEncryptionKeyScheme,
       minLoadRetryCount,
       bufferConfig,
+      pictureInPictureResizeMode,
       ...rest
     },
     ref,
@@ -905,6 +906,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
             onControlsVisibilityChange ? _onControlsVisibilityChange : undefined
           }
           viewType={_viewType}
+          pictureInPictureResizeMode={pictureInPictureResizeMode}
         />
         {_renderPoster()}
       </View>

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -401,6 +401,7 @@ export interface VideoNativeProps extends ViewProps {
   onTextTracks?: DirectEventHandler<OnTextTracksData>; // android
   onTextTrackDataChanged?: DirectEventHandler<OnTextTrackDataChangedData>; // iOS
   onVideoTracks?: DirectEventHandler<OnVideoTracksData>; // android
+  pictureInPictureResizeMode?: WithDefault<string, 'none'>;
 }
 
 type NativeVideoComponentType = HostComponent<VideoNativeProps>;

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -351,4 +351,5 @@ export interface ReactVideoProps extends ReactVideoEvents, ViewProps {
   allowsExternalPlayback?: boolean; // iOS
   controlsStyles?: ControlsStyles; // Android
   disableAudioSessionManagement?: boolean; // iOS
+  pictureInPictureResizeMode?: EnumValues<VideoResizeMode>; // Android
 }


### PR DESCRIPTION
## Summary
This PR adds a new prop `pictureInPictureResizeMode` to control the video scaling in Picture-in-Picture (PiP) mode on Android. This helps prevent white bars when the video aspect ratio does not match the PiP window.

### Motivation
Previously, videos with an aspect ratio different from the PiP window could display white bars. By introducing `pictureInPictureResizeMode`, developers can explicitly set how the video should scale (e.g., `cover`, `contain`, `stretch`) in PiP mode.

### Changes
- Added `pictureInPictureResizeMode` prop in React Native Video.
- Updated Android PiP handling to use this prop.
- Ensures videos fill the PiP window according to the selected scaling mode, avoiding white bars.

## Test plan
1. Launch the example app on an Android device that supports PiP.
2. Set the `pictureInPictureResizeMode` prop to `cover`, `contain`, or `stretch`.
3. Enter PiP mode with a video whose aspect ratio differs from the PiP window.
4. Verify the video scales correctly according to the prop and no white bars appear.
5. Ensure smooth playback and no crashes.
