### PR TITLE
fix(android): add null check for player in videoLoaded() to prevent NPE

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1478,7 +1478,14 @@ public class ReactExoplayerView extends FrameLayout implements
     }
 
     private void videoLoaded() {
-        if (!player.isPlayingAd() && loadVideoStarted) {
+        // player can be null here: ListenerSet posts onEvents() on the main
+        // looper, and if the view is unmounted (releasePlayer() nulls player)
+        // before that posted message is dispatched, this fires against an
+        // already-released player. Most visible in feed-style UIs that
+        // mount/unmount <Video> on scroll or key-remount on source change.
+        // Fixes #4902.
+        if (player == null) return;
+        if (!isPlayingAd() && loadVideoStarted) {
             loadVideoStarted = false;
             if (audioTrackType != null) {
                 setSelectedAudioTrack(audioTrackType, audioTrackValue);


### PR DESCRIPTION
## Summary
Fixes #4902 — fatal `NullPointerException` in `ReactExoplayerView.videoLoaded()`.

`videoLoaded()` calls `player.isPlayingAd()` directly on the field with no null check. `ListenerSet` posts `Player.Listener.onEvents()` on the main looper; if the view unmounts (`releasePlayer()` nulls `player`) before that posted message dispatches, the callback fires `onPlaybackStateChanged(STATE_READY)` → `videoLoaded()` → `player.isPlayingAd()` against an already-released player.

This surfaces most often in feed-style UIs that mount/unmount `<Video>` on scroll, or apps that key-remount `<Video>` on source change — the unmount window overlaps the `STATE_READY` event more frequently there. We hit this in production (Crashlytics fatal on 6.19.2) and traced it to this exact race before finding #4902 already had the same root-cause analysis.

## Fix
Adds an early-return null guard, and switches the call site to the existing private `isPlayingAd()` null-safe helper (already defined in this file at L345 and used elsewhere, e.g. L285) instead of dereferencing `player` raw — so this call site now matches the rest of the class.

## Test plan
- [x] Verified locally: 50 rapid interactions on a screen that mounts/unmounts `<Video>` per swipe, before/after — exception count went from present to zero, no change in playback behavior, images/video still load and play correctly.
- [ ] Would appreciate a maintainer sanity-check on Android CI, since I can't run the full device matrix from here.

Note: there was a prior attempt at this exact fix (#4903) that was closed without merging — this PR reproduces that same diff against the current `support/6.x.x` head, since the underlying bug is still present in 6.19.2.