### PR TITLE
fix(ios): report observed bitrate for HLS

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -61,8 +61,8 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     private var _startPosition: Float64 = -1
     var _disableAudioSessionManagement: Bool = false
     var _showNotificationControls = false
-    // Buffer last bitrate value received. Initialized to -2 to ensure -1 (sometimes reported by AVPlayer) is not missed
-    private var _lastBitrate = -2.0
+    // Buffer the last valid bitrate value received
+    private var _lastBitrate = -1.0
     private var _enterPictureInPictureOnLeave = false {
         didSet {
             if isPictureInPictureActive() { return }
@@ -1802,8 +1802,10 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             return
         }
         guard let lastEvent = accessLog.events.last else { return }
-        if lastEvent.indicatedBitrate != _lastBitrate {
-            _lastBitrate = lastEvent.indicatedBitrate
+        let bitrate = lastEvent.indicatedBitrate >= 0 ? lastEvent.indicatedBitrate : lastEvent.observedBitrate
+        guard bitrate >= 0 else { return }
+        if bitrate != _lastBitrate {
+            _lastBitrate = bitrate
             onVideoBandwidthUpdate?(["bitrate": _lastBitrate, "target": reactTag as Any])
         }
     }


### PR DESCRIPTION
## Summary

Closes #4153.

### Motivation

`AVPlayerItemAccessLogEvent.indicatedBitrate` can be negative for HLS streams even when `observedBitrate` contains a valid measured throughput. The existing implementation emits the negative indicated value once and then suppresses later updates while that value remains unchanged.

### Changes

- preserve `indicatedBitrate` when AVPlayer provides a valid value
- fall back to `observedBitrate` when the indicated value is unknown
- skip the callback when both values are unknown
- initialize the cached bitrate with a sentinel below the valid range

## Test plan

- `swiftformat --lint ios/Video/RCTVideo.swift`
- `swiftlint lint --no-cache ios/Video/RCTVideo.swift`
- direct AVPlayer access-log probe on an iPhone 16 Pro simulator (iOS 18.6)
  - issue stream: `indicated=-1`, `observed=16351824`, selected value `16351824`
  - Apple HLS control stream: three access-log events received and valid indicated values preserved
