### PR TITLE
fix(ios): disable audio session management when no views

### DIFF
--- a/ios/Video/AudioSessionManager.swift
+++ b/ios/Video/AudioSessionManager.swift
@@ -9,6 +9,11 @@ class AudioSessionManager {
     private var remoteControlEventsActive = false
 
     private var isAudioSessionManagementDisabled: Bool {
+        // If no views are registered, disable audio session management
+        if videoViews.allObjects.isEmpty {
+            return true
+        }
+
         return videoViews.allObjects.contains { view in
             return view._disableAudioSessionManagement == true
         }


### PR DESCRIPTION
This PR fixes a major issue for calling apps.
When there are no video views, it is considered `disableAudioSessionManagement` as false
Therefore, it's fighting any other library trying to configure the audio session forever, which is, in my case, a callkit library

This guarantees that when there is a video, we rely on the prop; otherwise, disable it, the app might have several libraries that can manage the audio session.
