### PR TITLE
FIX: Exception Caused by android.content.pm.PackageManager$NameNotFou…

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/PictureInPictureUtil.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/PictureInPictureUtil.kt
@@ -180,10 +180,14 @@ object PictureInPictureUtil {
     private fun checkIsSystemSupportPIP(context: ThemedReactContext): Boolean {
         val activity = context.findActivity() ?: return false
 
-        val activityInfo = activity.packageManager.getActivityInfo(activity.componentName, PackageManager.GET_META_DATA)
-        // detect current activity's android:supportsPictureInPicture value defined within AndroidManifest.xml
-        // https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/content/pm/ActivityInfo.java;l=1090-1093;drc=7651f0a4c059a98f32b0ba30cd64500bf135385f
-        val isActivitySupportPip = activityInfo.flags and FLAG_SUPPORTS_PICTURE_IN_PICTURE != 0
+        val isActivitySupportPip = try {
+            val activityInfo = activity.packageManager.getActivityInfo(activity.componentName, PackageManager.GET_META_DATA)
+            // detect current activity's android:supportsPictureInPicture value defined within AndroidManifest.xml
+            // https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/content/pm/ActivityInfo.java;l=1090-1093;drc=7651f0a4c059a98f32b0ba30cd64500bf135385f
+            activityInfo.flags and FLAG_SUPPORTS_PICTURE_IN_PICTURE != 0
+        } catch (e: kotlin.Exception) {
+            false
+        }
 
         // PIP might be disabled on devices that have low RAM.
         val isPipAvailable = activity.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)


### PR DESCRIPTION
## Summary

Following issue has been reported by Play Developer Console-
Exception java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:507)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:912)
Caused by java.lang.reflect.InvocationTargetException:
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:497)
Caused by android.content.pm.PackageManager$NameNotFoundException:
  at android.app.ApplicationPackageManager.getActivityInfo (ApplicationPackageManager.java:436)
  at com.brentvatne.exoplayer.PictureInPictureUtil.checkIsSystemSupportPIP (PictureInPictureUtil.kt:182)
  at com.brentvatne.exoplayer.PictureInPictureUtil.isSupportPictureInPicture (PictureInPictureUtil.kt:171)
  at com.brentvatne.exoplayer.PictureInPictureUtil.updatePictureInPictureActions (PictureInPictureUtil.kt:121)
  at com.brentvatne.exoplayer.PictureInPictureUtil.applySourceRectHint (PictureInPictureUtil.kt:116)
  at com.brentvatne.exoplayer.ReactExoplayerView.lambda$createViews$0 (ReactExoplayerView.java:355)
  at android.view.View.layout (View.java:21373)
  at android.view.ViewGroup.layout (ViewGroup.java:6302)
  at com.brentvatne.exoplayer.ExoPlayerView.measureAndLayout$lambda$0 (ExoPlayerView.kt:278)
  at android.os.Handler.handleCallback (Handler.java:873)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:193)
  at android.app.ActivityThread.main (ActivityThread.java:6819)

### Changes
As this issue occurred inside Android Source code,
We wrapped the 'ApplicationPackageManager.getActivityInfo' call is in try-catch block.