### PR TITLE
chore(android): enable flexible page sizes in native build configuration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -142,6 +142,11 @@ android {
         buildConfigField "boolean", "USE_EXOPLAYER_DASH", ExoplayerDependencies["useExoplayerDash"].toString()
         buildConfigField "boolean", "USE_EXOPLAYER_HLS", ExoplayerDependencies["useExoplayerHls"].toString()
         buildConfigField "boolean", "USE_EXOPLAYER_RTSP", ExoplayerDependencies["useExoplayerRtsp"].toString()
+        externalNativeBuild {
+            cmake {
+                arguments "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
+            }
+        }
 
         ndk {
             abiFilters(*reactNativeArchitectures())

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,9 +1,9 @@
 RNVideo_kotlinVersion=1.8.0
 RNVideo_minSdkVersion=23
-RNVideo_targetSdkVersion=34
-RNVideo_compileSdkVersion=34
-RNVideo_ndkversion=26.1.10909125
-RNVideo_buildToolsVersion=34.0.0
+RNVideo_targetSdkVersion=35
+RNVideo_compileSdkVersion=35
+RNVideo_ndkversion=27.1.12297006
+RNVideo_buildToolsVersion=35.0.0
 RNVideo_media3Version=1.4.1
 RNVideo_useExoplayerIMA=false
 RNVideo_useExoplayerRtsp=false

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 RNVideo_kotlinVersion=1.8.0
-RNVideo_minSdkVersion=23
+RNVideo_minSdkVersion=24
 RNVideo_targetSdkVersion=35
 RNVideo_compileSdkVersion=35
 RNVideo_ndkversion=27.1.12297006

--- a/android/src/main/java/com/brentvatne/common/react/VideoEventEmitter.kt
+++ b/android/src/main/java/com/brentvatne/common/react/VideoEventEmitter.kt
@@ -142,20 +142,28 @@ class VideoEventEmitter {
                             putString("errorStackTrace", stackTrace)
 
                             // https://github.com/facebook/react-native/blob/v0.80.2/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp#L465
-                            putMap("cause", Arguments.createMap().apply {
-                                putString("name", exception.javaClass.simpleName)
-                                exception.message?.let { putString("message", it) }
-                                putArray("stackElements", Arguments.createArray().apply {
-                                    exception.stackTrace.forEach { element ->
-                                        pushMap(Arguments.createMap().apply {
-                                            putString("className", element.className)
-                                            putString("fileName", element.fileName)
-                                            putInt("lineNumber", element.lineNumber)
-                                            putString("methodName", element.methodName)
-                                        })
-                                    }
-                                })
-                            })
+                            putMap(
+                                "cause",
+                                Arguments.createMap().apply {
+                                    putString("name", exception.javaClass.simpleName)
+                                    exception.message?.let { putString("message", it) }
+                                    putArray(
+                                        "stackElements",
+                                        Arguments.createArray().apply {
+                                            exception.stackTrace.forEach { element ->
+                                                pushMap(
+                                                    Arguments.createMap().apply {
+                                                        putString("className", element.className)
+                                                        putString("fileName", element.fileName)
+                                                        putInt("lineNumber", element.lineNumber)
+                                                        putString("methodName", element.methodName)
+                                                    }
+                                                )
+                                            }
+                                        }
+                                    )
+                                }
+                            )
                         }
                     )
                 }


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
This PR adds support for 16 KB memory page size on Android 15+ devices.
To achieve this, the `build.gradle` file was updated to enable flexible page size support in the native build process by passing the following argument to CMake:
```
externalNativeBuild {
  cmake {
    arguments "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
  }
}
```
This ensures the React Native app can run correctly on newer Android devices that use a 16 KB page size by default.

### Motivation
Starting with Android 15, some devices use 16 KB memory pages instead of the traditional 4 KB pages.
Without enabling flexible page size support, apps may experience native crashes, memory mapping issues, or incompatibility on those devices.
This change ensures the app remains stable and forward-compatible with upcoming Android versions.

### Changes

- Updated build.gradle to pass the -DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON flag to CMake.
- No JavaScript/TypeScript or runtime logic was modified.
- This is a build-time configuration change only, affecting the native Android build process.

## Test plan

1. Build and install the app on an Android 15 emulator or device configured with a 16 KB page size.
2. Verify that the app launches and runs without native crashes related to memory mapping or page alignment.
3. Optionally, test on devices with 4 KB page size to confirm backward compatibility.