### PR TITLE
fix(player): trigger relayout after exiting pip

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -2474,6 +2474,7 @@ public class ReactExoplayerView extends FrameLayout implements
                     rootView.getChildAt(i).setVisibility(rootViewChildrenOriginalVisibility.get(i));
                 }
                 addView(exoPlayerView, 0, layoutParams);
+                reLayoutControls();
             }
         }
     }


### PR DESCRIPTION
## Summary
This PR triggers relayout when the user re-opens the app so the player is sized properly.

### Motivation
On our team we have noticed Android users exprience a smaller video is displayed after exiting from the PiP mode (and thus open the full activity).

After inspection on Android Studio we have found the player view is not resized even after the activity has opened fully, and triggering the relayout manually seems to fix this.

### Changes
Add a `reLayoutControls` call.

## Test plan