### PR TITLE
fix(AudioSessionManager.swift): notification control hide after pausing video

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -78,7 +78,7 @@ jobs:
           -scheme BareExample \
           -sdk iphonesimulator \
           -configuration Debug \
-          -destination 'platform=iOS Simulator,name=iPhone 14' \
+          -destination 'platform=iOS Simulator,name=iPhone 16' \
           build \
           CODE_SIGNING_ALLOWED=NO | xcpretty"
 
@@ -142,7 +142,7 @@ jobs:
           -scheme BareExample \
           -sdk iphonesimulator \
           -configuration Debug \
-          -destination 'platform=iOS Simulator,name=iPhone 14' \
+          -destination 'platform=iOS Simulator,name=iPhone 16' \
           build \
           CODE_SIGNING_ALLOWED=NO | xcpretty"
 
@@ -209,6 +209,6 @@ jobs:
           -scheme BareExample \
           -sdk iphonesimulator \
           -configuration Debug \
-          -destination 'platform=iOS Simulator,name=iPhone 14' \
+          -destination 'platform=iOS Simulator,name=iPhone 16' \
           build \
           CODE_SIGNING_ALLOWED=NO | xcpretty"

--- a/ios/Video/AudioSessionManager.swift
+++ b/ios/Video/AudioSessionManager.swift
@@ -152,14 +152,16 @@ class AudioSessionManager {
             return view._mixWithOthers == "mix" || view._mixWithOthers == "duck"
         }
 
-        let canAllowMixing = anyPlayerWantsMixing || (!anyPlayerShowNotificationControls && !anyPlayerNeedsBackgroundPlayback)
+        let anyPlayerUsesNotificationControlFeature = anyPlayerShowNotificationControls && anyPlayerNeedsBackgroundPlayback
+
+        let canAllowMixing = anyPlayerWantsMixing || !anyPlayerUsesNotificationControlFeature
 
         if isAudioSessionManagementDisabled {
             // AUDIO SESSION MANAGEMENT DISABLED BY USER
             return
         }
 
-        if !anyPlayerPlaying {
+        if !anyPlayerPlaying && !anyPlayerUsesNotificationControlFeature {
             options.insert(.mixWithOthers)
         } else if canAllowMixing {
             let shouldEnableMixing = videoViews.allObjects.contains { view in

--- a/ios/Video/Features/RCTPictureInPicture.swift
+++ b/ios/Video/Features/RCTPictureInPicture.swift
@@ -6,7 +6,7 @@ import React
 
 #if os(iOS)
     class RCTPictureInPicture: NSObject, AVPictureInPictureControllerDelegate {
-        public private(set) var _pipController: AVPictureInPictureController?
+        private(set) var _pipController: AVPictureInPictureController?
         private var _onPictureInPictureEnter: (() -> Void)?
         private var _onPictureInPictureExit: (() -> Void)?
         private var _onRestoreUserInterfaceForPictureInPictureStop: (() -> Void)?
@@ -92,7 +92,7 @@ import React
     }
 #else
     class RCTPictureInPicture: NSObject {
-        public let _pipController: NSObject? = nil
+        let _pipController: NSObject? = nil
 
         func setRestoreUserInterfaceForPIPStopCompletionHandler(_: Bool) {}
         func setupPipController(_: AVPlayerLayer?) {}

--- a/ios/Video/NowPlayingInfoCenterManager.swift
+++ b/ios/Video/NowPlayingInfoCenterManager.swift
@@ -81,7 +81,7 @@ class NowPlayingInfoCenterManager {
         }
     }
 
-    public func cleanup() {
+    func cleanup() {
         observers.removeAll()
         players.removeAllObjects()
 
@@ -199,7 +199,7 @@ class NowPlayingInfoCenterManager {
         remoteCommandCenter.togglePlayPauseCommand.removeTarget(togglePlayPauseTarget)
     }
 
-    public func updateNowPlayingInfo() {
+    func updateNowPlayingInfo() {
         guard let player = currentPlayer, let currentItem = player.currentItem else {
             invalidateCommandTargets()
             MPNowPlayingInfoCenter.default().nowPlayingInfo = [:]


### PR DESCRIPTION
## Summary
Don't allow .mixWithOthers when notification control or background playback are enabled

### Motivation
Notification control hide when pressing pause and user cannot resume video anymore from notification

### Changes
Block possibility to add to options .mixWithOthers when any player uses notification controls

### Test Scenario

1. Mount component with video
2. Play start
3. Observe that control notification appears
4. Pause video by passing prop paused={true}
5. Observe that control notification vanish